### PR TITLE
docs: fix binary name in Japanese README

### DIFF
--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -7,7 +7,7 @@ Rustとgpuiを使用し、macOS Finderのモダンな代替となる、**高速�
 * **ツールチェーン:** Rust (stable)、 `rust-toolchain.toml` によりバージョン固定
 * **ビルド (コアライブラリのみ):** `cargo build`
 * **GUIバイナリのビルド (プレースホルダーUI):** `cargo build --features gui`
-* **GUIバイナリの実行:** `cargo run --features gui --bin nohr`
+* **GUIバイナリの実行:** `cargo run --features gui --bin nohrs`
 
 **注記**
 


### PR DESCRIPTION
`docs/README.ja.md`側でバイナリ実行の際の名前が間違えていたので修正しました。