### PR TITLE
Add pull-request skill for review-driven PR loop

### DIFF
--- a/.claude/skills/pull-request/SKILL.md
+++ b/.claude/skills/pull-request/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: pull-request
+description: >
+  Take a change from working tree to a merge-ready pull request, then keep
+  iterating until the CI checks and AI reviewers (CodeRabbit, cubic) all pass.
+  Runs the local quality gate, opens or updates the PR following this repo's PR
+  hygiene rules, and — for UI changes — verifies the GUI headlessly and attaches
+  screenshots. Use when asked to "open a PR", "ship this", "get this through
+  review", or "fix the review comments". Invoke with /pull-request.
+metadata:
+  version: "1.0.0"
+---
+
+# Pull request: open, verify, and pass review
+
+End-to-end flow for turning the current change into a pull request that passes
+this repo's automated quality gate, fixing review feedback in a loop until green.
+
+The quality gate here is **not** classic GitHub Actions (there are none yet). It
+is:
+
+1. **Local gate** you run before pushing: `cargo fmt`, `cargo clippy`, `cargo build`, `cargo test`.
+2. **AI reviewers** that run as PR status checks and post review threads:
+   - `CodeRabbit` (`coderabbitai[bot]`)
+   - `cubic · AI code reviewer` (`cubic-dev-ai[bot]`)
+
+"Green" = all `gh pr checks` pass **and** no unresolved review threads from those
+bots. The loop below drives toward that state.
+
+## When to use
+
+- The user wants a change opened as a PR and taken through to merge-ready.
+- The user wants existing review comments addressed and pushed until checks pass.
+- Any user-visible (UI) change that should ship with visual evidence.
+
+## Prerequisites (check, don't assume)
+
+- `gh auth status` is logged in. If not, stop and ask the user to `gh auth login`.
+- Working tree changes are the ones intended for this PR (`git status`, `git diff`).
+- For UI verification: `script/ui-run.sh setup` has been run once and `xdotool`
+  is installed (see `docs/agent-ui-verification.md`). If they're missing and the
+  change is UI-facing, ask the user to install them rather than skipping evidence.
+
+The two helper scripts live next to this file:
+
+- `scripts/review-status.sh [PR#]` — prints checks + unresolved AI threads, exits
+  `0` green / `1` blocked / `2` error.
+- `scripts/attach-screenshots.sh <slug> <png...>` — publishes images to the
+  `pr-assets` branch and prints Markdown embeds.
+
+---
+
+## Phase 1 — Branch and local quality gate
+
+1. **Never commit on `develop` or `main`.** Check `git rev-parse --abbrev-ref HEAD`.
+   If on a protected branch, create a topic branch first (descriptive, e.g.
+   `git switch -c fix-project-panel-crash`).
+2. Run the local gate and fix everything it reports **before** pushing — this is
+   cheaper than a review round-trip:
+   ```bash
+   cargo fmt --all
+   cargo clippy --all-targets -- -D warnings
+   cargo build
+   cargo test
+   ```
+   (For GUI code, build with the linker path from `ui-run.sh setup`:
+   `RUSTFLAGS="-L $HOME/.local/devlibs" cargo build --features gui --bin nohrs`.)
+3. Follow the repo's Rust guidelines (CLAUDE.md): no `unwrap()`/panics, no silent
+   `let _ =` on fallible calls, propagate errors with `?`. The AI reviewers flag
+   these, so getting them right now saves a loop iteration.
+
+## Phase 2 — UI verification (only if the change is user-visible)
+
+If the diff touches layout, panels, navigation, previews, or anything rendered,
+verify it for real and capture evidence. Full workflow: `docs/agent-ui-verification.md`.
+
+```bash
+# Build, launch, screenshot the relevant states.
+RUSTFLAGS="-L $HOME/.local/devlibs" cargo build --features gui --bin nohrs
+./script/ui-run.sh launch                      # prints WINDOW / DISPLAY / PID
+./script/ui-run.sh shot /tmp/before.png        # then Read the PNG to confirm state
+# Drive the UI with xdotool, re-shoot after each step (coordinates are absolute):
+DISP=$(./script/ui-run.sh display); WIN=$(./script/ui-run.sh win)
+DISPLAY=$DISP xdotool windowactivate "$WIN" mousemove X Y sleep 0.4 click 1 sleep 1.2
+./script/ui-run.sh shot /tmp/after.png         # Read it; verify the expected change
+./script/ui-run.sh stop
+```
+
+**Read each PNG back yourself** and confirm the change actually happened — a clean
+build is not evidence. Keep the PNGs that best show before/after for the PR. Mind
+the gotchas in the doc (`pkill -x nohrs`, find window by PID, black-first-frame).
+
+## Phase 3 — Open or update the PR
+
+1. Commit with a clear message and push the branch:
+   ```bash
+   git add -A && git commit -m "<imperative summary>"
+   git push -u origin HEAD
+   ```
+   End commit messages with the trailer:
+   `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`
+2. If a PR for this branch already exists (`gh pr view`), update it instead of
+   opening a new one.
+3. **Attach screenshots** (UI changes only) before writing the body, so you have
+   the embed URLs:
+   ```bash
+   .claude/skills/pull-request/scripts/attach-screenshots.sh ui-change /tmp/before.png /tmp/after.png
+   ```
+   Paste the printed `![...](...)` lines into the PR body under a `## Verification`
+   heading. (Images go to the `pr-assets` branch, so they never appear in the code
+   diff the AI reviewers read.)
+4. Open the PR honoring **PR hygiene** (CLAUDE.md):
+   - Imperative, correctly-capitalized title, no conventional-commit prefix
+     (`fix:`/`feat:`), no trailing punctuation. Optionally prefix with the crate
+     name when one crate is the clear scope (e.g. `git_ui: Add history view`).
+   - Body ends with a `Release Notes:` section — blank line after the heading,
+     one bullet: `- Added ...` / `- Fixed ...` / `- Improved ...`, or `- N/A` for
+     docs-only / non-user-facing changes.
+
+   ```bash
+   gh pr create --base develop --title "<title>" --body "$(cat <<'EOF'
+   <what changed and why>
+
+   ## Verification
+   <screenshot embeds + how it was verified, or "N/A">
+
+   Release Notes:
+
+   - <Added/Fixed/Improved ...  or  N/A>
+   EOF
+   )"
+   ```
+
+## Phase 4 — Review loop (drive to green)
+
+Repeat until `review-status.sh` exits `0`, capped at **3 fix iterations** (see
+Phase 5 for what to do if still blocked).
+
+1. **Wait for the gate to settle**, then read it:
+   ```bash
+   gh pr checks --watch --interval 30      # blocks until checks finish (or fail)
+   .claude/skills/pull-request/scripts/review-status.sh
+   ```
+   - Exit `0` → green. Go to "Done".
+   - Exit `1` → blocked. The output lists failing checks and every unresolved
+     AI review thread (`[bot] path:line: comment`). Continue.
+   - Exit `2` → query error (no PR / auth). Resolve and retry.
+2. **Address every unresolved thread on its merits.** For each:
+   - If the comment is correct, fix the code. Re-run the relevant part of the
+     **local gate** (Phase 1) so you don't re-break clippy/tests.
+   - If it's a false positive or out of scope, reply on the thread explaining why,
+     rather than silently ignoring it. Use:
+     ```bash
+     gh pr comment <PR#> --body "..."        # general reply
+     # or reply inline to a specific review comment via the API if needed.
+     ```
+   - Do **not** mark threads resolved on the author's behalf without a real fix or
+     a clear justification — that defeats the gate.
+3. If a UI behavior changed during fixes, **re-run Phase 2** and refresh the
+   screenshots (run `attach-screenshots.sh` again; update the body embeds).
+4. Commit and push the fixes (this re-triggers the AI reviewers):
+   ```bash
+   git add -A && git commit -m "Address review feedback" && git push
+   ```
+5. Go back to step 1.
+
+## Phase 5 — Done or escalate
+
+- **Green:** Tell the user the PR is passing — link (`gh pr view --web` URL),
+  a one-line summary of what changed, and what was verified (with the screenshot
+  links for UI work). Do **not** merge unless the user explicitly asks.
+- **Still blocked after 3 iterations:** Stop looping. Post a concise summary to
+  the user: which checks/threads remain, what you tried, and the specific decision
+  or access you need from them. Don't keep pushing speculative fixes — repeated
+  no-op pushes spam the reviewers and burn CI.
+
+---
+
+## Reference
+
+| Need | Command |
+| --- | --- |
+| Current branch | `git rev-parse --abbrev-ref HEAD` |
+| Local gate | `cargo fmt --all && cargo clippy --all-targets -- -D warnings && cargo build && cargo test` |
+| GUI build | `RUSTFLAGS="-L $HOME/.local/devlibs" cargo build --features gui --bin nohrs` |
+| Launch / shot / stop GUI | `./script/ui-run.sh {launch,shot <png>,stop}` |
+| Watch checks | `gh pr checks --watch --interval 30` |
+| Gate report | `.claude/skills/pull-request/scripts/review-status.sh [PR#]` |
+| Publish screenshots | `.claude/skills/pull-request/scripts/attach-screenshots.sh <slug> <png...>` |
+| PR review threads (raw) | `gh api repos/{owner}/{repo}/pulls/{n}/comments` |
+
+**AI reviewer bots** treated as the gate: `coderabbitai[bot]`, `cubic-dev-ai[bot]`.
+Override with the `PR_REVIEW_BOTS` env var (space-separated) if the set changes.

--- a/.claude/skills/pull-request/scripts/attach-screenshots.sh
+++ b/.claude/skills/pull-request/scripts/attach-screenshots.sh
@@ -19,12 +19,23 @@ slug="${1:-}"
 shift || true
 [ -n "$slug" ] && [ "$#" -ge 1 ] || {
   echo "usage: attach-screenshots.sh <slug> <file1> [file2 ...]" >&2; exit 2; }
+# slug is interpolated into the published path; restrict it to a safe charset so
+# values like "../.." or "a/b" can't escape the screenshots/ subdirectory.
+[[ "$slug" =~ ^[A-Za-z0-9._-]+$ ]] || {
+  echo "error: slug must match ^[A-Za-z0-9._-]+$ (no path separators)" >&2; exit 2; }
 
 ASSET_BRANCH="${PR_ASSETS_BRANCH:-pr-assets}"
 
-# Validate inputs up front so we never push a half-empty batch.
+# Validate inputs up front so we never create a worktree or push a bad batch.
+# Files are stored by basename, so two inputs sharing one would overwrite each
+# other and yield wrong embeds — reject the batch rather than silently lose one.
+declare -A seen_basenames=()
 for f in "$@"; do
   [ -f "$f" ] || { echo "error: not a file: $f" >&2; exit 2; }
+  base=$(basename "$f")
+  [ -z "${seen_basenames[$base]:-}" ] \
+    || { echo "error: duplicate filename in batch: $base" >&2; exit 2; }
+  seen_basenames[$base]=1
 done
 
 origin_url=$(git remote get-url origin 2>/dev/null) \
@@ -49,7 +60,8 @@ if git ls-remote --exit-code --heads origin "$ASSET_BRANCH" >/dev/null 2>&1; the
   git worktree add --quiet -B "$ASSET_BRANCH" "$tmp" "origin/$ASSET_BRANCH" \
     || { echo "error: failed to check out $ASSET_BRANCH" >&2; exit 1; }
 else
-  git worktree add --quiet --orphan "$ASSET_BRANCH" "$tmp" \
+  # git 2.43: --orphan takes the branch name via -b, not as a positional arg.
+  git worktree add --quiet --orphan -b "$ASSET_BRANCH" "$tmp" \
     || { echo "error: failed to create orphan $ASSET_BRANCH" >&2; exit 1; }
 fi
 

--- a/.claude/skills/pull-request/scripts/attach-screenshots.sh
+++ b/.claude/skills/pull-request/scripts/attach-screenshots.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Publish UI verification screenshots (or any image/mp4) to a dedicated assets
+# branch and print Markdown embeds you can paste into the PR body. This keeps
+# the PR's code diff clean (the AI reviewers never see the binaries) while the
+# images still render inline because the repo is public.
+#
+# Usage:
+#   attach-screenshots.sh <slug> <file1.png> [file2.png ...]
+#     <slug>  short label for this batch, e.g. "pr-105" or "grid-view".
+#
+# Env:
+#   PR_ASSETS_BRANCH   assets branch name (default: pr-assets)
+#
+# Prints, on success, a Markdown block of `![slug-name](raw-url)` lines on stdout.
+# All diagnostics go to stderr. Exit nonzero on any failure.
+set -uo pipefail
+
+slug="${1:-}"
+shift || true
+[ -n "$slug" ] && [ "$#" -ge 1 ] || {
+  echo "usage: attach-screenshots.sh <slug> <file1> [file2 ...]" >&2; exit 2; }
+
+ASSET_BRANCH="${PR_ASSETS_BRANCH:-pr-assets}"
+
+# Validate inputs up front so we never push a half-empty batch.
+for f in "$@"; do
+  [ -f "$f" ] || { echo "error: not a file: $f" >&2; exit 2; }
+done
+
+origin_url=$(git remote get-url origin 2>/dev/null) \
+  || { echo "error: no 'origin' remote" >&2; exit 2; }
+# Derive owner/repo from either https or ssh remote forms.
+slug_path=$(printf '%s' "$origin_url" | sed -E 's#^.*github\.com[:/]##; s#\.git$##')
+owner=$(printf '%s' "$slug_path" | cut -d/ -f1)
+repo=$(printf '%s' "$slug_path" | cut -d/ -f2)
+[ -n "$owner" ] && [ -n "$repo" ] \
+  || { echo "error: could not parse owner/repo from $origin_url" >&2; exit 2; }
+
+# A per-run subdir keeps repeated uploads from colliding. $RANDOM is fine here:
+# we only need uniqueness, not unpredictability.
+dest_dir="screenshots/${slug}/$$-$RANDOM"
+
+tmp=$(mktemp -d) || { echo "error: mktemp failed" >&2; exit 2; }
+cleanup() { git worktree remove --force "$tmp" >/dev/null 2>&1 || rm -rf "$tmp"; }
+trap cleanup EXIT
+
+git fetch --quiet origin "$ASSET_BRANCH" 2>/dev/null
+if git ls-remote --exit-code --heads origin "$ASSET_BRANCH" >/dev/null 2>&1; then
+  git worktree add --quiet -B "$ASSET_BRANCH" "$tmp" "origin/$ASSET_BRANCH" \
+    || { echo "error: failed to check out $ASSET_BRANCH" >&2; exit 1; }
+else
+  git worktree add --quiet --orphan "$ASSET_BRANCH" "$tmp" \
+    || { echo "error: failed to create orphan $ASSET_BRANCH" >&2; exit 1; }
+fi
+
+mkdir -p "$tmp/$dest_dir" || { echo "error: mkdir failed" >&2; exit 1; }
+
+embeds=""
+for f in "$@"; do
+  base=$(basename "$f")
+  cp "$f" "$tmp/$dest_dir/$base" || { echo "error: copy failed: $f" >&2; exit 1; }
+  raw="https://raw.githubusercontent.com/${owner}/${repo}/${ASSET_BRANCH}/${dest_dir}/${base}"
+  embeds+="![${slug}-${base}](${raw})"$'\n'
+done
+
+(
+  cd "$tmp" || exit 1
+  git add -A "$dest_dir" || exit 1
+  git commit --quiet -m "Add screenshots for ${slug}" || exit 1
+  git push --quiet origin "HEAD:${ASSET_BRANCH}" || exit 1
+) || { echo "error: failed to commit/push screenshots" >&2; exit 1; }
+
+echo "published to branch '$ASSET_BRANCH' under $dest_dir" >&2
+printf '%s' "$embeds"

--- a/.claude/skills/pull-request/scripts/review-status.sh
+++ b/.claude/skills/pull-request/scripts/review-status.sh
@@ -79,9 +79,18 @@ query($owner:String!, $repo:String!, $pr:Int!) {
   }
 }' 2>/dev/null) || { echo "error: graphql query failed" >&2; exit 2; }
 
-unresolved=$(printf '%s' "$threads_json" | REVIEW_BOTS="$REVIEW_BOTS" python3 -c '
+# Python emits the human-readable listing followed by a final
+# "__UNRESOLVED_COUNT__=N" line. We must FAIL FAST if it errors: defaulting the
+# count to 0 on parse failure would report a false "green" and unblock the gate.
+parsed=$(printf '%s' "$threads_json" | REVIEW_BOTS="$REVIEW_BOTS" python3 -c '
 import sys, json, os
-bots = set(os.environ.get("REVIEW_BOTS", "").split())
+
+def norm(name):
+    # GraphQL author.login omits the trailing "[bot]" that the REST API adds;
+    # normalize so the configured names match regardless of which form is used.
+    return name[:-5] if name.endswith("[bot]") else name
+
+bots = {norm(b) for b in os.environ.get("REVIEW_BOTS", "").split()}
 data = json.load(sys.stdin)
 threads = (((data.get("data") or {}).get("repository") or {})
            .get("pullRequest") or {}).get("reviewThreads", {}).get("nodes", [])
@@ -91,19 +100,20 @@ for t in threads:
         continue
     comments = (t.get("comments") or {}).get("nodes") or []
     author = (comments[0].get("author") or {}).get("login", "") if comments else ""
-    if bots and author not in bots:
+    if bots and norm(author) not in bots:
         continue
     count += 1
     body = (comments[0].get("body", "") if comments else "").strip().replace("\n", " ")
     outdated = " (outdated)" if t.get("isOutdated") else ""
     loc = f'"'"'{t.get("path","?")}:{t.get("line","?")}'"'"'
     print(f"  [{author}] {loc}{outdated}: {body[:160]}")
-print(f"__UNRESOLVED_COUNT__={count}", file=sys.stderr)
-' 2>/tmp/.review-count.$$)
-echo "$unresolved"
-unresolved_count=$(sed -n 's/^__UNRESOLVED_COUNT__=//p' "/tmp/.review-count.$$" 2>/dev/null)
-rm -f "/tmp/.review-count.$$"
-unresolved_count="${unresolved_count:-0}"
+print(f"__UNRESOLVED_COUNT__={count}")
+') || { echo "error: failed to parse review threads" >&2; exit 2; }
+
+printf '%s\n' "$parsed" | grep -v '^__UNRESOLVED_COUNT__='
+unresolved_count=$(printf '%s\n' "$parsed" | sed -n 's/^__UNRESOLVED_COUNT__=//p')
+[[ "$unresolved_count" =~ ^[0-9]+$ ]] \
+  || { echo "error: parser did not report a thread count" >&2; exit 2; }
 [ "$unresolved_count" -eq 0 ] && echo "  (none)"
 
 # --- verdict ---------------------------------------------------------------

--- a/.claude/skills/pull-request/scripts/review-status.sh
+++ b/.claude/skills/pull-request/scripts/review-status.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Aggregate the PR review gate into one machine-readable report:
+#   - CI / status checks (gh pr checks)
+#   - Unresolved review threads from the AI reviewers (CodeRabbit, cubic)
+#
+# Usage:
+#   review-status.sh [PR_NUMBER]
+# If PR_NUMBER is omitted it is resolved from the current branch.
+#
+# Exit codes:
+#   0  green   -> all checks passed AND no unresolved AI review threads
+#   1  blocked -> at least one check failing/pending OR unresolved threads remain
+#   2  error   -> could not query GitHub (no PR for branch, auth, etc.)
+#
+# The bots we treat as the AI review gate. Extend if more reviewers are added.
+set -uo pipefail
+
+REVIEW_BOTS_DEFAULT="coderabbitai[bot] cubic-dev-ai[bot]"
+REVIEW_BOTS="${PR_REVIEW_BOTS:-$REVIEW_BOTS_DEFAULT}"
+
+pr="${1:-}"
+
+meta() {
+  # Prints: <number>\t<owner>\t<repo>
+  local fields
+  if [ -n "$pr" ]; then
+    fields=$(gh pr view "$pr" --json number,headRepositoryOwner,headRepository 2>/dev/null) || return 1
+  else
+    fields=$(gh pr view --json number,headRepositoryOwner,headRepository 2>/dev/null) || return 1
+  fi
+  printf '%s' "$fields" | python3 -c '
+import sys, json
+d = json.load(sys.stdin)
+owner = (d.get("headRepositoryOwner") or {}).get("login", "")
+repo  = (d.get("headRepository") or {}).get("name", "")
+num = d.get("number", "")
+print("\t".join((str(num), owner, repo)))
+' 2>/dev/null
+}
+
+info=$(meta) || { echo "error: no PR found for this branch (open one first)" >&2; exit 2; }
+PR_NUM=$(printf '%s' "$info" | cut -f1)
+OWNER=$(printf '%s' "$info" | cut -f2)
+REPO=$(printf '%s' "$info" | cut -f3)
+[ -n "$PR_NUM" ] && [ -n "$OWNER" ] && [ -n "$REPO" ] \
+  || { echo "error: could not resolve owner/repo/number" >&2; exit 2; }
+
+echo "== PR #$PR_NUM ($OWNER/$REPO) =="
+
+# --- 1. CI / status checks -------------------------------------------------
+echo
+echo "-- checks --"
+checks_out=$(gh pr checks "$PR_NUM" 2>&1)
+checks_rc=$?
+echo "$checks_out"
+# gh pr checks: rc 0 = all passing, 8 = still pending, other nonzero = failing.
+checks_green=0
+if [ "$checks_rc" -eq 0 ]; then checks_green=1; fi
+
+# --- 2. Unresolved AI review threads --------------------------------------
+echo
+echo "-- unresolved review threads --"
+threads_json=$(gh api graphql -F owner="$OWNER" -F repo="$REPO" -F pr="$PR_NUM" -f query='
+query($owner:String!, $repo:String!, $pr:Int!) {
+  repository(owner:$owner, name:$repo) {
+    pullRequest(number:$pr) {
+      reviewThreads(first: 100) {
+        nodes {
+          isResolved
+          isOutdated
+          path
+          line
+          comments(first: 1) {
+            nodes { author { login } body }
+          }
+        }
+      }
+    }
+  }
+}' 2>/dev/null) || { echo "error: graphql query failed" >&2; exit 2; }
+
+unresolved=$(printf '%s' "$threads_json" | REVIEW_BOTS="$REVIEW_BOTS" python3 -c '
+import sys, json, os
+bots = set(os.environ.get("REVIEW_BOTS", "").split())
+data = json.load(sys.stdin)
+threads = (((data.get("data") or {}).get("repository") or {})
+           .get("pullRequest") or {}).get("reviewThreads", {}).get("nodes", [])
+count = 0
+for t in threads:
+    if t.get("isResolved"):
+        continue
+    comments = (t.get("comments") or {}).get("nodes") or []
+    author = (comments[0].get("author") or {}).get("login", "") if comments else ""
+    if bots and author not in bots:
+        continue
+    count += 1
+    body = (comments[0].get("body", "") if comments else "").strip().replace("\n", " ")
+    outdated = " (outdated)" if t.get("isOutdated") else ""
+    loc = f'"'"'{t.get("path","?")}:{t.get("line","?")}'"'"'
+    print(f"  [{author}] {loc}{outdated}: {body[:160]}")
+print(f"__UNRESOLVED_COUNT__={count}", file=sys.stderr)
+' 2>/tmp/.review-count.$$)
+echo "$unresolved"
+unresolved_count=$(sed -n 's/^__UNRESOLVED_COUNT__=//p' "/tmp/.review-count.$$" 2>/dev/null)
+rm -f "/tmp/.review-count.$$"
+unresolved_count="${unresolved_count:-0}"
+[ "$unresolved_count" -eq 0 ] && echo "  (none)"
+
+# --- verdict ---------------------------------------------------------------
+echo
+if [ "$checks_green" -eq 1 ] && [ "$unresolved_count" -eq 0 ]; then
+  echo "VERDICT: green (checks pass, no unresolved AI review threads)"
+  exit 0
+fi
+echo "VERDICT: blocked (checks_green=$checks_green, unresolved_threads=$unresolved_count)"
+exit 1


### PR DESCRIPTION
Adds a `/pull-request` agent skill that takes a change from the working tree to a merge-ready pull request and loops until the quality gate is green.

## What's included

- **`SKILL.md`** — end-to-end flow: branch + local gate (`cargo fmt/clippy/build/test`) → optional headless GUI verification with screenshots for UI changes → open/update PR following this repo's PR hygiene → review loop until green, capped at 3 fix iterations before escalating to a human.
- **`scripts/review-status.sh`** — aggregates the gate into one report: `gh pr checks` plus unresolved AI review threads from `coderabbitai[bot]` and `cubic-dev-ai[bot]` (via GraphQL `reviewThreads`). Exits `0` green / `1` blocked / `2` error.
- **`scripts/attach-screenshots.sh`** — publishes UI screenshots to a dedicated `pr-assets` branch and prints Markdown embeds, keeping the code diff (and the AI reviewers' view) free of binaries.

The "green" definition matches this repo's actual gate: all PR checks pass **and** no unresolved CodeRabbit/cubic review threads. The bot set is overridable via `PR_REVIEW_BOTS`.

## Verification

- `bash -n` passes on both scripts; both are executable.
- `review-status.sh 105` run live against an open PR correctly reported `VERDICT: green` (exit 0).
- owner/repo derivation verified for both https and ssh remote forms.
- `attach-screenshots.sh` was not run live (it pushes to the remote); logic and parsing were checked statically. No UI/Rust code changed, so the cargo gate and GUI verification were not applicable.

Release Notes:

- N/A

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `/pull-request` agent skill that takes local changes to a merge-ready PR and loops until the gate is green. It runs local Rust checks, attaches UI screenshots when relevant, opens/updates the PR, and waits on CI checks and unresolved threads from `coderabbitai[bot]` and `cubic-dev-ai[bot]`.

- **New Features**
  - `.claude/skills/pull-request/SKILL.md`: End-to-end flow — branch, `cargo fmt/clippy/build/test`, optional headless GUI screenshots, PR create/update, review loop (max 3), and escalation.
  - `.claude/skills/pull-request/scripts/review-status.sh`: Aggregates `gh pr checks` plus unresolved review threads via GraphQL; exits 0 (green) / 1 (blocked) / 2 (error); bots overridable via `PR_REVIEW_BOTS`.
  - `.claude/skills/pull-request/scripts/attach-screenshots.sh`: Publishes images to `pr-assets` (override with `PR_ASSETS_BRANCH`) and prints Markdown embeds to keep binaries out of the diff.

- **Bug Fixes**
  - `review-status.sh`: Fail fast on thread-parse errors to prevent false green; normalize `[bot]` suffix so reviewer matching works.
  - `attach-screenshots.sh`: Validate `slug` to prevent path traversal; reject duplicate basenames; fix Git 2.43 orphan worktree syntax (`-b`).

<sup>Written for commit 9534157263d8a4743f9f870932bb737f61185d82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/noh-rs/nohrs/pull/106?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive PR workflow guide covering prerequisites, local quality gates, optional UI verification, PR creation/update steps, iterative review limits, and escalation guidance.

* **Chores**
  * Added automation to publish screenshots/assets to PRs.
  * Added a CI-friendly review-status check that aggregates CI results and unresolved AI-review threads and emits a clear pass/block verdict.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/noh-rs/nohrs/pull/106?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->