### PR TITLE
Rewrite README and move Planned Features to ROADMAP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,114 +1,102 @@
 <div align="center">
-  <img src="assets/doc/icon.png" alt="Nohrs Icon" width="128" height="128">
-  
+  <img src="assets/doc/icon.png" alt="Nohrs icon" width="128" height="128">
+
   # Nohrs
-  
-  **A fast, flexible, and extensible file explorer for macOS**
-  
-  Built with Rust 🦀 and gpui for blazing-fast performance
-  
-  [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
-  [![Rust](https://img.shields.io/badge/rust-stable-orange.svg)](https://www.rust-lang.org)
+
+  **Launcher × Explorer** — a fast, extensible, plugin-ready file workspace for macOS, built in Rust.
+
+  [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+  [![Rust](https://img.shields.io/badge/rust-stable-orange.svg)](rust-toolchain.toml)
   [![Platform](https://img.shields.io/badge/platform-macOS-lightgrey.svg)](https://www.apple.com/macos)
-  
-  <img src="assets/doc/screen-shot.jpeg" alt="Nohrs Screenshot" width="800">
-  
-  ---
-  
-  A modern alternative to macOS Finder, combining everyday usability with power-user functionality through a seamless, high-performance interface.
-  Spotlight-style navigation, cloud-connected workflows, and AI agents are planned to keep file work fast and intelligent.
-  
+  [![CI](https://github.com/noh-rs/nohrs/actions/workflows/ci.yml/badge.svg)](https://github.com/noh-rs/nohrs/actions/workflows/ci.yml)
+  [![Discord](https://img.shields.io/discord/0?label=Discord&logo=discord&logoColor=white&color=5865F2)](https://discord.gg/dZM7fUtE94)
+
+  [Quick Start](#quick-start) · [Why Nohrs?](#why-nohrs) · [Roadmap](docs/ROADMAP.md) · [日本語 README](docs/README.ja.md)
+
+  <img src="assets/doc/screen-shot.jpeg" alt="Nohrs screenshot" width="800">
 </div>
 
-## Development
+Nohrs combines a Raycast-style launcher and a modern, keyboard-driven file explorer in a single app — a Finder alternative that stays fast, scriptable, and extensible through sandboxed plugins.
 
-- Toolchain: Rust (stable), pinned via `rust-toolchain.toml`.
-- Build (core library only): `cargo build`
-- Build GUI binary (placeholder UI): `cargo build --features gui`
-  - Run GUI binary: `cargo run --features gui --bin nohrs`
+## Demo
 
-Notes
+<div align="center">
+  <img src="assets/doc/screen-shot.jpeg" alt="Nohrs in action" width="760">
+</div>
 
-- The GUI is currently a placeholder entry-point that will be wired to gpui once a pinned version is selected.
+> A demo GIF is on the way. Until then, build from source (see [Quick Start](#quick-start)) to try it locally.
 
-### macOS prerequisites for gpui
+## Why Nohrs?
 
-gpui uses Metal on macOS and requires Xcode and the Metal toolchain.
+- **Launcher first-class** — a built-in launcher you can summon from a global hotkey, not bolted on after the fact.
+- **Explorer first-class** — split view, tabs, drag-and-drop, and bulk operations expected of a modern file manager.
+- **WASM Component Model plugins** — extend Nohrs in Rust, TypeScript, or Python, running sandboxed under an explicit-consent permission model.
+- **Search without Spotlight** — a self-contained SQLite + Tantivy hybrid index, with no dependency on the OS search daemon and first-class code-base awareness.
 
-1. Install Xcode from the App Store (launch it once to finish setup)
-2. Install command line tools:
-   - `xcode-select --install`
-3. Ensure CLI uses the installed Xcode:
-   - `sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer`
-4. If build complains about missing Metal toolchain, fetch it:
-   - `xcodebuild -downloadComponent MetalToolchain`
+See the [Roadmap](docs/ROADMAP.md#ビジョン) for how these pillars map to releases.
 
-After completing the above, try building the GUI again.
+## Quick Start
 
-## Planned Features
+### Install (macOS)
 
-### Navigation & UI
+Nohrs is **pre-alpha** and not yet published. Once the first release ships:
 
-- [ ] Tabs and split view for parallel directories
-- [ ] Inline preview for images, PDFs, text, and Markdown
-- [ ] Command palette for quick action search (VS Code-style)
-- [ ] Spotlight-style UI for fast, keyboard-driven navigation
-- [ ] File icons and custom emoji labels
+```sh
+# Planned — not available yet
+cargo install nohrs
+```
 
-### File Operations
-- [ ] In-place editing for `.txt` and `.md`
-- [ ] Bulk rename with regex and metadata rules
-- [ ] Advanced drag-and-drop (S3 upload, Git staging)
-- [ ] Clipboard history for multiple copied items
+Prebuilt macOS binaries will appear on the [Releases](https://github.com/noh-rs/nohrs/releases) page. For now, build from source.
 
-### Search & Indexing
-- [ ] Fast full-text search with Tantivy + ripgrep (fuzzy supported)
-- [ ] Smart folders filtered by tags, type, or date
-- [ ] Search inside previews (PDF, Markdown, code)
-- [ ] File ranking by open frequency, recency, and relevance etc.
+### Build from source
 
-### Terminal Integration
-- [ ] Built-in PTY linked to current directory
-- [ ] Drag-to-escape paste for file paths
-- [ ] Task runner for one-click command execution
+```sh
+# Core library only
+cargo build
 
-### Git Integration
-- [ ] Sidebar for status and branches
-- [ ] Diff preview and blame view
-- [ ] Merge-conflict resolution UI
+# GUI binary
+cargo build --features gui
+cargo run --features gui --bin nohrs
+```
 
-### Cloud Features
-- [ ] Cloud storage integrations (S3-compatible services and more)
-- [ ] Cross-device sync and offline-first workflows
-- [ ] Secure sharing with access controls
+#### macOS prerequisites for gpui
 
-### S3-Compatible Storage
-- [ ] MinIO, Wasabi, and Cloudflare R2 support
-- [ ] Transfer queue and parallel uploads
-- [ ] Metadata editing and presigned URLs
-- [ ] Offline cache and sync recovery
+gpui renders with Metal on macOS, so Xcode and the Metal toolchain are required:
 
-### Automation & Extensions
-- [ ] Plugin system for custom UI or features
-- [ ] Folder-watch actions (auto-tag, auto-transfer)
-- [ ] CLI / HTTP API for external control
-- [ ] Remote browsing via SSH
+1. Install Xcode from the App Store (launch it once to finish setup).
+2. Install the command line tools: `xcode-select --install`
+3. Point the CLI at the installed Xcode: `sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer`
+4. If the build reports a missing Metal toolchain: `xcodebuild -downloadComponent MetalToolchain`
 
-### AI Agent Features
-- [ ] AI agent assistance for file organization and workflows
-- [ ] Natural-language actions (find, move, summarize, tag)
-- [ ] Smart automation suggestions based on context
+> For Linux native, Nix, and Docker setups, see the [recommended setup matrix](docs/dev-environment.md#1-推奨セットアップ早見表).
 
-## Contributing
+## Status
 
-Contributions are welcome! Please feel free to submit a pull request.
+**Pre-alpha (v0.x).** The app is under active development and APIs, UI, and data formats will change without notice. The current GUI is an early entry point being wired up to gpui. Expect rough edges, and please file issues.
 
-### Code Style
+## Roadmap
 
-- Rust (stable; toolchain pinned via rust-toolchain.toml): Follow standard conventions
+Nohrs ships in six serial phases from `v0.2.0` to `v0.7.0`. Highlights:
 
+| Phase | Milestone | Theme |
+|-------|-----------|-------|
+| **P1** | `v0.2.0` | Foundation — quality, workspace split, dev/CI infra, web MVP |
+| **P2** | `v0.3.0` | Explorer Essentials — DnD, file ops, split view, tabs, persistence |
+| **P3** | `v0.4.0` | Launcher & Search — global-hotkey launcher, SQLite FTS5 search |
+| **P4** | `v0.5.0` | Plugin Host — WASM Component Model, 3-language templates |
+| **P5** | `v0.6.0` | Ecosystem — Plugin Store, community plugins |
+| **P6** | `v0.7.0` | Stabilization — multi-OS strategy, performance gates, docs |
 
-## Links
+Full details, vision, and design docs live in [`docs/ROADMAP.md`](docs/ROADMAP.md).
 
-- **Discord**: https://discord.gg/dZM7fUtE94  
+## Community
+
+- **Discord**: https://discord.gg/dZM7fUtE94
 - **X (Twitter)**: https://x.com/nohrsdotapp
+- **GitHub**: https://github.com/noh-rs/nohrs
+
+Contributions are welcome — open an issue or a pull request.
+
+## License
+
+Released under the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@
   [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
   [![Rust](https://img.shields.io/badge/rust-stable-orange.svg)](rust-toolchain.toml)
   [![Platform](https://img.shields.io/badge/platform-macOS-lightgrey.svg)](https://www.apple.com/macos)
-  [![CI](https://github.com/noh-rs/nohrs/actions/workflows/ci.yml/badge.svg)](https://github.com/noh-rs/nohrs/actions/workflows/ci.yml)
-  [![Discord](https://img.shields.io/discord/0?label=Discord&logo=discord&logoColor=white&color=5865F2)](https://discord.gg/dZM7fUtE94)
+  [![Discord](https://img.shields.io/badge/Discord-join-5865F2?logo=discord&logoColor=white)](https://discord.gg/dZM7fUtE94)
 
   [Quick Start](#quick-start) · [Why Nohrs?](#why-nohrs) · [Roadmap](docs/ROADMAP.md) · [日本語 README](docs/README.ja.md)
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -8,8 +8,7 @@
   [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](../LICENSE)
   [![Rust](https://img.shields.io/badge/rust-stable-orange.svg)](../rust-toolchain.toml)
   [![Platform](https://img.shields.io/badge/platform-macOS-lightgrey.svg)](https://www.apple.com/macos)
-  [![CI](https://github.com/noh-rs/nohrs/actions/workflows/ci.yml/badge.svg)](https://github.com/noh-rs/nohrs/actions/workflows/ci.yml)
-  [![Discord](https://img.shields.io/discord/0?label=Discord&logo=discord&logoColor=white&color=5865F2)](https://discord.gg/dZM7fUtE94)
+  [![Discord](https://img.shields.io/badge/Discord-join-5865F2?logo=discord&logoColor=white)](https://discord.gg/dZM7fUtE94)
 
   [クイックスタート](#クイックスタート) · [なぜ-nohrs](#なぜ-nohrs) · [ロードマップ](ROADMAP.md) · [English README](../README.md)
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,89 +1,102 @@
-# Nohrs
+<div align="center">
+  <img src="../assets/doc/icon.png" alt="Nohrs アイコン" width="128" height="128">
 
-Rustとgpuiを使用し、macOS Finderのモダンな代替となる、**高速で柔軟性があり、拡張可能なファイルエクスプローラー**を開発します。シームレスで高性能なインターフェースを通じて、日常的な使いやすさとパワーユーザー向けの機能性を両立することを目指しています。Spotlight風UI、クラウド連携、AIエージェントによる支援も計画しています。
+  # Nohrs
 
-## 開発
+  **Launcher × Explorer** — Rust 製の高速・拡張可能・プラグイン対応な macOS 向けファイルワークスペース。
 
-* **ツールチェーン:** Rust (stable)、 `rust-toolchain.toml` によりバージョン固定
-* **ビルド (コアライブラリのみ):** `cargo build`
-* **GUIバイナリのビルド (プレースホルダーUI):** `cargo build --features gui`
-* **GUIバイナリの実行:** `cargo run --features gui --bin nohrs`
+  [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](../LICENSE)
+  [![Rust](https://img.shields.io/badge/rust-stable-orange.svg)](../rust-toolchain.toml)
+  [![Platform](https://img.shields.io/badge/platform-macOS-lightgrey.svg)](https://www.apple.com/macos)
+  [![CI](https://github.com/noh-rs/nohrs/actions/workflows/ci.yml/badge.svg)](https://github.com/noh-rs/nohrs/actions/workflows/ci.yml)
+  [![Discord](https://img.shields.io/discord/0?label=Discord&logo=discord&logoColor=white&color=5865F2)](https://discord.gg/dZM7fUtE94)
 
-**注記**
+  [クイックスタート](#クイックスタート) · [なぜ-nohrs](#なぜ-nohrs) · [ロードマップ](ROADMAP.md) · [English README](../README.md)
 
-* 現在のGUIはプレースホルダー（仮の）エントリーポイントであり、gpuiの固定バージョンが選定され次第、接続される予定です。
+  <img src="../assets/doc/screen-shot.jpeg" alt="Nohrs スクリーンショット" width="800">
+</div>
 
-### gpuiのためのmacOS前提条件
+Nohrs は、Raycast 風ランチャーとモダンでキーボード中心のファイルエクスプローラを 1 つのアプリに統合します。高速でスクリプタブル、かつサンドボックス化されたプラグインで拡張できる、Finder の代替を目指しています。
 
-gpuiはmacOS上でMetalを使用するため、XcodeとMetalツールチェーンが必要です。
+## デモ
 
-1.  App StoreからXcodeをインストールします（一度起動してセットアップを完了させてください）
-2.  コマンドラインツールをインストールします:
-    * `xcode-select --install`
-3.  CLIがインストールされたXcodeを使用するように設定します:
-    * `sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer`
-4.  ビルド時にMetalツールチェーンが見つからないとエラーが出る場合、取得します:
-    * `xcodebuild -downloadComponent MetalToolchain`
+<div align="center">
+  <img src="../assets/doc/screen-shot.jpeg" alt="Nohrs の動作画面" width="760">
+</div>
 
-上記を完了した後、再度GUIのビルドを試してください。
+> デモ GIF は準備中です。それまでは[クイックスタート](#クイックスタート)に従ってソースからビルドしてお試しください。
 
-## 計画中の機能
+## なぜ Nohrs?
 
-### ナビゲーション & UI
-* 複数のディレクトリを並行して開くためのタブと分割ビュー
-* 画像、PDF、テキスト、Markdownのインラインプレビュー
-* 素早いアクション検索のためのコマンドパレット（VS Code風）
-* Spotlight風UIによるキーボード中心の高速ナビゲーション
-* ファイルアイコンとカスタム絵文字ラベル
+- **Launcher first-class** — グローバルホットキーから呼び出せるランチャーを内蔵。後付けではありません。
+- **Explorer first-class** — スプリットビュー / タブ / ドラッグ＆ドロップ / バルク操作を備えた現代的なファイラー。
+- **WASM Component Model プラグイン** — Rust / TypeScript / Python で拡張可能。サンドボックス + 明示同意の権限モデルで動作します。
+- **Spotlight に依存しない検索** — SQLite + Tantivy のハイブリッドインデックスで、OS の検索デーモンに依存せず、コードベースにも対応。
 
-### ファイル操作
-* `.txt` および `.md` ファイルのその場での編集
-* 正規表現やメタデータルールを使用した一括リネーム
-* 高度なドラッグ＆ドロップ（S3へのアップロード、Gitのステージングなど）
-* 複数のコピー項目に対応したクリップボード履歴
+これらの柱がどのリリースに対応するかは[ロードマップ](ROADMAP.md#ビジョン)を参照してください。
 
-### 検索 & インデックス
-* Tantivy + ripgrepによる高速な全文検索（あいまい検索対応）
-* タグ、種類、日付でフィルタリングされるスマートフォルダ
-* プレビュー内（PDF、Markdown、コード）の検索
-* ファイルの表示頻度、最新度、関連性などによるランキング
+## クイックスタート
 
-### ターミナル統合
-* 現在のディレクトリに連動する内蔵PTY（仮想端末）
-* ファイルパスをエスケープしてペーストするためのドラッグ操作
-* ワンクリックでコマンドを実行するタスクランナー
+### インストール (macOS)
 
-### Git統合
-* ステータスとブランチを表示するサイドバー
-* 差分（Diff）プレビューとBlameビュー
-* マージコンフリクト（競合）解消のためのUI
+Nohrs は **pre-alpha** であり、まだ公開されていません。最初のリリース公開後は次のように導入できる予定です。
 
-### クラウド機能
-* クラウドストレージ連携（S3互換サービスなど）
-* デバイス間同期とオフライン優先のワークフロー
-* アクセス制御付きの安全な共有
+```sh
+# 予定 — 現時点では未提供
+cargo install nohrs
+```
 
-### S3互換ストレージ
-* MinIO, Wasabi, Cloudflare R2 のサポート
-* 転送キューと並列アップロード
-* メタデータ編集と署名付きURL（Presigned URLs）の生成
-* オフラインキャッシュと同期の復元
+ビルド済みの macOS バイナリは [Releases](https://github.com/noh-rs/nohrs/releases) ページで提供予定です。現時点ではソースからビルドしてください。
 
-### 自動化 & 拡張機能
-* カスタムUIや機能のためのプラグインシステム
-* フォルダ監視アクション（自動タグ付け、自動転送など）
-* 外部から制御するためのCLI / HTTP API
-* SSH経由のリモートブラウジング
+### ソースからビルド
 
-### AIエージェント機能
-* ファイル整理やワークフローを支援するAIエージェント
-* 自然言語による操作（検索、移動、要約、タグ付け）
-* 文脈に応じたスマートな自動化提案
+```sh
+# コアライブラリのみ
+cargo build
 
-## コントリビューション (貢献)
+# GUI バイナリ
+cargo build --features gui
+cargo run --features gui --bin nohrs
+```
 
-コントリビューションを歓迎します！お気軽にプルリクエストを送信してください。
+#### gpui のための macOS 前提条件
 
-### コードスタイル
+gpui は macOS 上で Metal を使用するため、Xcode と Metal ツールチェーンが必要です。
 
-* **Rust (stable; `rust-toolchain.toml` によりツールチェーンを固定):** 標準的な規約に従ってください
+1. App Store から Xcode をインストールします（一度起動してセットアップを完了させてください）。
+2. コマンドラインツールをインストールします: `xcode-select --install`
+3. CLI がインストール済みの Xcode を使用するよう設定します: `sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer`
+4. Metal ツールチェーンが見つからないとエラーが出る場合: `xcodebuild -downloadComponent MetalToolchain`
+
+> Linux native / Nix / Docker でのセットアップは[推奨セットアップ早見表](dev-environment.md#1-推奨セットアップ早見表)を参照してください。
+
+## ステータス
+
+**Pre-alpha (v0.x)。** 活発に開発中であり、API・UI・データ形式は予告なく変更されます。現在の GUI は gpui に接続中の初期エントリーポイントです。粗削りな点が多いため、不具合は Issue でお知らせください。
+
+## ロードマップ
+
+Nohrs は `v0.2.0` から `v0.7.0` まで、6 つのシリアルなフェーズで開発します。概要は次のとおりです。
+
+| Phase | Milestone | テーマ |
+|-------|-----------|--------|
+| **P1** | `v0.2.0` | Foundation — 品質改善・workspace 化・開発/CI 基盤・web MVP |
+| **P2** | `v0.3.0` | Explorer Essentials — DnD・ファイル操作・スプリットビュー・タブ・永続化 |
+| **P3** | `v0.4.0` | Launcher & Search — グローバルホットキーランチャー・SQLite FTS5 検索 |
+| **P4** | `v0.5.0` | Plugin Host — WASM Component Model・3 言語テンプレ |
+| **P5** | `v0.6.0` | Ecosystem — Plugin Store・コミュニティプラグイン |
+| **P6** | `v0.7.0` | Stabilization — 多 OS 戦略・パフォーマンスゲート・ドキュメント |
+
+ビジョン・各フェーズの詳細・設計ドキュメントは [`docs/ROADMAP.md`](ROADMAP.md) にあります。
+
+## コミュニティ
+
+- **Discord**: https://discord.gg/dZM7fUtE94
+- **X (Twitter)**: https://x.com/nohrsdotapp
+- **GitHub**: https://github.com/noh-rs/nohrs
+
+コントリビューションを歓迎します。Issue や Pull Request をお気軽にどうぞ。
+
+## ライセンス
+
+[MIT License](../LICENSE) のもとで公開しています。


### PR DESCRIPTION
Closes #57

Rewrites the README into the structure requested in the epic: **Hero / Demo / Why / Quick Start / Status / Roadmap / Community / License**, and keeps `docs/README.ja.md` in sync.

## Changes

- Removed the long "Planned Features" bullet list (~50 lines); the feature breakdown now lives in [`docs/ROADMAP.md`](docs/ROADMAP.md).
- **Hero** — "Launcher × Explorer" tagline, icon, screenshot, badges (License / Rust / Platform / CI / Discord), and quick nav links.
- **Demo** — screenshot section (GIF noted as coming).
- **Why Nohrs?** — the four differentiators (launcher first-class, explorer first-class, WASM Component Model plugins, Spotlight-independent search).
- **Quick Start** — macOS install (planned `cargo install` + releases page), build-from-source steps, gpui/Metal prerequisites, and a pointer to the recommended setup matrix in `docs/dev-environment.md`.
- **Status** — explicit "Pre-alpha (v0.x)".
- **Roadmap** — phase summary table linking to `docs/ROADMAP.md`.
- **Community / License** — Discord / X / GitHub and MIT.
- Synced `docs/README.ja.md` with the same structure and cross-links to the English README.

## Notes

- The CI badge points at the planned `.github/workflows/ci.yml`; it will light up once P1 CI lands. A standalone coverage badge was omitted since `coverage.nohrs.app` is not live yet — coverage is tracked in the roadmap.
- The recommended setup matrix is linked from `docs/dev-environment.md` rather than duplicated inline (coordinates with #52).

Release Notes:

- N/A

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrites the README into the Hero / Demo / Why / Quick Start / Status / Roadmap / Community / License structure, moves the “Planned Features” list to `docs/ROADMAP.md`, and keeps `docs/README.ja.md` in sync. Updates badges to be reliable and removes CI/coverage until infra lands.

- **Refactors**
  - Added “Launcher × Explorer” tagline, app icon, and badges (License / Rust / Platform / Discord join).
  - Introduced Demo and Why sections; emphasized launcher-/explorer-first pillars and the plugin model.
  - Expanded Quick Start with macOS install plan, build-from-source, and `gpui`/Metal prerequisites; linked to `docs/dev-environment.md`.
  - Added explicit Pre‑alpha status and a phase summary table linking to `docs/ROADMAP.md`.
  - Removed the long features list from README; roadmap is now the source of truth.
  - Replaced the dynamic Discord badge with a static “join” badge and removed CI/coverage badges until P1 CI lands.

<sup>Written for commit 6e25e158f9e71e3f8ae6398fb545fead73fdca45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/noh-rs/nohrs/pull/108?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Major README refresh: new hero/branding, tagline, screenshot, and product positioning (“Launcher × Explorer”).
  * Added Demo and “Why Nohrs?” sections and condensed Status/Roadmap overview (phased roadmap v0.2.0–v0.7.0).
  * Overhauled Quick Start to emphasize pre-alpha, clarify install/build commands, prerequisites, and link to recommended setup matrix.
  * Added Japanese README and updated community/license links; removed outdated development/contributing detail.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/noh-rs/nohrs/pull/108?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->