### PR TITLE
Add OSS hygiene baseline: CI, community files, and crate metadata

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,78 @@
+name: Bug report
+description: Report a problem with Nohrs
+title: "[Bug] "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report. Please search
+        [existing issues](https://github.com/noh-rs/nohrs/issues) first to avoid duplicates.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: A clear and concise description of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps that reliably trigger the bug.
+      placeholder: |
+        1. Run `cargo run --features gui --bin nohrs`
+        2. Open ...
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: Include error messages, logs, or screenshots if available.
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Nohrs version / commit
+      description: Output of `nohrs --version`, or the git commit you built from.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - macOS
+        - Linux
+        - Other (note in summary)
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Rust toolchain (`rustc --version`), OS version, and anything else relevant.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues and this is not a duplicate.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discord
+    url: https://discord.gg/dZM7fUtE94
+    about: Questions, ideas, and general discussion.
+  - name: Security report
+    url: https://github.com/noh-rs/nohrs/security/advisories/new
+    about: Privately report a security vulnerability (see SECURITY.md).

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,46 @@
+name: Feature request
+description: Suggest an idea or enhancement for Nohrs
+title: "[Feature] "
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion! Please check the [Roadmap](https://github.com/noh-rs/nohrs/blob/develop/docs/ROADMAP.md)
+        and [existing issues](https://github.com/noh-rs/nohrs/issues) first.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What problem does this solve? What are you trying to do?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the feature or behavior you would like.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you have thought about, if any.
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Mockups, links, or anything else that helps.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues and the roadmap, and this is not a duplicate.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,36 @@
+<!--
+PR title rules (see CONTRIBUTING.md):
+  - Imperative mood, correctly capitalized: "Fix crash in project panel"
+  - No conventional-commit prefixes (no "fix:", "feat:", "docs:", ...)
+  - No trailing punctuation
+  - Optionally prefix with the crate/scope when one is the clear owner: "search: Add fuzzy matching"
+-->
+
+## Summary
+
+<!-- What does this PR change and why? Link the issue it closes, e.g. "Closes #47". -->
+
+## Changes
+
+<!-- Bullet the notable changes. -->
+
+-
+
+## Testing
+
+<!-- How did you verify this? e.g. `cargo test`, `cargo clippy`, manual GUI run. -->
+
+- [ ] `cargo fmt --all --check`
+- [ ] `cargo clippy --all-targets -- -D warnings`
+- [ ] `cargo test`
+
+## Release Notes
+
+<!--
+One bullet. Use "Added ...", "Fixed ...", or "Improved ..." for user-facing
+changes, or "N/A" for docs-only / non-user-facing changes.
+-->
+
+Release Notes:
+
+- N/A

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+updates:
+  # Rust crates for the core workspace. `web/` (TypeScript) is handled by a
+  # separate ecosystem below so its updates do not add noise to Rust reviews
+  # (see docs/adr/0006-monorepo-web.md).
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "deps"
+    labels:
+      - dependencies
+      - rust
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+    labels:
+      - dependencies
+      - github-actions
+
+  # When web/ (TypeScript, excluded from the Cargo workspace) lands, add an
+  # npm ecosystem here scoped to directory "/web" so its updates stay separate
+  # from Rust reviews (ADR 0006). Left out for now because no manifest exists.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,15 +26,17 @@ jobs:
     name: fmt / clippy / test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: rustfmt, clippy
 
       - name: Cache cargo artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Format
         run: cargo fmt --all --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: CI
+
+on:
+  push:
+    branches: [develop, main]
+    paths-ignore:
+      - "web/**"
+      - "docs/**"
+      - "**.md"
+  pull_request:
+    paths-ignore:
+      - "web/**"
+      - "docs/**"
+      - "**.md"
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-D warnings"
+
+jobs:
+  check:
+    name: fmt / clippy / test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Format
+        run: cargo fmt --all --check
+
+      # gpui renders with Metal and only builds on macOS, so the `gui`
+      # feature (and its `[[bin]]`) is excluded from the Linux CI build.
+      - name: Clippy
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: Build
+        run: cargo build --locked
+
+      - name: Test
+        run: cargo test --locked

--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,6 @@ coverage/
 .agent
 
 # personal
-/.github
 /.specify
 
 # Python bytecode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+While Nohrs is pre-alpha (`0.x`), minor versions may include breaking changes.
+
+## [Unreleased]
+
+### Added
+
+- OSS hygiene baseline: CI workflow, Dependabot config, issue/PR templates,
+  `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, and this changelog.
+- Package metadata (`description`, `repository`, `homepage`, `license`,
+  `keywords`, `categories`, `authors`, `rust-version`) so `cargo publish` works.
+
+[Unreleased]: https://github.com/noh-rs/nohrs/commits/develop

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,85 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement via our [Discord](https://discord.gg/dZM7fUtE94). All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,96 @@
+# Contributing to Nohrs
+
+Thanks for your interest in contributing! Nohrs is **pre-alpha**, so things move
+fast — issues, pull requests, and discussion are all welcome.
+
+By participating you agree to abide by our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Getting started
+
+1. Read the [Roadmap](docs/ROADMAP.md) to see where the project is headed.
+2. Browse [open issues](https://github.com/noh-rs/nohrs/issues). Issues labeled
+   `good first issue` are a good entry point.
+3. For anything non-trivial, open (or comment on) an issue first so we can agree
+   on the approach before you invest time.
+
+## Development environment
+
+The Rust toolchain is pinned by [`rust-toolchain.toml`](rust-toolchain.toml);
+`rustup` picks it up automatically. The full setup matrix (macOS, Linux native,
+Nix, Docker) lives in [`docs/dev-environment.md`](docs/dev-environment.md).
+
+```sh
+# Core library (no GUI) — builds on any platform
+cargo build
+
+# GUI binary — requires gpui's platform deps (Metal on macOS; see dev-environment.md)
+cargo run --features gui --bin nohrs
+```
+
+The `gui` feature pulls in `gpui` and only builds where its platform backend is
+available, so CI and the core library checks run **without** it.
+
+## Branching and pull requests
+
+- Branch off `develop` (the default branch). `main` tracks releases.
+- Keep pull requests focused; split unrelated changes into separate PRs.
+- Open your PR against `develop` and fill in the PR template.
+
+### PR title rules
+
+- Imperative mood, correctly capitalized — e.g. `Fix crash in project panel`.
+- **No** conventional-commit prefixes (`fix:`, `feat:`, `docs:`, …).
+- No trailing punctuation.
+- Optionally prefix with the crate/scope when one is the clear owner —
+  e.g. `search: Add fuzzy matching`.
+
+### Release notes
+
+Every PR body ends with a `Release Notes:` section containing exactly one bullet:
+
+```
+Release Notes:
+
+- Added ...        # or "Fixed ..." / "Improved ..." for user-facing changes
+- N/A              # for docs-only / non-user-facing changes
+```
+
+User-facing changes should also be added to the `[Unreleased]` section of
+[`CHANGELOG.md`](CHANGELOG.md).
+
+## Commit messages
+
+- Write in the imperative mood and explain the *why* when it isn't obvious.
+- Group logically related changes into a single commit; avoid noisy fixups in
+  the final history (squash locally before pushing if needed).
+
+## Code style and quality gate
+
+Run these before pushing — they mirror what CI enforces:
+
+```sh
+cargo fmt --all --check
+cargo clippy --all-targets -- -D warnings
+cargo test
+```
+
+Coding conventions (error handling, naming, avoiding panics, GPUI patterns) are
+documented in [`.rules`](.rules) / `CLAUDE.md`. Highlights:
+
+- Prefer correctness and clarity over cleverness.
+- Never panic in library code: propagate errors with `?` instead of `unwrap()` /
+  `expect()`, and never silently discard errors with `let _ =`.
+- Only add comments that explain a non-obvious *why*.
+
+## Testing
+
+- Unit tests live in each module under `#[cfg(test)] mod tests`.
+- GPUI view/state tests use `TestAppContext`. Drive async work with the GPUI
+  executor timer (`cx.background_executor.timer(...).await`) and
+  `run_until_parked()` — **not** `smol::Timer` / `tokio::time::sleep`, which the
+  GPUI scheduler doesn't track. See [`docs/testing.md`](docs/testing.md).
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the
+[MIT License](LICENSE).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ available, so CI and the core library checks run **without** it.
 
 Every PR body ends with a `Release Notes:` section containing exactly one bullet:
 
-```
+```text
 Release Notes:
 
 - Added ...        # or "Fixed ..." / "Improved ..." for user-facing changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,15 @@
 name = "nohrs"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.83"
+description = "Launcher × Explorer — a fast, extensible, plugin-ready file workspace built in Rust."
+authors = ["nohrs contributors"]
+license = "MIT"
+readme = "README.md"
+repository = "https://github.com/noh-rs/nohrs"
+homepage = "https://nohrs.app"
+keywords = ["launcher", "file-explorer", "file-manager", "gpui", "productivity"]
+categories = ["filesystem", "gui"]
 
 [lib]
 name = "nohrs"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 shuya goto
+Copyright (c) 2025 Nohrs contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 
   **Launcher × Explorer** — a fast, extensible, plugin-ready file workspace for macOS, built in Rust.
 
+  [![CI](https://github.com/noh-rs/nohrs/actions/workflows/ci.yml/badge.svg?branch=develop)](https://github.com/noh-rs/nohrs/actions/workflows/ci.yml)
   [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
   [![Rust](https://img.shields.io/badge/rust-stable-orange.svg)](rust-toolchain.toml)
   [![Platform](https://img.shields.io/badge/platform-macOS-lightgrey.svg)](https://www.apple.com/macos)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,37 @@
+# Security Policy
+
+Nohrs is **pre-alpha** software. We still take security seriously and appreciate
+responsible disclosure.
+
+## Supported versions
+
+Until the first stable release, only the latest `develop` is supported. Security
+fixes land there and ship in the next release.
+
+| Version            | Supported |
+| ------------------ | --------- |
+| `develop` (latest) | ✅        |
+| older / tagged     | ❌        |
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for security vulnerabilities.**
+
+Report privately via GitHub's
+[security advisory form](https://github.com/noh-rs/nohrs/security/advisories/new).
+If you cannot use that, reach a maintainer through the
+[Discord](https://discord.gg/dZM7fUtE94) and ask for a private channel.
+
+Please include:
+
+- A description of the vulnerability and its impact.
+- Steps to reproduce or a proof of concept.
+- Affected version / commit and platform.
+
+## What to expect
+
+- We aim to acknowledge a report within **5 business days**.
+- We will keep you informed of progress and let you know when a fix is released.
+- With your consent, we are happy to credit you in the release notes.
+
+Thank you for helping keep Nohrs and its users safe.

--- a/src/pages/explorer/preview.rs
+++ b/src/pages/explorer/preview.rs
@@ -200,10 +200,9 @@ impl ExplorerPage {
                     if let Some(file_result) = results.iter().find(|r| r.path == path) {
                         if let Some(first_match) = file_result.matches.first() {
                             // `line_number` is 1-based; `line_start_offset` takes a 0-based index.
-                            if let Some(offset) = line_start_offset(
-                                &text,
-                                first_match.line_number.saturating_sub(1),
-                            ) {
+                            if let Some(offset) =
+                                line_start_offset(&text, first_match.line_number.saturating_sub(1))
+                            {
                                 if let Some(editor) = self.preview_editor.clone() {
                                     editor.update(cx, |editor, cx| {
                                         editor.scroll_to(offset, window, cx);

--- a/src/pages/explorer/state.rs
+++ b/src/pages/explorer/state.rs
@@ -217,8 +217,8 @@ impl ExplorerPage {
                 } else {
                     0
                 };
-                let total_height = config::BASE_ROW_HEIGHT
-                    + (snippet_count as f32 * config::SNIPPET_ROW_HEIGHT);
+                let total_height =
+                    config::BASE_ROW_HEIGHT + (snippet_count as f32 * config::SNIPPET_ROW_HEIGHT);
                 size(px(total_width), px(total_height))
             })
             .collect();

--- a/src/services/fs/listing.rs
+++ b/src/services/fs/listing.rs
@@ -52,7 +52,7 @@ fn list_dir_impl(path: &str, limit: usize, cursor: Option<&str>) -> Result<ListR
         let file_name = os_str_to_string(entry.file_name());
         names.push((file_name, entry.path()));
     }
-    names.sort_by(|a, b| a.0.to_lowercase().cmp(&b.0.to_lowercase()));
+    names.sort_by_key(|a| a.0.to_lowercase());
 
     let total = names.len();
     let offset = cursor

--- a/src/services/search/engine.rs
+++ b/src/services/search/engine.rs
@@ -1,6 +1,4 @@
 use super::indexer::IndexManager;
-#[cfg(not(target_os = "macos"))]
-use super::ripgrep::RipgrepBackend;
 use super::watcher::FileWatcher;
 use super::{SearchBackend, SearchResult, SearchScope};
 use anyhow::{Context, Result};

--- a/src/services/search/indexer.rs
+++ b/src/services/search/indexer.rs
@@ -119,12 +119,10 @@ impl IndexManager {
                 .hidden(false)
                 .git_ignore(true)
                 .build();
-            for result in walker {
-                if let Ok(entry) = result {
-                    // Count both files and directories
-                    if entry.path().is_file() || entry.path().is_dir() {
-                        total_files += 1;
-                    }
+            for entry in walker.flatten() {
+                // Count both files and directories
+                if entry.path().is_file() || entry.path().is_dir() {
+                    total_files += 1;
                 }
             }
         }
@@ -143,7 +141,7 @@ impl IndexManager {
                     if path.is_file() {
                         if let Err(e) = self.index_single_file(
                             path,
-                            &mut *writer_guard,
+                            &mut writer_guard,
                             path_field,
                             filename_field,
                             content_field,
@@ -154,7 +152,7 @@ impl IndexManager {
                     } else if path.is_dir() {
                         if let Err(e) = self.index_single_directory(
                             path,
-                            &mut *writer_guard,
+                            &mut writer_guard,
                             path_field,
                             filename_field,
                             content_field,
@@ -291,7 +289,7 @@ impl IndexManager {
             if path.exists() {
                 if let Err(e) = self.index_single_file(
                     path,
-                    &mut *writer_guard,
+                    &mut writer_guard,
                     path_field,
                     filename_field,
                     content_field,

--- a/src/services/search/ripgrep.rs
+++ b/src/services/search/ripgrep.rs
@@ -34,7 +34,7 @@ impl Sink for MatchStorage {
         let mut results = self
             .results
             .lock()
-            .map_err(|_| std::io::Error::new(std::io::ErrorKind::Other, "Lock poisoned"))?;
+            .map_err(|_| std::io::Error::other("Lock poisoned"))?;
 
         results.push(SearchResult {
             path: self.path.clone(),
@@ -60,7 +60,7 @@ impl SearchBackend for RipgrepBackend {
         for result in walker {
             match result {
                 Ok(entry) => {
-                    if entry.file_type().map_or(false, |ft| ft.is_file()) {
+                    if entry.file_type().is_some_and(|ft| ft.is_file()) {
                         let path = entry.path().to_path_buf();
                         let results_clone = results.clone();
                         let sink = MatchStorage {

--- a/src/services/search/spotlight.rs
+++ b/src/services/search/spotlight.rs
@@ -9,6 +9,12 @@ use std::process::Command;
 
 pub struct SpotlightBackend;
 
+impl Default for SpotlightBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl SpotlightBackend {
     pub fn new() -> Self {
         Self

--- a/src/ui/components/file_list.rs
+++ b/src/ui/components/file_list.rs
@@ -209,9 +209,7 @@ pub fn format_date(timestamp: &u64) -> String {
 
     let format = format_description!("[year]/[month]/[day]");
     match OffsetDateTime::from_unix_timestamp(*timestamp as i64) {
-        Ok(datetime) => datetime
-            .format(&format)
-            .unwrap_or_else(|_| "-".to_string()),
+        Ok(datetime) => datetime.format(&format).unwrap_or_else(|_| "-".to_string()),
         Err(_) => "-".to_string(),
     }
 }

--- a/src/ui/components/layout/footer.rs
+++ b/src/ui/components/layout/footer.rs
@@ -114,11 +114,7 @@ pub fn footer<V: gpui::Render>(props: FooterProps, cx: &mut Context<V>) -> impl 
                             .flex()
                             .items_center()
                             .gap_1()
-                            .child(
-                                Icon::new(IconName::Info)
-                                    .size_3()
-                                    .text_color(rgb(color)),
-                            )
+                            .child(Icon::new(IconName::Info).size_3().text_color(rgb(color)))
                             .child(div().text_xs().text_color(rgb(color)).child(message)),
                     )
                 }),


### PR DESCRIPTION
Establishes the minimum OSS hygiene set so the project is presentable for public
contribution and `cargo publish` works. Implements issue #47 (parent #40).

## Changes

- **`.gitignore`**: drop the `/.github` line so CI/CD is git-managed.
- **`Cargo.toml`** `[package]`: add `description`, `authors`, `license = "MIT"`,
  `readme`, `repository`, `homepage`, `keywords`, `categories`, and
  `rust-version = "1.83"` (values per `docs/architecture.md` §workspace.package).
  Feature setup was already correct (`gpui`/`gpui-component`/`rust-embed` optional;
  `image`/`syntect` already `default-features = false`).
- **`.github/`**: CI workflow (`fmt` / `clippy -D warnings` / `build` / `test` on
  Linux stable, `gui` feature excluded since gpui needs Metal; `paths-ignore` for
  `web/`+docs), Dependabot (`cargo` + `github-actions` weekly; npm deferred with a
  note until `web/` lands, per ADR 0006), issue templates, and a PR template that
  encodes the title + Release-Notes rules.
- **Community files**: `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md` (Contributor
  Covenant v2.1), `SECURITY.md`, `CHANGELOG.md` (Keep a Changelog).
- **`LICENSE`**: normalize the copyright line to match the `authors` metadata.
- **`README.md`**: add a CI status badge.
- **Quality gate fixes**: resolve 4 pre-existing `cargo fmt` violations and the
  `clippy` warnings in `src/services/` (unused import, `sort_by_key`, `flatten`,
  auto-deref, `io::Error::other`, `is_some_and`, a `Default` impl) — all
  behavior-preserving — so CI is genuinely green.

## Verification

- `cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`,
  `cargo build --locked`, `cargo test --locked` all pass.
- `cargo publish --dry-run --package nohrs` succeeds with no metadata errors.
- All `.github` YAML files parse cleanly.

No user-visible/UI change, so no screenshots.

## Suggested .rules additions

None.

Release Notes:

- N/A

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the OSS hygiene baseline: adds CI, community docs, and crate metadata so the repo is ready for public contributions and `cargo publish` works. Hardens CI by pinning actions to SHAs and disabling checkout credentials; fixes formatting and lint warnings so CI is green. Closes #47.

- New Features
  - GitHub Actions CI: `rustfmt`/`clippy`/build/test on Linux; `gui` feature excluded; ignores `web/**`, `docs/**`, and `**.md`; actions pinned to SHAs and `persist-credentials: false`.
  - Dependabot weekly for `cargo` and `github-actions`.
  - Issue/PR templates plus `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, `CHANGELOG.md` (adds a language tag to the release-notes code fence).
  - Package metadata in `Cargo.toml` (description, authors, license `MIT`, readme, repository, homepage, keywords, categories, `rust-version = "1.83"`).
  - Track `.github/`, add CI badge to `README.md`, and align `LICENSE` copyright.

- Refactors
  - Fixed pre-existing `cargo fmt` and `clippy -D warnings` across services/UI (behavior unchanged).

<sup>Written for commit debac1091a2bf6bad34d13bf10105a27e209cdea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/noh-rs/nohrs/pull/116?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added CI workflow, PR template, issue templates (bug report & feature request), Dependabot config, changelog, README badge, and security/contributing/code-of-conduct documents.
  * Updated project metadata and license holder.

* **Refactor**
  * Small internal code cleanup and API-safe adjustments for consistency.

* **Style**
  * Formatting and minor readability tweaks across the codebase.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/noh-rs/nohrs/pull/116?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->