### PR TITLE
Add branch naming and PR workflow rules

### DIFF
--- a/.rules
+++ b/.rules
@@ -139,6 +139,8 @@ Other entities can then register a callback to handle these events by doing `cx.
 
 # Pull request hygiene
 
+When work is complete, use the pull-request skill (`/pull-request`) to open the PR.
+
 When an agent opens or updates a pull request, it must:
 
 - Use a clear, correctly capitalized, imperative PR title (for example, `Fix crash in project panel`).
@@ -156,6 +158,9 @@ Release Notes:
 
 - N/A
 ```
+
+- Name branches `<type>/<short-description>` where `<type>` is one of `feature`, `fix`, `docs`, or `chore` (for example, `feature/history-view`, `fix/search-crash`).
+- Delete the branch as soon as its pull request merges (enable GitHub's auto-delete-on-merge, or delete it right after merging) so stale branches do not accumulate.
 
 # Crash Investigation
 


### PR DESCRIPTION
Add three conventions to `.rules` under Pull request hygiene:

- Use the pull-request skill (`/pull-request`) to open a PR when work is complete.
- Name branches `<type>/<short-description>` (type: `feature`/`fix`/`docs`/`chore`).
- Delete a branch as soon as its PR merges so stale branches do not accumulate.

## Verification

N/A — documentation-only change to `.rules`.

Release Notes:

- N/A

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated `.rules` with PR workflow conventions: use `/pull-request` to open PRs, name branches `<type>/<short-description>`, and delete branches after merge. This standardizes PRs and prevents stale branches.

<sup>Written for commit 6019314d8f5e148fd9b83f2ad477ff65617a4727. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/noh-rs/nohrs/pull/129?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor guidelines to include pull request workflow best practices and branch naming conventions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/noh-rs/nohrs/pull/129?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->