### PR TITLE
Add minimal XDG config.toml with hot reload and config CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,6 +76,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -886,6 +936,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "cocoa"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -961,6 +1051,12 @@ name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "command-fds"
@@ -3124,6 +3220,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3727,6 +3829,7 @@ dependencies = [
 name = "nohrs"
 version = "0.2.0"
 dependencies = [
+ "clap",
  "gpui",
  "gpui-component",
  "nohrs-core",
@@ -3742,8 +3845,15 @@ dependencies = [
 name = "nohrs-core"
 version = "0.2.0"
 dependencies = [
+ "dirs 5.0.1",
+ "notify 6.1.1",
+ "schemars",
+ "serde",
+ "serde_json",
+ "tempfile",
  "thiserror 1.0.69",
  "time",
+ "toml 0.8.23",
  "tracing",
  "tracing-subscriber",
 ]
@@ -4179,6 +4289,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oneshot"
@@ -5802,6 +5918,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6904,6 +7026,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/crates/nohrs-core/Cargo.toml
+++ b/crates/nohrs-core/Cargo.toml
@@ -18,6 +18,15 @@ thiserror.workspace          = true
 tracing.workspace            = true
 tracing-subscriber.workspace = true
 time.workspace               = true
+serde.workspace              = true
+serde_json.workspace         = true
+toml                         = "0.8"
+schemars                     = "1"
+notify                       = "6"
+dirs                         = "5"
+
+[dev-dependencies]
+tempfile = "3"
 
 [lints]
 workspace = true

--- a/crates/nohrs-core/src/config.rs
+++ b/crates/nohrs-core/src/config.rs
@@ -1,10 +1,27 @@
-//! Centralized configuration constants shared across the application.
+//! Centralized configuration shared across the application.
 //!
-//! Values live here (rather than inline literals) so behaviour can be tuned in
-//! one place and so the upcoming `nohrs-core` extraction (#48) has a single home
-//! for tunables.
+//! Two distinct things live under `config`:
+//!
+//! * The compile-time UI layout constants below (window/table sizing), kept
+//!   here so behaviour can be tuned in one place.
+//! * The user-facing `config.toml` system in the [`settings`], [`paths`],
+//!   [`loader`], and [`watcher`] submodules: schema, XDG paths, the
+//!   4-layer override merge, lenient validation, hot-reload watching, and the
+//!   on-disk lifecycle (see `docs/config.md`).
 
 use std::time::Duration;
+
+pub mod loader;
+pub mod paths;
+pub mod settings;
+pub mod watcher;
+
+pub use loader::{backup, ensure_exists, needs_migration, reset, write_default};
+pub use settings::{
+    json_schema_string, load_from_path, report_diagnostics, Config, ConfigOverride, Diagnostic,
+    DiagnosticLevel, SortOrder, Theme, ThemeMode, Ui, CURRENT_SCHEMA_VERSION, SCHEMA_URL,
+};
+pub use watcher::ConfigWatcher;
 
 /// Default window dimensions on first launch (logical pixels).
 pub const WINDOW_WIDTH: f32 = 1280.0;

--- a/crates/nohrs-core/src/config/loader.rs
+++ b/crates/nohrs-core/src/config/loader.rs
@@ -1,0 +1,128 @@
+//! On-disk lifecycle for `config.toml`: writing the default file, backing up an
+//! existing one before overwriting, resetting, and the (P1-minimal) migration
+//! scaffold.
+//!
+//! Migration support is intentionally a skeleton: only `schema_version = 1`
+//! exists today, so [`needs_migration`] is always `false`. The
+//! peek-version → backup → overwrite shape is in place so future bumps slot in
+//! without reworking callers (config.md §7).
+
+use super::settings::{Config, CURRENT_SCHEMA_VERSION};
+use std::io;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Ensure the parent directory of `path` exists.
+fn ensure_parent_dir(path: &Path) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    Ok(())
+}
+
+/// Write the default `config.toml` (with `#:schema` header) to `path`, creating
+/// parent directories as needed. Overwrites any existing file — callers that
+/// must preserve the old contents should [`backup`] first.
+pub fn write_default(path: &Path) -> io::Result<()> {
+    ensure_parent_dir(path)?;
+    std::fs::write(path, Config::default_toml_template())
+}
+
+/// Create the config file with defaults only if it does not already exist.
+/// Returns `true` if a new file was written.
+pub fn ensure_exists(path: &Path) -> io::Result<bool> {
+    if path.exists() {
+        return Ok(false);
+    }
+    write_default(path)?;
+    Ok(true)
+}
+
+/// Copy `path` to a timestamped sibling `config.toml.bak-<unix-seconds>` so a
+/// destructive operation is recoverable. Returns the backup path, or `None` if
+/// the source does not exist.
+pub fn backup(path: &Path) -> io::Result<Option<PathBuf>> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let seconds = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or(0);
+    let file_name = path
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "config.toml".to_string());
+    let backup_path = path.with_file_name(format!("{file_name}.bak-{seconds}"));
+    std::fs::copy(path, &backup_path)?;
+    Ok(Some(backup_path))
+}
+
+/// Reset configuration to defaults, backing up any existing file first. Returns
+/// the backup path (if one was made).
+pub fn reset(path: &Path) -> io::Result<Option<PathBuf>> {
+    let backup_path = backup(path)?;
+    write_default(path)?;
+    Ok(backup_path)
+}
+
+/// Whether a file declaring `version` requires migration before this build can
+/// use it. P1 only knows v1, so this is always `false`; kept as the hook for
+/// future schema bumps.
+pub fn needs_migration(version: u64) -> bool {
+    version < CURRENT_SCHEMA_VERSION
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn write_default_creates_parent_dirs() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("nested/config.toml");
+        write_default(&path).unwrap();
+        assert!(path.exists());
+        let contents = std::fs::read_to_string(&path).unwrap();
+        assert!(contents.starts_with("#:schema"));
+    }
+
+    #[test]
+    fn ensure_exists_is_idempotent() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        assert!(ensure_exists(&path).unwrap());
+        std::fs::write(&path, "schema_version = 1\n").unwrap();
+        // Second call must not overwrite the user's edits.
+        assert!(!ensure_exists(&path).unwrap());
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            "schema_version = 1\n"
+        );
+    }
+
+    #[test]
+    fn reset_backs_up_then_restores_defaults() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, "schema_version = 1\nmangled").unwrap();
+        let backup_path = reset(&path).unwrap().unwrap();
+        assert!(backup_path.exists());
+        assert_eq!(
+            std::fs::read_to_string(&backup_path).unwrap(),
+            "schema_version = 1\nmangled"
+        );
+        assert!(std::fs::read_to_string(&path)
+            .unwrap()
+            .starts_with("#:schema"));
+    }
+
+    #[test]
+    fn backup_of_missing_file_is_none() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        assert!(backup(&path).unwrap().is_none());
+    }
+}

--- a/crates/nohrs-core/src/config/paths.rs
+++ b/crates/nohrs-core/src/config/paths.rs
@@ -1,0 +1,87 @@
+//! XDG-style path resolution for nohrs data locations.
+//!
+//! Per `docs/config.md` §1 we resolve `$XDG_CONFIG_HOME` / `$XDG_DATA_HOME` /
+//! `$XDG_CACHE_HOME` directly, falling back to `~/.config`, `~/.local/share`,
+//! and `~/.cache`. We deliberately do **not** use `dirs::config_dir()` and
+//! friends: on macOS those return OS-native paths (`~/Library/...`) which
+//! conflict with the dotfile layout nohrs uses on every platform. `dirs` is
+//! used only to locate the home directory for the fallback.
+
+use std::path::PathBuf;
+
+/// Application directory name used under each XDG base directory.
+const APP_DIR: &str = "nohrs";
+
+/// Resolve an XDG base directory: use the environment variable if it is set to
+/// an absolute path (relative values are ignored per the XDG spec), otherwise
+/// fall back to `~/<default_subdir>`. Falls back to the current directory if the
+/// home directory cannot be determined, so callers always get a usable path.
+fn xdg_base(env_var: &str, default_subdir: &str) -> PathBuf {
+    if let Some(value) = std::env::var_os(env_var) {
+        let path = PathBuf::from(value);
+        if path.is_absolute() {
+            return path;
+        }
+    }
+    match dirs::home_dir() {
+        Some(home) => home.join(default_subdir),
+        None => PathBuf::from(default_subdir),
+    }
+}
+
+/// `$XDG_CONFIG_HOME` or `~/.config`.
+pub fn config_home() -> PathBuf {
+    xdg_base("XDG_CONFIG_HOME", ".config")
+}
+
+/// `$XDG_DATA_HOME` or `~/.local/share`.
+pub fn data_home() -> PathBuf {
+    xdg_base("XDG_DATA_HOME", ".local/share")
+}
+
+/// `$XDG_CACHE_HOME` or `~/.cache`.
+pub fn cache_home() -> PathBuf {
+    xdg_base("XDG_CACHE_HOME", ".cache")
+}
+
+/// The nohrs config directory (`.../nohrs`).
+pub fn config_dir() -> PathBuf {
+    config_home().join(APP_DIR)
+}
+
+/// The nohrs data directory (`.../nohrs`).
+pub fn data_dir() -> PathBuf {
+    data_home().join(APP_DIR)
+}
+
+/// The nohrs cache directory (`.../nohrs`).
+pub fn cache_dir() -> PathBuf {
+    cache_home().join(APP_DIR)
+}
+
+/// Full path to `config.toml`.
+pub fn config_file() -> PathBuf {
+    config_dir().join("config.toml")
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_file_lives_under_config_home() {
+        let file = config_file();
+        assert!(file.ends_with("nohrs/config.toml"));
+    }
+
+    #[test]
+    fn absolute_xdg_var_is_honoured() {
+        // Guard against other tests mutating the same process env concurrently
+        // by setting and reading within the same call sequence.
+        std::env::set_var("XDG_CONFIG_HOME", "/tmp/xdg-test-abs");
+        let dir = config_dir();
+        std::env::remove_var("XDG_CONFIG_HOME");
+        assert_eq!(dir, PathBuf::from("/tmp/xdg-test-abs/nohrs"));
+    }
+}

--- a/crates/nohrs-core/src/config/settings.rs
+++ b/crates/nohrs-core/src/config/settings.rs
@@ -418,31 +418,49 @@ fn warn_unknown_keys(
 /// Generate the JSON Schema for [`Config`] as pretty JSON. Backs both
 /// `nohrs config schema` and the committed `docs/config.schema.json`.
 ///
-/// Object keys are sorted so the output is byte-for-byte stable regardless of
-/// whether `serde_json`'s `preserve_order` feature happens to be enabled in the
-/// build (it is in the GUI binary but not in a `nohrs-core`-only build, via
-/// Cargo feature unification). Without this the committed file and
-/// `nohrs config schema` would disagree on key order. Array element order
-/// (enum variants, `required`) is left untouched.
+/// The schema is normalized so the output is portable and byte-for-byte stable:
+///
+/// * Object keys are sorted, so the result does not depend on whether
+///   `serde_json`'s `preserve_order` feature is enabled (it is in the GUI binary
+///   but not in a `nohrs-core`-only build, via Cargo feature unification);
+///   otherwise the committed file and `nohrs config schema` would disagree.
+/// * Schemars' Rust-specific integer `format`s (e.g. `uint64`) are dropped:
+///   they are not standard JSON Schema draft 2020-12 formats, and `type` +
+///   `minimum` already capture the constraint. Standard string formats are kept.
+///
+/// Array element order (enum variants, `required`) is left untouched.
 pub fn json_schema_string() -> serde_json::Result<String> {
     let schema = schemars::schema_for!(Config);
     let value = serde_json::to_value(&schema)?;
-    serde_json::to_string_pretty(&sort_json_keys(value))
+    serde_json::to_string_pretty(&normalize_schema(value))
 }
 
-fn sort_json_keys(value: serde_json::Value) -> serde_json::Value {
+/// Rust integer `format` values schemars emits that are not standard JSON Schema.
+const RUST_INT_FORMATS: &[&str] = &[
+    "uint", "uint8", "uint16", "uint32", "uint64", "uint128", "int", "int8", "int16", "int32",
+    "int64", "int128",
+];
+
+fn normalize_schema(value: serde_json::Value) -> serde_json::Value {
     match value {
         serde_json::Value::Object(map) => {
             let mut entries: Vec<_> = map.into_iter().collect();
             entries.sort_by(|(left, _), (right, _)| left.cmp(right));
-            let mut sorted = serde_json::Map::new();
+            let mut normalized = serde_json::Map::new();
             for (key, child) in entries {
-                sorted.insert(key, sort_json_keys(child));
+                if key == "format"
+                    && child
+                        .as_str()
+                        .is_some_and(|format| RUST_INT_FORMATS.contains(&format))
+                {
+                    continue;
+                }
+                normalized.insert(key, normalize_schema(child));
             }
-            serde_json::Value::Object(sorted)
+            serde_json::Value::Object(normalized)
         }
         serde_json::Value::Array(items) => {
-            serde_json::Value::Array(items.into_iter().map(sort_json_keys).collect())
+            serde_json::Value::Array(items.into_iter().map(normalize_schema).collect())
         }
         other => other,
     }

--- a/crates/nohrs-core/src/config/settings.rs
+++ b/crates/nohrs-core/src/config/settings.rs
@@ -1,0 +1,642 @@
+//! User configuration: the P1 minimal `config.toml` schema, its 4-layer
+//! override/merge strategy, lenient validation, JSON Schema generation, and the
+//! on-disk template.
+//!
+//! Parsing is deliberately forward-compatible: unknown keys and out-of-range
+//! values are downgraded to warnings rather than hard errors so a single typo
+//! never prevents the app from starting. The only fatal case is TOML that does
+//! not parse at all, which the caller surfaces in the UI status bar while
+//! falling back to [`Config::default`].
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+/// Schema version understood by this build. Bumped only when the on-disk
+/// schema changes in a way that requires migration.
+pub const CURRENT_SCHEMA_VERSION: u64 = 1;
+
+/// URL advertised in the `#:schema` header of `config.toml` so TOML-aware
+/// editors can offer completion and validation.
+pub const SCHEMA_URL: &str = "https://nohrs.app/schema/config.schema.json";
+
+/// The fully merged, validated configuration.
+///
+/// Only the P1 surface (`theme` / `ui`) is modelled here. `[keybindings]` and
+/// `[plugins]` are recognised as reserved sections (see [`is_reserved_section`])
+/// but intentionally not deserialized yet, so their future shapes can be added
+/// without breaking older files.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct Config {
+    /// On-disk schema version. Must be [`CURRENT_SCHEMA_VERSION`] for this build.
+    pub schema_version: u64,
+    pub theme: Theme,
+    pub ui: Ui,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            schema_version: CURRENT_SCHEMA_VERSION,
+            theme: Theme::default(),
+            ui: Ui::default(),
+        }
+    }
+}
+
+/// Appearance settings.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct Theme {
+    /// Light/dark selection, or following the OS.
+    pub mode: ThemeMode,
+    /// Accent colour, given as a named colour or a hex string. Full
+    /// customization lands in P5; P1 stores the value and applies the mode.
+    pub accent: String,
+}
+
+impl Default for Theme {
+    fn default() -> Self {
+        Self {
+            mode: ThemeMode::System,
+            accent: "blue".to_string(),
+        }
+    }
+}
+
+/// Explorer / view settings.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct Ui {
+    /// Column the listing is sorted by on load.
+    pub default_sort: SortOrder,
+    /// Whether dotfiles are shown in listings.
+    pub show_hidden: bool,
+    /// Identifier of the icon pack used to render entries.
+    pub icon_pack: String,
+}
+
+impl Default for Ui {
+    fn default() -> Self {
+        Self {
+            default_sort: SortOrder::Name,
+            show_hidden: false,
+            icon_pack: "default".to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum ThemeMode {
+    #[default]
+    System,
+    Light,
+    Dark,
+}
+
+impl ThemeMode {
+    /// Parse the `config.toml` / CLI / env spelling (`system`/`light`/`dark`).
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "system" => Some(Self::System),
+            "light" => Some(Self::Light),
+            "dark" => Some(Self::Dark),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum SortOrder {
+    #[default]
+    Name,
+    Modified,
+    Size,
+    Kind,
+}
+
+impl SortOrder {
+    /// Parse the `config.toml` / CLI / env spelling
+    /// (`name`/`modified`/`size`/`kind`).
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "name" => Some(Self::Name),
+            "modified" => Some(Self::Modified),
+            "size" => Some(Self::Size),
+            "kind" => Some(Self::Kind),
+            _ => None,
+        }
+    }
+}
+
+/// Severity of a configuration [`Diagnostic`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiagnosticLevel {
+    /// Recoverable: a value was ignored and a default used. The app keeps running.
+    Warning,
+    /// Fatal for the file: it could not be parsed (or targets an unknown schema
+    /// version), so defaults are used. Surfaced in the UI status bar.
+    Error,
+}
+
+/// A single message produced while loading configuration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Diagnostic {
+    pub level: DiagnosticLevel,
+    pub message: String,
+}
+
+impl Diagnostic {
+    fn warn(message: impl Into<String>) -> Self {
+        Self {
+            level: DiagnosticLevel::Warning,
+            message: message.into(),
+        }
+    }
+
+    fn error(message: impl Into<String>) -> Self {
+        Self {
+            level: DiagnosticLevel::Error,
+            message: message.into(),
+        }
+    }
+}
+
+/// A sparse set of overrides applied on top of a loaded [`Config`]. Used for the
+/// environment-variable and CLI-argument layers, where only the keys that were
+/// actually provided should take effect.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ConfigOverride {
+    pub theme_mode: Option<ThemeMode>,
+    pub theme_accent: Option<String>,
+    pub ui_default_sort: Option<SortOrder>,
+    pub ui_show_hidden: Option<bool>,
+    pub ui_icon_pack: Option<String>,
+}
+
+impl ConfigOverride {
+    /// Build the environment-variable layer (`NOHRS_*`). Invalid values are
+    /// logged and skipped rather than aborting startup.
+    pub fn from_env() -> Self {
+        let mut over = ConfigOverride::default();
+
+        if let Ok(value) = std::env::var("NOHRS_THEME") {
+            match ThemeMode::parse(value.trim()) {
+                Some(mode) => over.theme_mode = Some(mode),
+                None => tracing::warn!("ignoring invalid NOHRS_THEME={value:?}"),
+            }
+        }
+        if let Ok(value) = std::env::var("NOHRS_ACCENT") {
+            over.theme_accent = Some(value);
+        }
+        if let Ok(value) = std::env::var("NOHRS_DEFAULT_SORT") {
+            match SortOrder::parse(value.trim()) {
+                Some(sort) => over.ui_default_sort = Some(sort),
+                None => tracing::warn!("ignoring invalid NOHRS_DEFAULT_SORT={value:?}"),
+            }
+        }
+        if let Ok(value) = std::env::var("NOHRS_SHOW_HIDDEN") {
+            match parse_bool(value.trim()) {
+                Some(flag) => over.ui_show_hidden = Some(flag),
+                None => tracing::warn!("ignoring invalid NOHRS_SHOW_HIDDEN={value:?}"),
+            }
+        }
+        if let Ok(value) = std::env::var("NOHRS_ICON_PACK") {
+            over.ui_icon_pack = Some(value);
+        }
+
+        over
+    }
+}
+
+fn parse_bool(value: &str) -> Option<bool> {
+    match value.to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Some(true),
+        "0" | "false" | "no" | "off" => Some(false),
+        _ => None,
+    }
+}
+
+impl Config {
+    /// Apply a sparse override layer in place. Only `Some` fields take effect.
+    pub fn apply_override(&mut self, over: &ConfigOverride) {
+        if let Some(mode) = over.theme_mode {
+            self.theme.mode = mode;
+        }
+        if let Some(accent) = &over.theme_accent {
+            self.theme.accent = accent.clone();
+        }
+        if let Some(sort) = over.ui_default_sort {
+            self.ui.default_sort = sort;
+        }
+        if let Some(show_hidden) = over.ui_show_hidden {
+            self.ui.show_hidden = show_hidden;
+        }
+        if let Some(icon_pack) = &over.ui_icon_pack {
+            self.ui.icon_pack = icon_pack.clone();
+        }
+    }
+
+    /// Parse `config.toml` contents into a [`Config`], collecting non-fatal
+    /// problems as warnings. A TOML syntax error or an unknown `schema_version`
+    /// yields [`Config::default`] plus an error diagnostic.
+    ///
+    /// This walks the parsed [`toml::Table`] field by field rather than using a
+    /// strict `Deserialize`, so a single bad value (e.g. `mode = "neon"`) only
+    /// resets that field instead of discarding the whole file.
+    pub fn from_toml_str(contents: &str) -> (Config, Vec<Diagnostic>) {
+        let table: toml::Table = match contents.parse() {
+            Ok(table) => table,
+            Err(error) => {
+                return (
+                    Config::default(),
+                    vec![Diagnostic::error(format!(
+                        "failed to parse config.toml: {error}"
+                    ))],
+                );
+            }
+        };
+        Config::from_table(&table)
+    }
+
+    fn from_table(table: &toml::Table) -> (Config, Vec<Diagnostic>) {
+        let mut config = Config::default();
+        let mut diagnostics = Vec::new();
+
+        // Reject configs from a future schema before reading anything else, so
+        // we never half-apply a layout this build does not understand.
+        if let Some(value) = table.get("schema_version") {
+            match value.as_integer() {
+                Some(version) if version as u64 == CURRENT_SCHEMA_VERSION => {}
+                _ => {
+                    diagnostics.push(Diagnostic::error(format!(
+                        "config.toml targets schema_version {value}, but this nohrs build \
+                         supports {CURRENT_SCHEMA_VERSION}; a newer version may be required. \
+                         Using defaults."
+                    )));
+                    return (Config::default(), diagnostics);
+                }
+            }
+        }
+
+        if let Some(theme) = table.get("theme") {
+            match theme.as_table() {
+                Some(theme) => read_theme(theme, &mut config.theme, &mut diagnostics),
+                None => diagnostics.push(Diagnostic::warn("[theme] is not a table; ignoring")),
+            }
+        }
+        if let Some(ui) = table.get("ui") {
+            match ui.as_table() {
+                Some(ui) => read_ui(ui, &mut config.ui, &mut diagnostics),
+                None => diagnostics.push(Diagnostic::warn("[ui] is not a table; ignoring")),
+            }
+        }
+
+        warn_unknown_keys(
+            table,
+            &["schema_version", "theme", "ui", "keybindings", "plugins"],
+            "",
+            &mut diagnostics,
+        );
+
+        (config, diagnostics)
+    }
+
+    /// Serialize the merged config as pretty JSON (used by `nohrs config show`).
+    pub fn to_json(&self) -> serde_json::Result<String> {
+        serde_json::to_string_pretty(self)
+    }
+
+    /// The default `config.toml` written on first run or `reset`, including the
+    /// `#:schema` header and empty reserved sections.
+    pub fn default_toml_template() -> String {
+        format!(
+            "#:schema {SCHEMA_URL}\n\
+             schema_version = {CURRENT_SCHEMA_VERSION}\n\
+             \n\
+             [theme]\n\
+             mode = \"system\"   # \"system\" | \"light\" | \"dark\"\n\
+             accent = \"blue\"   # named colour or hex (full customization in P5)\n\
+             \n\
+             [ui]\n\
+             default_sort = \"name\"   # \"name\" | \"modified\" | \"size\" | \"kind\"\n\
+             show_hidden = false\n\
+             icon_pack = \"default\"\n\
+             \n\
+             # Reserved for future use; left empty in P1.\n\
+             [keybindings]\n\
+             \n\
+             [plugins]\n"
+        )
+    }
+}
+
+/// Whether `name` is a reserved top-level section that P1 recognises but does
+/// not yet read (so its presence is not flagged as an unknown key).
+pub fn is_reserved_section(name: &str) -> bool {
+    matches!(name, "keybindings" | "plugins")
+}
+
+fn read_theme(table: &toml::Table, theme: &mut Theme, diagnostics: &mut Vec<Diagnostic>) {
+    if let Some(value) = table.get("mode") {
+        match value.as_str().and_then(ThemeMode::parse) {
+            Some(mode) => theme.mode = mode,
+            None => diagnostics.push(Diagnostic::warn(format!(
+                "invalid theme.mode {value}; using {:?}",
+                theme.mode
+            ))),
+        }
+    }
+    if let Some(value) = table.get("accent") {
+        match value.as_str() {
+            Some(accent) if !accent.trim().is_empty() => theme.accent = accent.to_string(),
+            _ => diagnostics.push(Diagnostic::warn(format!(
+                "invalid theme.accent {value}; using {:?}",
+                theme.accent
+            ))),
+        }
+    }
+    warn_unknown_keys(table, &["mode", "accent"], "theme.", diagnostics);
+}
+
+fn read_ui(table: &toml::Table, ui: &mut Ui, diagnostics: &mut Vec<Diagnostic>) {
+    if let Some(value) = table.get("default_sort") {
+        match value.as_str().and_then(SortOrder::parse) {
+            Some(sort) => ui.default_sort = sort,
+            None => diagnostics.push(Diagnostic::warn(format!(
+                "invalid ui.default_sort {value}; using {:?}",
+                ui.default_sort
+            ))),
+        }
+    }
+    if let Some(value) = table.get("show_hidden") {
+        match value.as_bool() {
+            Some(flag) => ui.show_hidden = flag,
+            None => diagnostics.push(Diagnostic::warn(format!(
+                "invalid ui.show_hidden {value}; using {}",
+                ui.show_hidden
+            ))),
+        }
+    }
+    if let Some(value) = table.get("icon_pack") {
+        match value.as_str() {
+            Some(pack) if !pack.trim().is_empty() => ui.icon_pack = pack.to_string(),
+            _ => diagnostics.push(Diagnostic::warn(format!(
+                "invalid ui.icon_pack {value}; using {:?}",
+                ui.icon_pack
+            ))),
+        }
+    }
+    warn_unknown_keys(
+        table,
+        &["default_sort", "show_hidden", "icon_pack"],
+        "ui.",
+        diagnostics,
+    );
+}
+
+/// Emit a warning for every key in `table` that is neither a known key nor a
+/// reserved top-level section. `prefix` is prepended for nested tables (e.g.
+/// `"theme."`) so messages point at the offending path.
+fn warn_unknown_keys(
+    table: &toml::Table,
+    known: &[&str],
+    prefix: &str,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    for key in table.keys() {
+        let is_known = known.contains(&key.as_str());
+        let is_reserved = prefix.is_empty() && is_reserved_section(key);
+        if !is_known && !is_reserved {
+            diagnostics.push(Diagnostic::warn(format!(
+                "unknown config key {prefix}{key}; ignoring"
+            )));
+        }
+    }
+}
+
+/// Generate the JSON Schema for [`Config`] as pretty JSON. Backs both
+/// `nohrs config schema` and the committed `docs/config.schema.json`.
+///
+/// Object keys are sorted so the output is byte-for-byte stable regardless of
+/// whether `serde_json`'s `preserve_order` feature happens to be enabled in the
+/// build (it is in the GUI binary but not in a `nohrs-core`-only build, via
+/// Cargo feature unification). Without this the committed file and
+/// `nohrs config schema` would disagree on key order. Array element order
+/// (enum variants, `required`) is left untouched.
+pub fn json_schema_string() -> serde_json::Result<String> {
+    let schema = schemars::schema_for!(Config);
+    let value = serde_json::to_value(&schema)?;
+    serde_json::to_string_pretty(&sort_json_keys(value))
+}
+
+fn sort_json_keys(value: serde_json::Value) -> serde_json::Value {
+    match value {
+        serde_json::Value::Object(map) => {
+            let mut entries: Vec<_> = map.into_iter().collect();
+            entries.sort_by(|(left, _), (right, _)| left.cmp(right));
+            let mut sorted = serde_json::Map::new();
+            for (key, child) in entries {
+                sorted.insert(key, sort_json_keys(child));
+            }
+            serde_json::Value::Object(sorted)
+        }
+        serde_json::Value::Array(items) => {
+            serde_json::Value::Array(items.into_iter().map(sort_json_keys).collect())
+        }
+        other => other,
+    }
+}
+
+/// Read `path` and parse it, returning [`Config::default`] with no diagnostics
+/// when the file does not exist (a missing config is normal, not an error).
+pub fn load_from_path(path: &Path) -> (Config, Vec<Diagnostic>) {
+    match std::fs::read_to_string(path) {
+        Ok(contents) => Config::from_toml_str(&contents),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            (Config::default(), Vec::new())
+        }
+        Err(error) => (
+            Config::default(),
+            vec![Diagnostic::error(format!(
+                "could not read {}: {error}",
+                path.display()
+            ))],
+        ),
+    }
+}
+
+/// Log all diagnostics and return the first error message (if any) so the caller
+/// can surface it in the UI. Warnings are logged but never returned.
+pub fn report_diagnostics(diagnostics: &[Diagnostic]) -> Option<String> {
+    let mut first_error = None;
+    for diagnostic in diagnostics {
+        match diagnostic.level {
+            DiagnosticLevel::Warning => tracing::warn!("config: {}", diagnostic.message),
+            DiagnosticLevel::Error => {
+                tracing::error!("config: {}", diagnostic.message);
+                if first_error.is_none() {
+                    first_error = Some(diagnostic.message.clone());
+                }
+            }
+        }
+    }
+    first_error
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn errors(diagnostics: &[Diagnostic]) -> Vec<&str> {
+        diagnostics
+            .iter()
+            .filter(|d| d.level == DiagnosticLevel::Error)
+            .map(|d| d.message.as_str())
+            .collect()
+    }
+
+    #[test]
+    fn defaults_match_spec() {
+        let config = Config::default();
+        assert_eq!(config.schema_version, 1);
+        assert_eq!(config.theme.mode, ThemeMode::System);
+        assert_eq!(config.theme.accent, "blue");
+        assert_eq!(config.ui.default_sort, SortOrder::Name);
+        assert!(!config.ui.show_hidden);
+        assert_eq!(config.ui.icon_pack, "default");
+    }
+
+    #[test]
+    fn parses_full_config() {
+        let toml = r##"
+            schema_version = 1
+            [theme]
+            mode = "dark"
+            accent = "#ff8800"
+            [ui]
+            default_sort = "modified"
+            show_hidden = true
+            icon_pack = "nerd"
+        "##;
+        let (config, diagnostics) = Config::from_toml_str(toml);
+        assert!(diagnostics.is_empty(), "{diagnostics:?}");
+        assert_eq!(config.theme.mode, ThemeMode::Dark);
+        assert_eq!(config.theme.accent, "#ff8800");
+        assert_eq!(config.ui.default_sort, SortOrder::Modified);
+        assert!(config.ui.show_hidden);
+        assert_eq!(config.ui.icon_pack, "nerd");
+    }
+
+    #[test]
+    fn syntax_error_falls_back_without_panicking() {
+        let (config, diagnostics) = Config::from_toml_str("this = = broken");
+        assert_eq!(config, Config::default());
+        assert_eq!(errors(&diagnostics).len(), 1);
+    }
+
+    #[test]
+    fn out_of_range_value_warns_and_keeps_default() {
+        let toml = r#"
+            [theme]
+            mode = "neon"
+            [ui]
+            default_sort = 42
+            show_hidden = "yes"
+        "#;
+        let (config, diagnostics) = Config::from_toml_str(toml);
+        // No errors: the file still loads.
+        assert!(errors(&diagnostics).is_empty());
+        // Bad fields fall back to defaults; others are untouched.
+        assert_eq!(config.theme.mode, ThemeMode::System);
+        assert_eq!(config.ui.default_sort, SortOrder::Name);
+        assert!(!config.ui.show_hidden);
+        // Three warnings: mode, default_sort, show_hidden.
+        assert_eq!(diagnostics.len(), 3);
+    }
+
+    #[test]
+    fn unknown_keys_warn_but_load() {
+        let toml = r#"
+            mystery = 1
+            [theme]
+            mode = "light"
+            shade = "x"
+            [keybindings]
+            quit = "ctrl-q"
+        "#;
+        let (config, diagnostics) = Config::from_toml_str(toml);
+        assert!(errors(&diagnostics).is_empty());
+        assert_eq!(config.theme.mode, ThemeMode::Light);
+        // `mystery` and `theme.shade` warn; `[keybindings]` is reserved and silent.
+        let warnings: Vec<_> = diagnostics.iter().map(|d| d.message.as_str()).collect();
+        assert!(warnings.iter().any(|m| m.contains("mystery")));
+        assert!(warnings.iter().any(|m| m.contains("theme.shade")));
+        assert!(!warnings.iter().any(|m| m.contains("keybindings")));
+    }
+
+    #[test]
+    fn future_schema_version_falls_back() {
+        let (config, diagnostics) = Config::from_toml_str("schema_version = 99");
+        assert_eq!(config, Config::default());
+        assert_eq!(errors(&diagnostics).len(), 1);
+        assert!(errors(&diagnostics)[0].contains("newer version"));
+    }
+
+    #[test]
+    fn env_layer_overrides_file() {
+        let (mut config, _) = Config::from_toml_str("[theme]\nmode = \"light\"");
+        config.apply_override(&ConfigOverride {
+            theme_mode: Some(ThemeMode::Dark),
+            ..Default::default()
+        });
+        assert_eq!(config.theme.mode, ThemeMode::Dark);
+    }
+
+    #[test]
+    fn override_is_sparse() {
+        let mut config = Config::default();
+        config.theme.accent = "green".into();
+        config.apply_override(&ConfigOverride {
+            ui_show_hidden: Some(true),
+            ..Default::default()
+        });
+        // Only the provided field changes.
+        assert!(config.ui.show_hidden);
+        assert_eq!(config.theme.accent, "green");
+    }
+
+    #[test]
+    fn parse_bool_accepts_common_spellings() {
+        assert_eq!(parse_bool("TRUE"), Some(true));
+        assert_eq!(parse_bool("off"), Some(false));
+        assert_eq!(parse_bool("maybe"), None);
+    }
+
+    #[test]
+    fn default_template_round_trips() {
+        let (config, diagnostics) = Config::from_toml_str(&Config::default_toml_template());
+        assert!(diagnostics.is_empty(), "{diagnostics:?}");
+        assert_eq!(config, Config::default());
+    }
+
+    #[test]
+    fn json_schema_is_generatable() {
+        let schema = json_schema_string().unwrap();
+        assert!(schema.contains("schema_version"));
+        assert!(schema.contains("default_sort"));
+    }
+
+    #[test]
+    fn committed_schema_is_up_to_date() {
+        let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../../docs/config.schema.json");
+        let committed = std::fs::read_to_string(path).unwrap();
+        let generated = json_schema_string().unwrap();
+        assert_eq!(
+            committed.trim_end(),
+            generated.trim_end(),
+            "docs/config.schema.json is stale; regenerate with `nohrs config schema > docs/config.schema.json`"
+        );
+    }
+}

--- a/crates/nohrs-core/src/config/watcher.rs
+++ b/crates/nohrs-core/src/config/watcher.rs
@@ -1,0 +1,50 @@
+//! Minimal `config.toml` file watcher used for hot reload (config.md §5).
+//!
+//! Editors commonly save by writing a temporary file and renaming it over the
+//! target, which means watching the file inode directly misses updates. We
+//! therefore watch the containing directory and filter events down to the
+//! config file. The watcher runs on a background thread owned by `notify`; the
+//! supplied callback is invoked there, so callers must marshal back onto their
+//! own thread (e.g. the GPUI foreground) before touching UI state.
+
+use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use std::path::{Path, PathBuf};
+
+/// Owns the underlying OS watch. Dropping it stops watching.
+pub struct ConfigWatcher {
+    _watcher: RecommendedWatcher,
+}
+
+impl ConfigWatcher {
+    /// Watch `config_file` for create/modify/remove/rename events, invoking
+    /// `on_change` for each relevant event. The parent directory is watched
+    /// non-recursively so atomic-rename saves are detected.
+    pub fn new(config_file: &Path, on_change: impl Fn() + Send + 'static) -> notify::Result<Self> {
+        let target: PathBuf = config_file.to_path_buf();
+        let watch_dir = target
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| PathBuf::from("."));
+
+        let mut watcher =
+            notify::recommended_watcher(move |result: notify::Result<Event>| match result {
+                Ok(event) => {
+                    if is_relevant(&event) && event.paths.iter().any(|path| path == &target) {
+                        on_change();
+                    }
+                }
+                Err(error) => tracing::warn!("config watcher error: {error}"),
+            })?;
+
+        watcher.watch(&watch_dir, RecursiveMode::NonRecursive)?;
+
+        Ok(Self { _watcher: watcher })
+    }
+}
+
+fn is_relevant(event: &Event) -> bool {
+    matches!(
+        event.kind,
+        EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_)
+    )
+}

--- a/crates/nohrs-core/src/telemetry/logging.rs
+++ b/crates/nohrs-core/src/telemetry/logging.rs
@@ -2,5 +2,10 @@ use tracing_subscriber::{fmt, EnvFilter};
 
 pub fn init_logging() {
     let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
-    let _ = fmt().with_env_filter(env_filter).try_init();
+    // Logs go to stderr so machine-readable command output (e.g.
+    // `nohrs config show`/`schema`) stays clean on stdout.
+    let _ = fmt()
+        .with_writer(std::io::stderr)
+        .with_env_filter(env_filter)
+        .try_init();
 }

--- a/crates/nohrs-pages/src/explorer/state.rs
+++ b/crates/nohrs-pages/src/explorer/state.rs
@@ -295,26 +295,6 @@ impl ExplorerPage {
         }
     }
 
-    /// Surface (or clear) a configuration error in the footer status bar. Only a
-    /// previously-set config error is cleared on `None`, so unrelated status
-    /// messages are left intact (config.md §6).
-    pub fn set_config_status(&mut self, error: Option<String>, cx: &mut Context<Self>) {
-        const PREFIX: &str = "config: ";
-        match error {
-            Some(message) => self.set_status(StatusLevel::Error, format!("{PREFIX}{message}")),
-            None => {
-                if self
-                    .status_message
-                    .as_ref()
-                    .is_some_and(|status| status.text.starts_with(PREFIX))
-                {
-                    self.clear_status();
-                }
-            }
-        }
-        cx.notify();
-    }
-
     pub(crate) fn set_sort_key(&mut self, key: SortKey) {
         if self.sort_key == key {
             self.sort_asc = !self.sort_asc;

--- a/crates/nohrs-pages/src/explorer/state.rs
+++ b/crates/nohrs-pages/src/explorer/state.rs
@@ -27,6 +27,10 @@ pub struct ExplorerPage {
     pub loaded: bool,
     pub sort_key: SortKey,
     pub sort_asc: bool,
+    // Whether dotfiles are listed; driven by `ui.show_hidden` (config.md §5).
+    pub show_hidden: bool,
+    // Identifier of the active icon pack; driven by `ui.icon_pack`.
+    pub icon_pack: String,
     pub search_query: String,
     pub search_visible: bool,
     pub search_input: Entity<InputState>,
@@ -98,6 +102,8 @@ impl ExplorerPage {
             loaded: false,
             sort_key: SortKey::Name,
             sort_asc: true,
+            show_hidden: false,
+            icon_pack: "default".to_string(),
             search_query: String::new(),
             search_visible: false,
             search_input,
@@ -242,13 +248,17 @@ impl ExplorerPage {
             return;
         }
 
+        let show_hidden = self.show_hidden;
+        let visible = self
+            .entries
+            .iter()
+            .filter(move |entry| show_hidden || !is_hidden(&entry.name));
+
         if self.search_query.is_empty() {
-            self.filtered_entries = self.entries.clone();
+            self.filtered_entries = visible.cloned().collect();
         } else {
             let query = self.search_query.to_lowercase();
-            self.filtered_entries = self
-                .entries
-                .iter()
+            self.filtered_entries = visible
                 .filter(|e| e.name.to_lowercase().contains(&query))
                 .cloned()
                 .collect();
@@ -256,6 +266,53 @@ impl ExplorerPage {
 
         entries::sort_entries(&mut self.filtered_entries, self.sort_key, self.sort_asc);
         self.update_item_sizes();
+    }
+
+    /// Apply the `[ui]` config section to this open view, re-sorting and
+    /// re-filtering when anything changed. Used both at startup and on hot
+    /// reload (config.md §5). Note: `icon_pack` is stored for the row renderer to
+    /// consult; there is no icon cache to invalidate yet.
+    pub fn apply_config_ui(&mut self, ui: &config::Ui, cx: &mut Context<Self>) {
+        let sort_key = sort_key_from_config(ui.default_sort);
+        let mut changed = false;
+        if self.sort_key != sort_key {
+            self.sort_key = sort_key;
+            self.sort_asc = true;
+            changed = true;
+        }
+        if self.show_hidden != ui.show_hidden {
+            self.show_hidden = ui.show_hidden;
+            changed = true;
+        }
+        if self.icon_pack != ui.icon_pack {
+            self.icon_pack = ui.icon_pack.clone();
+            changed = true;
+        }
+        if changed {
+            entries::sort_entries(&mut self.entries, self.sort_key, self.sort_asc);
+            self.apply_filter();
+            cx.notify();
+        }
+    }
+
+    /// Surface (or clear) a configuration error in the footer status bar. Only a
+    /// previously-set config error is cleared on `None`, so unrelated status
+    /// messages are left intact (config.md §6).
+    pub fn set_config_status(&mut self, error: Option<String>, cx: &mut Context<Self>) {
+        const PREFIX: &str = "config: ";
+        match error {
+            Some(message) => self.set_status(StatusLevel::Error, format!("{PREFIX}{message}")),
+            None => {
+                if self
+                    .status_message
+                    .as_ref()
+                    .is_some_and(|status| status.text.starts_with(PREFIX))
+                {
+                    self.clear_status();
+                }
+            }
+        }
+        cx.notify();
     }
 
     pub(crate) fn set_sort_key(&mut self, key: SortKey) {
@@ -268,4 +325,17 @@ impl ExplorerPage {
         entries::sort_entries(&mut self.entries, self.sort_key, self.sort_asc);
         self.apply_filter();
     }
+}
+
+fn sort_key_from_config(order: config::SortOrder) -> SortKey {
+    match order {
+        config::SortOrder::Name => SortKey::Name,
+        config::SortOrder::Modified => SortKey::Modified,
+        config::SortOrder::Size => SortKey::Size,
+        config::SortOrder::Kind => SortKey::Type,
+    }
+}
+
+fn is_hidden(name: &str) -> bool {
+    name.starts_with('.')
 }

--- a/crates/nohrs-pages/src/root.rs
+++ b/crates/nohrs-pages/src/root.rs
@@ -163,8 +163,21 @@ impl RootView {
                             .timer(Duration::from_millis(400))
                             .await;
                         let mut changed = false;
-                        while receiver.try_recv().is_ok() {
-                            changed = true;
+                        let mut disconnected = false;
+                        loop {
+                            match receiver.try_recv() {
+                                Ok(()) => changed = true,
+                                Err(mpsc::TryRecvError::Empty) => break,
+                                // The watcher was dropped; stop polling rather
+                                // than spinning every 400ms forever.
+                                Err(mpsc::TryRecvError::Disconnected) => {
+                                    disconnected = true;
+                                    break;
+                                }
+                            }
+                        }
+                        if disconnected {
+                            break;
                         }
                         if !changed {
                             continue;

--- a/crates/nohrs-pages/src/root.rs
+++ b/crates/nohrs-pages/src/root.rs
@@ -12,19 +12,23 @@ use crate::{
     extensions::ExtensionsPage, git::GitPage, s3::S3Page, settings::SettingsPage, PageKind,
 };
 use gpui::{
-    div, prelude::*, px, rgb, AnyElement, App, Context, Entity, FocusHandle, Focusable,
-    InteractiveElement, Render, Window,
+    div, prelude::*, px, rgb, AnyElement, App, AsyncWindowContext, Context, Entity, FocusHandle,
+    Focusable, InteractiveElement, Render, WeakEntity, Window,
 };
 use gpui_component::input::InputState;
 use gpui_component::resizable::ResizableState;
-use gpui_component::{Icon, Root};
+use gpui_component::{Icon, Root, Theme, ThemeMode as GpuiThemeMode};
+use nohrs_core::config::{self, Config, ConfigOverride, ConfigWatcher};
 use nohrs_services::search::SearchService;
 use nohrs_ui::components::layout::footer::{footer, FooterProps};
 use nohrs_ui::components::layout::unified_toolbar::{
     unified_toolbar, AccountMenuAction, AccountMenuCommand, UnifiedToolbarProps,
 };
 use nohrs_ui::theme::theme;
+use std::path::PathBuf;
+use std::sync::mpsc;
 use std::sync::Arc;
+use std::time::Duration;
 use tracing::info;
 
 pub struct RootView {
@@ -38,6 +42,14 @@ pub struct RootView {
     settings: Entity<SettingsPage>,
     search_service: Option<Arc<SearchService>>,
     indexing_progress: Option<f32>,
+    // Currently-applied configuration and the inputs needed to recompute it on
+    // hot reload: the file path and the env/CLI override layers that sit above
+    // the file (config.md §3).
+    config: Config,
+    config_path: PathBuf,
+    config_overrides: Vec<ConfigOverride>,
+    // Kept alive for the window's lifetime so the OS watch is not dropped.
+    _config_watcher: Option<ConfigWatcher>,
 }
 
 impl RootView {
@@ -45,9 +57,14 @@ impl RootView {
     /// the indexing-progress poll. `resizable` is created at the application
     /// level and the search service is initialized by the binary (it owns the
     /// async runtime), keeping `nohrs-pages` free of runtime concerns.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         resizable: Entity<ResizableState>,
         search_service: Option<Arc<SearchService>>,
+        config: Config,
+        config_path: PathBuf,
+        config_overrides: Vec<ConfigOverride>,
+        config_error: Option<String>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
@@ -77,9 +94,98 @@ impl RootView {
             settings,
             search_service,
             indexing_progress: Some(1.0), // Start as hidden/done
+            // Start from defaults so the initial `apply_config` below treats the
+            // loaded config as a change and applies theme + ui uniformly.
+            config: Config::default(),
+            config_path,
+            config_overrides,
+            _config_watcher: None,
         };
         view.start_progress_loop(window, cx);
+        view.apply_config(config, config_error, window, cx);
+        view.start_config_watch(window, cx);
         view
+    }
+
+    /// Apply a freshly-merged configuration to the live UI: switch the theme
+    /// mode, propagate `[ui]` settings to the explorer, and surface any load
+    /// error in the status bar. Safe to call repeatedly (hot reload).
+    pub fn apply_config(
+        &mut self,
+        config: Config,
+        config_error: Option<String>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if config.theme.mode != self.config.theme.mode {
+            let mode = match config.theme.mode {
+                config::ThemeMode::Light => GpuiThemeMode::Light,
+                config::ThemeMode::Dark => GpuiThemeMode::Dark,
+                // `system` follows the OS appearance reported by the window.
+                config::ThemeMode::System => GpuiThemeMode::from(window.appearance()),
+            };
+            Theme::change(mode, Some(window), cx);
+        }
+
+        let ui = config.ui.clone();
+        self.explorer.update(cx, |page, cx| {
+            page.apply_config_ui(&ui, cx);
+            page.set_config_status(config_error, cx);
+        });
+
+        self.config = config;
+        cx.notify();
+    }
+
+    /// Watch `config.toml` and re-apply on change. The `notify` callback runs on
+    /// a background thread and only pings a channel; a foreground poll loop does
+    /// the reload so all entity updates happen on the GPUI thread.
+    fn start_config_watch(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let (sender, receiver) = mpsc::channel::<()>();
+        match ConfigWatcher::new(&self.config_path, move || {
+            // A closed channel just means the app is shutting down.
+            let _ = sender.send(());
+        }) {
+            Ok(watcher) => self._config_watcher = Some(watcher),
+            Err(error) => {
+                tracing::warn!("config hot reload disabled: {error}");
+                return;
+            }
+        }
+
+        cx.spawn_in(
+            window,
+            move |this: WeakEntity<RootView>, cx: &mut AsyncWindowContext| {
+                let mut cx = cx.clone();
+                async move {
+                    loop {
+                        cx.background_executor()
+                            .timer(Duration::from_millis(400))
+                            .await;
+                        let mut changed = false;
+                        while receiver.try_recv().is_ok() {
+                            changed = true;
+                        }
+                        if !changed {
+                            continue;
+                        }
+                        let update = this.update_in(&mut cx, |this, window, cx| {
+                            let (mut config, diagnostics) =
+                                config::load_from_path(&this.config_path);
+                            for over in &this.config_overrides {
+                                config.apply_override(over);
+                            }
+                            let config_error = config::report_diagnostics(&diagnostics);
+                            this.apply_config(config, config_error, window, cx);
+                        });
+                        if update.is_err() {
+                            break; // The view (and window) is gone.
+                        }
+                    }
+                }
+            },
+        )
+        .detach();
     }
 
     pub fn set_page(&mut self, page: PageKind, cx: &mut Context<Self>) {

--- a/crates/nohrs-pages/src/root.rs
+++ b/crates/nohrs-pages/src/root.rs
@@ -48,6 +48,10 @@ pub struct RootView {
     config: Config,
     config_path: PathBuf,
     config_overrides: Vec<ConfigOverride>,
+    // Latest config load error, surfaced in the footer. Held here (not in the
+    // explorer's transient status) so it is not cleared by an explorer
+    // directory reload and survives across pages.
+    config_status: Option<String>,
     // Kept alive for the window's lifetime so the OS watch is not dropped.
     _config_watcher: Option<ConfigWatcher>,
 }
@@ -99,6 +103,7 @@ impl RootView {
             config: Config::default(),
             config_path,
             config_overrides,
+            config_status: None,
             _config_watcher: None,
         };
         view.start_progress_loop(window, cx);
@@ -127,11 +132,16 @@ impl RootView {
             Theme::change(mode, Some(window), cx);
         }
 
-        let ui = config.ui.clone();
-        self.explorer.update(cx, |page, cx| {
-            page.apply_config_ui(&ui, cx);
-            page.set_config_status(config_error, cx);
+        // Condense the (possibly multi-line) diagnostic to a single line plus the
+        // file path for the one-line status bar; full detail is in the logs.
+        self.config_status = config_error.as_ref().map(|error| {
+            let summary = error.lines().next().unwrap_or(error.as_str());
+            format!("config: {summary} ({})", self.config_path.display())
         });
+
+        let ui = config.ui.clone();
+        self.explorer
+            .update(cx, |page, cx| page.apply_config_ui(&ui, cx));
 
         self.config = config;
         cx.notify();
@@ -284,11 +294,15 @@ impl Render for RootView {
             .child(
                 // Footer status bar
                 {
-                    let (status_message, status_is_error) =
-                        match self.explorer.read(cx).status_for_footer() {
+                    // A config load error takes precedence over the explorer's
+                    // transient status and is always shown as an error.
+                    let (status_message, status_is_error) = match &self.config_status {
+                        Some(message) => (Some(message.clone()), true),
+                        None => match self.explorer.read(cx).status_for_footer() {
                             Some((text, is_error)) => (Some(text), is_error),
                             None => (None, false),
-                        };
+                        },
+                    };
                     let props = FooterProps {
                         indexing_progress: self.indexing_progress,
                         status_message,

--- a/crates/nohrs-ui/src/components/layout/footer.rs
+++ b/crates/nohrs-ui/src/components/layout/footer.rs
@@ -113,7 +113,16 @@ pub fn footer<V: gpui::Render>(props: FooterProps, cx: &mut Context<V>) -> impl 
                             .items_center()
                             .gap_1()
                             .child(Icon::new(IconName::Info).size_3().text_color(rgb(color)))
-                            .child(div().text_xs().text_color(rgb(color)).child(message)),
+                            .child(
+                                // Keep the status on one line so a long or
+                                // multi-line message can't overflow the footer.
+                                div()
+                                    .text_xs()
+                                    .whitespace_nowrap()
+                                    .overflow_hidden()
+                                    .text_color(rgb(color))
+                                    .child(message),
+                            ),
                     )
                 }),
         )

--- a/crates/nohrs/Cargo.toml
+++ b/crates/nohrs/Cargo.toml
@@ -26,6 +26,7 @@ gpui = "0.2"
 gpui-component = "0.3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tracing.workspace = true
+clap = { version = "4", features = ["derive"] }
 
 [lints]
 workspace = true

--- a/crates/nohrs/src/app.rs
+++ b/crates/nohrs/src/app.rs
@@ -6,10 +6,11 @@
 //! window hosting `nohrs_pages::RootView`. The launcher window (`nohrs-launcher`,
 //! P3) will be opened from here too, as a symmetric second pillar.
 
+use crate::cli::Cli;
 use gpui::{px, size, App, AppContext, Application, Bounds};
 use gpui_component::resizable::ResizableState;
 use gpui_component::Root;
-use nohrs_core::config;
+use nohrs_core::config::{self, ConfigOverride};
 use nohrs_core::telemetry::logging::init_logging;
 use nohrs_pages::RootView;
 use nohrs_services::search::SearchService;
@@ -23,10 +24,25 @@ use tokio::task;
 pub struct NohrsApp;
 
 impl NohrsApp {
-    pub fn run() {
+    pub fn run(cli: &Cli) {
         init_logging();
 
-        Application::new().with_assets(Assets).run(|app: &mut App| {
+        // Load configuration before opening the window: defaults < file < env <
+        // CLI (config.md §3). A missing file is created with defaults so users
+        // have something to edit and the watcher has a target. Parse failures are
+        // non-fatal — we fall back to defaults and surface the error in the UI.
+        let config_path = config::paths::config_file();
+        if let Err(error) = config::ensure_exists(&config_path) {
+            tracing::warn!("could not create {}: {error}", config_path.display());
+        }
+        let (mut config, diagnostics) = config::load_from_path(&config_path);
+        let config_overrides = vec![ConfigOverride::from_env(), cli.overrides()];
+        for over in &config_overrides {
+            config.apply_override(over);
+        }
+        let config_error = config::report_diagnostics(&diagnostics);
+
+        Application::new().with_assets(Assets).run(move |app: &mut App| {
             gpui_component::init(app);
             let resizable = ResizableState::new(app);
             let bounds = Bounds::centered(
@@ -37,25 +53,41 @@ impl NohrsApp {
             let traffic_lights = TrafficLightsHook::new().center_vertically(UNIFIED_TOOLBAR_HEIGHT);
             let window_options = window::unified_window_options(bounds, &traffic_lights);
 
-            let opened = app.open_window(window_options, |window, cx| {
-                // Initialize SearchService. Failure is non-fatal: the app starts
-                // with full-text search disabled rather than crashing.
-                let handle = Handle::current();
-                let search_service: Option<Arc<SearchService>> =
-                    task::block_in_place(move || match handle.block_on(SearchService::new()) {
-                        Ok(service) => Some(Arc::new(service)),
-                        Err(e) => {
-                            tracing::error!(
-                                "Failed to initialize search service; starting with search disabled: {}",
-                                e
-                            );
-                            None
-                        }
-                    });
+            let opened = app.open_window(window_options, {
+                let config = config.clone();
+                let config_path = config_path.clone();
+                let config_overrides = config_overrides.clone();
+                let config_error = config_error.clone();
+                move |window, cx| {
+                    // Initialize SearchService. Failure is non-fatal: the app starts
+                    // with full-text search disabled rather than crashing.
+                    let handle = Handle::current();
+                    let search_service: Option<Arc<SearchService>> =
+                        task::block_in_place(move || match handle.block_on(SearchService::new()) {
+                            Ok(service) => Some(Arc::new(service)),
+                            Err(e) => {
+                                tracing::error!(
+                                    "Failed to initialize search service; starting with search disabled: {}",
+                                    e
+                                );
+                                None
+                            }
+                        });
 
-                let view =
-                    cx.new(|cx| RootView::new(resizable.clone(), search_service, window, cx));
-                cx.new(|cx| Root::new(view.into(), window, cx))
+                    let view = cx.new(|cx| {
+                        RootView::new(
+                            resizable.clone(),
+                            search_service,
+                            config,
+                            config_path,
+                            config_overrides,
+                            config_error,
+                            window,
+                            cx,
+                        )
+                    });
+                    cx.new(|cx| Root::new(view.into(), window, cx))
+                }
             });
             if let Err(error) = opened {
                 tracing::error!("failed to open main window: {error}");

--- a/crates/nohrs/src/cli.rs
+++ b/crates/nohrs/src/cli.rs
@@ -1,0 +1,159 @@
+//! Command-line interface: argument parsing plus the `nohrs config` subcommands
+//! (config.md §8). With no subcommand the parsed global overrides are handed to
+//! the GUI; with a `config` subcommand we run it and exit without opening a
+//! window.
+
+use clap::{Parser, Subcommand};
+use nohrs_core::config::{self, ConfigOverride, ThemeMode};
+use std::process::Command as ProcessCommand;
+
+#[derive(Parser, Debug)]
+#[command(name = "nohrs", version, about = "Launcher × Explorer file workspace")]
+pub struct Cli {
+    /// Override the theme mode for this run: system, light, or dark.
+    #[arg(long, global = true, value_name = "MODE")]
+    pub theme: Option<String>,
+
+    /// Override the accent colour for this run (named colour or hex).
+    #[arg(long, global = true, value_name = "COLOR")]
+    pub accent: Option<String>,
+
+    #[command(subcommand)]
+    pub command: Option<Command>,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Command {
+    /// Inspect or manage the user configuration.
+    Config {
+        #[command(subcommand)]
+        action: ConfigAction,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum ConfigAction {
+    /// Print the fully merged config (defaults < file < env < CLI) as JSON.
+    Show,
+    /// Open config.toml in $EDITOR (creating it with defaults if missing).
+    Edit,
+    /// Validate config.toml, reporting parse errors and warnings.
+    Validate,
+    /// Print the JSON Schema for config.toml to stdout.
+    Schema,
+    /// Print the full path to config.toml.
+    Path,
+    /// Reset config.toml to defaults, backing up any existing file first.
+    Reset,
+}
+
+impl Cli {
+    /// Build the CLI override layer from the global `--theme` / `--accent` flags.
+    /// An invalid `--theme` value is warned about and ignored rather than
+    /// aborting (it still leaves the file/env value in effect).
+    pub fn overrides(&self) -> ConfigOverride {
+        let mut over = ConfigOverride::default();
+        if let Some(theme) = &self.theme {
+            match ThemeMode::parse(theme.trim()) {
+                Some(mode) => over.theme_mode = Some(mode),
+                None => tracing::warn!("ignoring invalid --theme {theme:?}"),
+            }
+        }
+        if let Some(accent) = &self.accent {
+            over.theme_accent = Some(accent.clone());
+        }
+        over
+    }
+}
+
+/// Run a `config` subcommand. Returns the process exit code.
+pub fn run_config_command(action: &ConfigAction, cli: &Cli) -> i32 {
+    let path = config::paths::config_file();
+    match action {
+        ConfigAction::Path => {
+            println!("{}", path.display());
+            0
+        }
+        ConfigAction::Schema => match config::json_schema_string() {
+            Ok(schema) => {
+                println!("{schema}");
+                0
+            }
+            Err(error) => {
+                eprintln!("failed to generate schema: {error}");
+                1
+            }
+        },
+        ConfigAction::Show => {
+            let (mut merged, diagnostics) = config::load_from_path(&path);
+            config::report_diagnostics(&diagnostics);
+            merged.apply_override(&ConfigOverride::from_env());
+            merged.apply_override(&cli.overrides());
+            match merged.to_json() {
+                Ok(json) => {
+                    println!("{json}");
+                    0
+                }
+                Err(error) => {
+                    eprintln!("failed to serialize config: {error}");
+                    1
+                }
+            }
+        }
+        ConfigAction::Validate => {
+            let (_, diagnostics) = config::load_from_path(&path);
+            let error = config::report_diagnostics(&diagnostics);
+            if let Some(message) = error {
+                eprintln!("invalid config ({}): {message}", path.display());
+                1
+            } else {
+                let warnings = diagnostics.len();
+                if warnings == 0 {
+                    println!("{}: OK", path.display());
+                } else {
+                    println!(
+                        "{}: OK with {warnings} warning(s) (see logs)",
+                        path.display()
+                    );
+                }
+                0
+            }
+        }
+        ConfigAction::Reset => match config::reset(&path) {
+            Ok(Some(backup)) => {
+                println!(
+                    "reset {}; backed up to {}",
+                    path.display(),
+                    backup.display()
+                );
+                0
+            }
+            Ok(None) => {
+                println!("wrote default config to {}", path.display());
+                0
+            }
+            Err(error) => {
+                eprintln!("failed to reset config: {error}");
+                1
+            }
+        },
+        ConfigAction::Edit => edit_config(&path),
+    }
+}
+
+fn edit_config(path: &std::path::Path) -> i32 {
+    if let Err(error) = config::ensure_exists(path) {
+        eprintln!("failed to create {}: {error}", path.display());
+        return 1;
+    }
+    let editor = std::env::var("VISUAL")
+        .or_else(|_| std::env::var("EDITOR"))
+        .unwrap_or_else(|_| "vi".to_string());
+    match ProcessCommand::new(&editor).arg(path).status() {
+        Ok(status) => status.code().unwrap_or(0),
+        Err(error) => {
+            eprintln!("failed to launch editor {editor:?}: {error}");
+            1
+        }
+    }
+}

--- a/crates/nohrs/src/cli.rs
+++ b/crates/nohrs/src/cli.rs
@@ -149,8 +149,15 @@ fn edit_config(path: &std::path::Path) -> i32 {
     let editor = std::env::var("VISUAL")
         .or_else(|_| std::env::var("EDITOR"))
         .unwrap_or_else(|_| "vi".to_string());
-    match ProcessCommand::new(&editor).arg(path).status() {
-        Ok(status) => status.code().unwrap_or(0),
+    // `$EDITOR` often carries arguments (e.g. `code --wait`), so split on
+    // whitespace rather than treating the whole string as a program path.
+    let mut parts = editor.split_whitespace();
+    let program = parts.next().unwrap_or("vi");
+    match ProcessCommand::new(program).args(parts).arg(path).status() {
+        // A signal-terminated child reports no exit code; surface that as a
+        // failure rather than masking it as success.
+        Ok(status) if status.success() => 0,
+        Ok(status) => status.code().unwrap_or(1),
         Err(error) => {
             eprintln!("failed to launch editor {editor:?}: {error}");
             1

--- a/crates/nohrs/src/main.rs
+++ b/crates/nohrs/src/main.rs
@@ -1,6 +1,17 @@
 mod app;
+mod cli;
+
+use clap::Parser;
 
 #[tokio::main]
 async fn main() {
-    app::NohrsApp::run();
+    let cli = cli::Cli::parse();
+
+    // `config` subcommands run headless and exit without opening a window.
+    if let Some(cli::Command::Config { action }) = &cli.command {
+        nohrs_core::telemetry::logging::init_logging();
+        std::process::exit(cli::run_config_command(action, &cli));
+    }
+
+    app::NohrsApp::run(&cli);
 }

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -64,7 +64,6 @@
   "properties": {
     "schema_version": {
       "description": "On-disk schema version. Must be [`CURRENT_SCHEMA_VERSION`] for this build.",
-      "format": "uint64",
       "minimum": 0,
       "type": "integer"
     },

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -1,0 +1,85 @@
+{
+  "$defs": {
+    "SortOrder": {
+      "enum": [
+        "name",
+        "modified",
+        "size",
+        "kind"
+      ],
+      "type": "string"
+    },
+    "Theme": {
+      "description": "Appearance settings.",
+      "properties": {
+        "accent": {
+          "description": "Accent colour, given as a named colour or a hex string. Full\ncustomization lands in P5; P1 stores the value and applies the mode.",
+          "type": "string"
+        },
+        "mode": {
+          "$ref": "#/$defs/ThemeMode",
+          "description": "Light/dark selection, or following the OS."
+        }
+      },
+      "required": [
+        "mode",
+        "accent"
+      ],
+      "type": "object"
+    },
+    "ThemeMode": {
+      "enum": [
+        "system",
+        "light",
+        "dark"
+      ],
+      "type": "string"
+    },
+    "Ui": {
+      "description": "Explorer / view settings.",
+      "properties": {
+        "default_sort": {
+          "$ref": "#/$defs/SortOrder",
+          "description": "Column the listing is sorted by on load."
+        },
+        "icon_pack": {
+          "description": "Identifier of the icon pack used to render entries.",
+          "type": "string"
+        },
+        "show_hidden": {
+          "description": "Whether dotfiles are shown in listings.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "default_sort",
+        "show_hidden",
+        "icon_pack"
+      ],
+      "type": "object"
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "The fully merged, validated configuration.\n\nOnly the P1 surface (`theme` / `ui`) is modelled here. `[keybindings]` and\n`[plugins]` are recognised as reserved sections (see [`is_reserved_section`])\nbut intentionally not deserialized yet, so their future shapes can be added\nwithout breaking older files.",
+  "properties": {
+    "schema_version": {
+      "description": "On-disk schema version. Must be [`CURRENT_SCHEMA_VERSION`] for this build.",
+      "format": "uint64",
+      "minimum": 0,
+      "type": "integer"
+    },
+    "theme": {
+      "$ref": "#/$defs/Theme"
+    },
+    "ui": {
+      "$ref": "#/$defs/Ui"
+    }
+  },
+  "required": [
+    "schema_version",
+    "theme",
+    "ui"
+  ],
+  "title": "Config",
+  "type": "object"
+}


### PR DESCRIPTION
Implements the P1 minimal configuration surface from `docs/config.md` (issue #49, parent #40): an XDG-located `config.toml` with `theme`/`ui` sections, a 4-layer override merge, panic-free validation, theme/ui hot reload, CLI subcommands, and a committed JSON Schema.

## What changed

**`nohrs-core::config`** (new submodules, unit-tested):
- `settings.rs` — P1 schema (`schema_version`, `[theme]` mode/accent, `[ui]` default_sort/show_hidden/icon_pack), defaults, serde, schemars JSON Schema, the 4-layer override merge (defaults < file < env < CLI), forward-compatible validation, the `NOHRS_*` env layer, and the default TOML template (with `#:schema` header + empty reserved `[keybindings]`/`[plugins]`).
- `paths.rs` — resolves `$XDG_CONFIG_HOME` → `~/.config` directly per §1 (uses `dirs` only for the home fallback, never `dirs::config_dir()`).
- `watcher.rs` — `notify`-based watcher (watches the parent dir so atomic-rename saves are detected).
- `loader.rs` — `write_default`/`ensure_exists`/`backup`/`reset` plus the migration scaffold.

**`nohrs` binary**:
- `cli.rs` — clap `config {show|edit|validate|schema|path|reset}` and global `--theme`/`--accent` overrides; `main.rs` runs config subcommands headless and exits.
- `app.rs` loads defaults < file < env < CLI at startup and applies them.

**Wiring** — `RootView::apply_config` switches the gpui theme mode and propagates `[ui]` to the open `ExplorerPage` (which gained `show_hidden` dotfile filtering and `icon_pack`); a foreground poll loop reloads on watcher pings. Config load errors are held on `RootView` and shown in the footer status bar (single line + file path) instead of panicking.

**Validation behaviour** (config.md §6): TOML syntax errors and unknown `schema_version` fall back to defaults with a status-bar error; unknown keys and out-of-range values warn and use the default for that field only.

Other: logging moved to stderr so `config show`/`schema` emit clean stdout; the JSON Schema is key-sorted and strips schemars' nonstandard integer `format` so it's portable and byte-stable (a drift test keeps `docs/config.schema.json` in sync with the `Config` struct).

P2 items (keybindings/plugins/indexing/search/launcher) are intentionally out of scope.

## Verification

`cargo fmt`/`clippy -D warnings`/`test` all green (18 new core tests). All six CLI subcommands exercised; 4-layer override precedence (CLI > env > file > default) confirmed. GUI verified headlessly (Xvfb):

Editing `show_hidden = false → true` and saving updates the listing live, no restart — **4 items → 7 items** (`.git`, `.hidden.cfg`, `.secret_dotfile` appear):

![hidden off — 4 items](https://raw.githubusercontent.com/noh-rs/nohrs/pr-assets/screenshots/config-minimal-v2/1877432-19062/step0c.png)
![hidden on — 7 items](https://raw.githubusercontent.com/noh-rs/nohrs/pr-assets/screenshots/config-minimal-v2/1877432-19062/step1.png)

A `config.toml` with broken TOML does not crash the app: it falls back to defaults and shows a single-line parse error with the file path in the status bar (shown here at startup):

![syntax error in status bar](https://raw.githubusercontent.com/noh-rs/nohrs/pr-assets/screenshots/config-minimal-v2/1877432-19062/step2_v2.png)

Release Notes:

- Added an XDG `config.toml` with `theme`/`ui` settings that hot-reload, environment/CLI overrides, panic-free validation, and `nohrs config {show,edit,validate,schema,path,reset}`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Persistent config with theme (mode, accent) and UI options (sort order, show hidden, icon pack); live application and hot-reload with safe backups
  * CLI commands to show/edit/validate/print-schema/path/reset config; env and CLI overrides supported
  * Explorer respects hidden-file visibility and icon pack; UI theme updates on config changes
  * Command prints config path and merged JSON output when requested

* **Documentation**
  * Added JSON Schema describing the merged/validated configuration

* **Style**
  * Logging configured to write structured output to stderr to keep stdout clean

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/noh-rs/nohrs/pull/131?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->