### PR TITLE
Replace silent error swallows with logged ignores

### DIFF
--- a/crates/nohrs-core/src/telemetry.rs
+++ b/crates/nohrs-core/src/telemetry.rs
@@ -1,1 +1,47 @@
 pub mod logging;
+
+use std::fmt::Display;
+
+/// Ignore an error while keeping it visible in the logs.
+///
+/// The project forbids silently swallowing fallible results with bare
+/// `let _ = fallible()`. When an error is genuinely non-fatal (a dropped
+/// progress receiver, a logger that is already initialised, …) call
+/// [`LogErr::log_err`] instead so the failure is surfaced at `warn` level,
+/// tagged with the call site, rather than discarded.
+pub trait LogErr<T> {
+    /// Return `Some(value)` on success. On error, log it via `tracing::warn!`
+    /// (tagged with the caller's location) and return `None`.
+    fn log_err(self) -> Option<T>;
+}
+
+impl<T, E: Display> LogErr<T> for Result<T, E> {
+    #[track_caller]
+    fn log_err(self) -> Option<T> {
+        match self {
+            Ok(value) => Some(value),
+            Err(error) => {
+                let location = std::panic::Location::caller();
+                tracing::warn!("{}:{}: {error}", location.file(), location.line());
+                None
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::LogErr;
+
+    #[test]
+    fn ok_is_passed_through() {
+        let result: Result<u8, &str> = Ok(7);
+        assert_eq!(result.log_err(), Some(7));
+    }
+
+    #[test]
+    fn err_is_logged_and_discarded() {
+        let result: Result<u8, &str> = Err("boom");
+        assert_eq!(result.log_err(), None);
+    }
+}

--- a/crates/nohrs-core/src/telemetry/logging.rs
+++ b/crates/nohrs-core/src/telemetry/logging.rs
@@ -1,11 +1,15 @@
+use super::LogErr;
 use tracing_subscriber::{fmt, EnvFilter};
 
 pub fn init_logging() {
     let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
     // Logs go to stderr so machine-readable command output (e.g.
-    // `nohrs config show`/`schema`) stays clean on stdout.
-    let _ = fmt()
+    // `nohrs config show`/`schema`) stays clean on stdout. A failed `try_init`
+    // just means a subscriber is already installed, which the existing
+    // subscriber will surface.
+    fmt()
         .with_writer(std::io::stderr)
         .with_env_filter(env_filter)
-        .try_init();
+        .try_init()
+        .log_err();
 }

--- a/crates/nohrs-pages/src/root.rs
+++ b/crates/nohrs-pages/src/root.rs
@@ -19,6 +19,7 @@ use gpui_component::input::InputState;
 use gpui_component::resizable::ResizableState;
 use gpui_component::{Icon, Root, Theme, ThemeMode as GpuiThemeMode};
 use nohrs_core::config::{self, Config, ConfigOverride, ConfigWatcher};
+use nohrs_core::telemetry::LogErr;
 use nohrs_services::search::SearchService;
 use nohrs_ui::components::layout::footer::{footer, FooterProps};
 use nohrs_ui::components::layout::unified_toolbar::{
@@ -154,7 +155,7 @@ impl RootView {
         let (sender, receiver) = mpsc::channel::<()>();
         match ConfigWatcher::new(&self.config_path, move || {
             // A closed channel just means the app is shutting down.
-            let _ = sender.send(());
+            sender.send(()).log_err();
         }) {
             Ok(watcher) => self._config_watcher = Some(watcher),
             Err(error) => {

--- a/crates/nohrs-services/src/search/engine.rs
+++ b/crates/nohrs-services/src/search/engine.rs
@@ -2,6 +2,7 @@ use super::indexer::IndexManager;
 use super::watcher::FileWatcher;
 use super::{SearchBackend, SearchResult, SearchScope};
 use anyhow::{Context, Result};
+use nohrs_core::telemetry::LogErr;
 use std::sync::Arc;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
@@ -56,7 +57,7 @@ impl SearchEngine {
                 tracing::info!(
                     "Schema outdated (missing filename field), forcing full indexing..."
                 );
-                let _ = progress_tx.send(0.0);
+                progress_tx.send(0.0).log_err();
                 if let Err(e) = initial_manager.index_home(Some(progress_tx)) {
                     tracing::error!("Initial indexing failed: {}", e);
                 }
@@ -69,7 +70,7 @@ impl SearchEngine {
                     let doc_count = reader.searcher().num_docs();
                     if doc_count == 0 {
                         tracing::info!("Index is empty, starting full indexing...");
-                        let _ = progress_tx.send(0.0); // Reset to 0 for indexing
+                        progress_tx.send(0.0).log_err(); // Reset to 0 for indexing
                         if let Err(e) = initial_manager.index_home(Some(progress_tx)) {
                             tracing::error!("Initial indexing failed: {}", e);
                         }
@@ -83,7 +84,7 @@ impl SearchEngine {
                 }
                 Err(e) => {
                     tracing::warn!("Failed to read index, running full indexing: {}", e);
-                    let _ = progress_tx.send(0.0);
+                    progress_tx.send(0.0).log_err();
                     if let Err(e) = initial_manager.index_home(Some(progress_tx)) {
                         tracing::error!("Initial indexing failed: {}", e);
                     }

--- a/crates/nohrs-services/src/search/indexer.rs
+++ b/crates/nohrs-services/src/search/indexer.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use nohrs_core::telemetry::LogErr;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
@@ -114,7 +115,7 @@ impl IndexManager {
         // 1. Count files if progress tracking is enabled
         let mut total_files = 0;
         if let Some(tx) = &progress_tx {
-            let _ = tx.send(0.0);
+            tx.send(0.0).log_err();
             let walker = ignore::WalkBuilder::new(&self.content_root)
                 .hidden(false)
                 .git_ignore(true)
@@ -166,7 +167,7 @@ impl IndexManager {
                     processed += 1;
                     if let Some(tx) = &progress_tx {
                         if total_files > 0 && processed % 100 == 0 {
-                            let _ = tx.send(processed as f32 / total_files as f32);
+                            tx.send(processed as f32 / total_files as f32).log_err();
                         }
                     }
                 }
@@ -175,7 +176,7 @@ impl IndexManager {
         }
 
         if let Some(tx) = &progress_tx {
-            let _ = tx.send(1.0); // Done
+            tx.send(1.0).log_err(); // Done
         }
 
         writer_guard.commit()?;


### PR DESCRIPTION
Closes #132.

The repo guidelines forbid discarding fallible results with a bare `let _ = ...`. Every remaining offender was a genuinely non-fatal error that was being dropped silently:

- `nohrs-services` search engine/indexer — progress values sent over a `watch` channel whose receiver may already be gone.
- `nohrs-core` telemetry — the tracing subscriber's `try_init` (fails only when a subscriber is already installed).
- `nohrs-pages` root view — the config-watcher ping over an `mpsc` channel that closes on shutdown.

This adds a small `LogErr` extension trait in `nohrs-core::telemetry`. `.log_err()` logs an ignored error at `warn` level (tagged with the caller's location via `#[track_caller]`) and returns `None`, matching the `.log_err()` idiom referenced in the project guidelines. The swallows now route through it, so the failures stay visible in the logs instead of vanishing.

All `unwrap()`/`expect()` calls that remain are confined to test code, where panicking is the intended failure mode.

## Verification

Not a UI/rendering change, so no screenshots.

- `cargo fmt --all` — clean
- `cargo clippy --all-targets -- -D warnings` plus `cargo clippy -p nohrs-pages -p nohrs-ui` — clean
- `cargo build` and `cargo build -p nohrs-pages` — compile
- `cargo test -p nohrs-core -p nohrs-services -p nohrs-models` — all pass, including the new `LogErr` unit tests and the `test_indexing_workflow` / `test_watcher_detects_changes` integration tests that exercise the modified progress-send paths

(The final `nohrs` GUI binary can't be linked in this headless environment because the X11 dev libraries are absent — a pre-existing constraint unrelated to this change; the library crates all compile.)

Release Notes:

- N/A

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced silent error swallows with logged ignores using a new `LogErr` extension trait. Non‑fatal failures are now logged at warn with the call site, so dropped progress updates and redundant logger init are visible.

- **Refactors**
  - Added `nohrs-core::telemetry::LogErr` for `Result<T, E>` that logs and returns `None`.
  - Routed channel sends through `.log_err()` in `nohrs-services` search engine/indexer and `nohrs-pages` config watcher.
  - Wrapped `tracing_subscriber::fmt().try_init()` with `.log_err()` in `nohrs-core` logging init.

<sup>Written for commit ac8e2e735f5648086da082f82e6016167ba1884f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/noh-rs/nohrs/pull/133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error logging in logging initialization, configuration hot-reload monitoring, and search indexing operations.
  * Errors that were previously silently ignored are now properly logged, improving visibility into initialization and background process failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->