### PR TITLE
Add Nix devshell with direnv support

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,8 @@
 
 # Logs & env
 *.log
-.env*
+.env
+.env.*
 
 # macOS
 .DS_Store
@@ -25,6 +26,11 @@ coverage/
 
 # personal
 /.specify
+
+# Nix
+result
+result-*
+.direnv/
 
 # Python bytecode
 __pycache__/

--- a/docs/dev-environment.md
+++ b/docs/dev-environment.md
@@ -119,36 +119,19 @@ GitHub Actions では Ubuntu runner で同 image を使用。
 
 ### `flake.nix` (devshell のみ、P1 提供)
 
-```nix
-{
-  description = "nohrs devshell";
-  inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    rust-overlay.url = "github:oxalica/rust-overlay";
-    flake-utils.url = "github:numtide/flake-utils";
-  };
-  outputs = { self, nixpkgs, rust-overlay, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system:
-      let
-        pkgs = import nixpkgs {
-          inherit system;
-          overlays = [ rust-overlay.overlays.default ];
-        };
-        rust = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
-      in {
-        devShells.default = pkgs.mkShell {
-          buildInputs = with pkgs; [
-            rust pkg-config openssl
-            libxkbcommon wayland
-            fontconfig freetype
-            mesa libGL
-            cargo-llvm-cov cargo-deny cargo-machete
-            typos wrangler
-          ];
-        };
-      });
-}
-```
+リポジトリルートの `flake.nix` が devshell を提供する。
+
+**inputs**:
+- `nixpkgs` (nixos-unstable) + `rust-overlay` + `flake-utils`
+- Rust toolchain は `rust-toolchain.toml` から自動取得（`rust-bin.fromRustupToolchainFile`）
+
+**buildInputs（共通）**: `rust`, `pkg-config`, `openssl`, `fontconfig`, `freetype`, `cargo-llvm-cov`, `cargo-deny`, `cargo-machete`, `typos`
+
+**buildInputs（Linux 追加）**: `libxkbcommon`, `wayland`, `mesa`, `libGL`, `xorg.libxcb`, `xorg.libX11`, `libxcursor`, `libxi`, `vulkan-loader`, `vulkan-headers`
+- macOS では Metal を使うためこれらは不要。`lib.optionals stdenv.isLinux` で条件付き。
+- `LD_LIBRARY_PATH` に `makeLibraryPath` で生成したパスを設定し、実行時リンクを解決。
+
+**direnv（任意）**: `.envrc`（`use flake`）をコミット済み。`direnv allow` で `cd` 時に自動ロード。
 
 **使用**:
 ```bash

--- a/docs/dev-environment.md
+++ b/docs/dev-environment.md
@@ -127,7 +127,7 @@ GitHub Actions では Ubuntu runner で同 image を使用。
 
 **buildInputs（共通）**: `rust`, `pkg-config`, `openssl`, `fontconfig`, `freetype`, `cargo-llvm-cov`, `cargo-deny`, `cargo-machete`, `typos`
 
-**buildInputs（Linux 追加）**: `libxkbcommon`, `wayland`, `mesa`, `libGL`, `xorg.libxcb`, `xorg.libX11`, `libxcursor`, `libxi`, `vulkan-loader`, `vulkan-headers`
+**buildInputs（Linux 追加）**: `libxkbcommon`, `wayland`, `mesa`, `libGL`, `libxcb`, `libx11`, `libxcursor`, `libxi`, `vulkan-loader`, `vulkan-headers`
 - macOS では Metal を使うためこれらは不要。`lib.optionals stdenv.isLinux` で条件付き。
 - `LD_LIBRARY_PATH` に `makeLibraryPath` で生成したパスを設定し、実行時リンクを解決。
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,96 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1780197589,
+        "narHash": "sha256-FVCr2Ij/jKf59a4LW481eeOF6rJRreOBrVgW/aUBTrw=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "21632e942d89bf1cce4e5a63d7e58a215a0cbfcc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -18,16 +18,13 @@
         linuxDeps = pkgs.lib.optionals pkgs.stdenv.isLinux (
           with pkgs; [
             libxkbcommon wayland mesa libGL
-            xorg.libxcb xorg.libX11 libxcursor libxi
+            libxcb libx11 libxcursor libxi
             vulkan-loader vulkan-headers
           ]
         );
-        libPath = pkgs.lib.makeLibraryPath (with pkgs; [
-          libxkbcommon wayland mesa libGL
-          xorg.libxcb xorg.libX11
-          vulkan-loader
-          fontconfig freetype openssl
-        ] ++ linuxDeps);
+        libPath = pkgs.lib.makeLibraryPath (
+          (with pkgs; [ fontconfig freetype openssl ]) ++ linuxDeps
+        );
       in {
         devShells.default = pkgs.mkShell {
           buildInputs = with pkgs; [

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,48 @@
+{
+  description = "nohrs devshell";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, rust-overlay, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ rust-overlay.overlays.default ];
+        };
+        rust = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+        linuxDeps = pkgs.lib.optionals pkgs.stdenv.isLinux (
+          with pkgs; [
+            libxkbcommon wayland mesa libGL
+            xorg.libxcb xorg.libX11 libxcursor libxi
+            vulkan-loader vulkan-headers
+          ]
+        );
+        libPath = pkgs.lib.makeLibraryPath (with pkgs; [
+          libxkbcommon wayland mesa libGL
+          xorg.libxcb xorg.libX11
+          vulkan-loader
+          fontconfig freetype openssl
+        ] ++ linuxDeps);
+      in {
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            rust
+            pkg-config
+            openssl
+            fontconfig
+            freetype
+            cargo-llvm-cov
+            cargo-deny
+            cargo-machete
+            typos
+          ] ++ linuxDeps;
+
+          LD_LIBRARY_PATH = libPath;
+        };
+      });
+}


### PR DESCRIPTION
#52 (Nix devshell 部分)

## 変更内容

- `flake.nix` — nixos-unstable + rust-overlay + flake-utils による devshell
  - macOS/Linux 両対応（Linux 専用パッケージは `lib.optionals stdenv.isLinux` で条件付き）
  - `LD_LIBRARY_PATH` を `makeLibraryPath` で設定し gpui の実行時リンクを解決
- `flake.lock` — ピン済み依存関係
- `.envrc` — `use flake` で direnv 自動ロード
- `.gitignore` — `result`, `result-*`, `.direnv/` を追加、`.envrc` が巻き込まれないよう `.env*` → `.env` / `.env.*` に修正
- `docs/dev-environment.md` §5 — コード例を実装に合わせた説明に更新（プラットフォーム条件、LD_LIBRARY_PATH、direnv の記述）

## Verification

`nix develop` 内で品質ゲート通過:
- `cargo fmt --all --check` ✓
- `cargo clippy --all-targets -- -D warnings` ✓
- `cargo build` ✓
- `cargo test` ✓

Release Notes:

- Added Nix devshell (`nix develop`) and direnv (`.envrc`) for Linux and macOS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Nix flake devshell with direnv auto-load to standardize the Rust dev setup on macOS and Linux. Makes `LD_LIBRARY_PATH` platform-safe and switches Linux deps to renamed `libxcb`/`libx11`.

- **New Features**
  - Devshell in `flake.nix` using `nixpkgs` (nixos-unstable), `rust-overlay`, and `flake-utils`; Rust toolchain from `rust-toolchain.toml`.
  - Linux-only deps via `lib.optionals stdenv.isLinux`; `LD_LIBRARY_PATH` built with `makeLibraryPath` from common libs + `linuxDeps` (safe on macOS).
  - `.envrc` with `use flake` for `direnv` auto-activation; docs expanded with inputs/buildInputs, platform notes, and `LD_LIBRARY_PATH`; `.gitignore` now ignores `result*` and `.direnv/`.

- **Dependencies**
  - Added `flake.lock` to pin inputs; replaced deprecated `xorg.*` refs with `libxcb` and `libx11`.

<sup>Written for commit 1cdec59a734a1184de2b38ac15c1c003e83ff5a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/noh-rs/nohrs/pull/137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a Nix flake-based development environment with direnv integration for streamlined local setup.
  * Tightened ignore patterns to more precisely exclude environment files and Nix/build artifacts.

* **Documentation**
  * Updated developer environment guide to describe the new Nix/devshell workflow, toolchain handling, LD_LIBRARY_PATH behavior, and platform-specific dependency notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->