### PR TITLE
Add Docker dev and ci environments

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libxkbcommon-dev libxkbcommon-x11-dev libwayland-dev \
     libxcb-shape0-dev libxcb-xfixes0-dev libxcb1-dev libx11-dev \
     libfontconfig1-dev libfreetype6-dev \
-    libgl1-mesa-dev libegl1-mesa-dev libvulkan-dev \
+    libgl1-mesa-dev libegl1-mesa-dev libvulkan-dev mesa-vulkan-drivers \
     libssl-dev \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -1,0 +1,20 @@
+FROM debian:bookworm
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential pkg-config curl ca-certificates \
+    xvfb xdotool x11-apps \
+    libxkbcommon-dev libwayland-dev \
+    libxcb-shape0-dev libxcb-xfixes0-dev libxcb1-dev libx11-dev \
+    libfontconfig1-dev libfreetype6-dev \
+    libgl1-mesa-dev libegl1-mesa-dev libvulkan-dev \
+    libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+WORKDIR /nohrs
+COPY rust-toolchain.toml .
+RUN rustup show
+
+CMD ["bash"]

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:bookworm
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential pkg-config curl ca-certificates \
     xvfb xdotool x11-apps \
-    libxkbcommon-dev libwayland-dev \
+    libxkbcommon-dev libxkbcommon-x11-dev libwayland-dev \
     libxcb-shape0-dev libxcb-xfixes0-dev libxcb1-dev libx11-dev \
     libfontconfig1-dev libfreetype6-dev \
     libgl1-mesa-dev libegl1-mesa-dev libvulkan-dev \

--- a/docker/ci/docker-compose.yml
+++ b/docker/ci/docker-compose.yml
@@ -7,5 +7,6 @@ services:
       - DISPLAY=:99
     volumes:
       - ../..:/nohrs
-      - ~/.cargo/registry:/root/.cargo/registry
-    command: bash -c "Xvfb :99 -screen 0 1280x800x24 & sleep 1 && cargo test"
+      - ${HOME}/.cargo/registry:/root/.cargo/registry
+    entrypoint: ["/bin/bash", "-lc", "Xvfb :99 -screen 0 1280x800x24 >/tmp/xvfb.log 2>&1 & sleep 1 && exec \"$@\"", "--"]
+    command: ["cargo", "test"]

--- a/docker/ci/docker-compose.yml
+++ b/docker/ci/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  nohrs:
+    build:
+      context: ../..
+      dockerfile: docker/ci/Dockerfile
+    environment:
+      - DISPLAY=:99
+    volumes:
+      - ../..:/nohrs
+      - ~/.cargo/registry:/root/.cargo/registry
+    command: bash -c "Xvfb :99 -screen 0 1280x800x24 & sleep 1 && cargo test"

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -1,0 +1,19 @@
+FROM debian:bookworm
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential pkg-config curl ca-certificates \
+    libxkbcommon-dev libwayland-dev \
+    libxcb-shape0-dev libxcb-xfixes0-dev libxcb1-dev libx11-dev \
+    libfontconfig1-dev libfreetype6-dev \
+    libgl1-mesa-dev libegl1-mesa-dev libvulkan-dev \
+    libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+WORKDIR /nohrs
+COPY rust-toolchain.toml .
+RUN rustup show
+
+CMD ["bash"]

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:bookworm
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential pkg-config curl ca-certificates \
-    libxkbcommon-dev libwayland-dev \
+    libxkbcommon-dev libxkbcommon-x11-dev libwayland-dev \
     libxcb-shape0-dev libxcb-xfixes0-dev libxcb1-dev libx11-dev \
     libfontconfig1-dev libfreetype6-dev \
     libgl1-mesa-dev libegl1-mesa-dev libvulkan-dev \

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libxkbcommon-dev libxkbcommon-x11-dev libwayland-dev \
     libxcb-shape0-dev libxcb-xfixes0-dev libxcb1-dev libx11-dev \
     libfontconfig1-dev libfreetype6-dev \
-    libgl1-mesa-dev libegl1-mesa-dev libvulkan-dev \
+    libgl1-mesa-dev libegl1-mesa-dev libvulkan-dev mesa-vulkan-drivers \
     libssl-dev \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  nohrs:
+    build:
+      context: ../..
+      dockerfile: docker/dev/Dockerfile
+    environment:
+      - DISPLAY
+    volumes:
+      - /tmp/.X11-unix:/tmp/.X11-unix:rw
+      - ${XAUTHORITY:-/dev/null}:/root/.Xauthority:ro
+      - ../..:/nohrs
+      - ~/.cargo/registry:/root/.cargo/registry

--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -9,4 +9,4 @@ services:
       - /tmp/.X11-unix:/tmp/.X11-unix:rw
       - ${XAUTHORITY:-/dev/null}:/root/.Xauthority:ro
       - ../..:/nohrs
-      - ~/.cargo/registry:/root/.cargo/registry
+      - ${HOME}/.cargo/registry:/root/.cargo/registry


### PR DESCRIPTION
Part of #52 (Docker dev/ci 部分)

## 変更内容

- `docker/dev/Dockerfile` — Debian Bookworm + rustup + gpui 依存プリインストール（X11 forwarding 対話開発用）
- `docker/dev/docker-compose.yml` — X11 socket / XAUTHORITY / ソース / Cargo registry マウント + DISPLAY 環境変数
- `docker/ci/Dockerfile` — Debian Bookworm + Xvfb + xdotool + x11-apps + rustup + gpui 依頼（headless / CI 用）
- `docker/ci/docker-compose.yml` — Xvfb 起動 + `cargo test` が動く構成、ソース/Cargo registry マウント付き

## Verification

```bash
docker compose -f docker/ci/docker-compose.yml run --rm nohrs cargo test
# → all tests passed
```

dev コンテナは X11 forwarding を使用するため Linux host が必要です。

Release Notes:

- Added Docker dev (X11 forwarding) and ci (Xvfb headless) environments

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Docker dev and CI environments for consistent Rust GUI builds and headless tests, now with software Vulkan support. Addresses #52 with reproducible images that include `rustup`, `gpui` deps, and `mesa-vulkan-drivers`.

- **New Features**
  - Dev image: Debian + `rustup` with `gpui` deps (incl. `libxkbcommon-x11-dev`, `libvulkan-dev`, `mesa-vulkan-drivers`); compose mounts X11 socket, `XAUTHORITY`, source, and `${HOME}/.cargo/registry`, and passes `DISPLAY`.
  - CI image: headless with `Xvfb`, `xdotool`, `x11-apps`, `libxkbcommon-x11-dev`, and software Vulkan (`libvulkan-dev` + `mesa-vulkan-drivers`).
  - CI compose: `entrypoint` starts `Xvfb :99` before `cargo test`; mounts source and `${HOME}/.cargo/registry`.

- **Migration**
  - Dev requires a Linux host with X11. Set `DISPLAY` and `XAUTHORITY`, then run: `docker compose -f docker/dev/docker-compose.yml run --rm nohrs`.
  - Verify CI locally: `docker compose -f docker/ci/docker-compose.yml run --rm nohrs`.

<sup>Written for commit 0d6df7cee9d1aef82b83933c62b76f896a4ec07c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/noh-rs/nohrs/pull/140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added development and CI container setups to simplify local development and automated testing.
  * Containers provide GUI/display support so graphics-related tests and workflows can run in dev and CI environments.
  * Rust toolchain is provisioned inside containers and host build-cache mounting is enabled to speed dependency resolution and test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->