### PR TITLE
Remove axum and replace #[tokio::main] with GPUI main

### DIFF
--- a/crates/nohrs-pages/src/explorer/search.rs
+++ b/crates/nohrs-pages/src/explorer/search.rs
@@ -45,21 +45,22 @@ impl ExplorerPage {
             move |this: gpui::WeakEntity<ExplorerPage>, cx: &mut AsyncApp| {
                 let mut cx = cx.clone();
                 async move {
-                    let search_result = service.search(query, scope).await;
-
-                    // Grouping and `results_to_entries` resolve per-file metadata
-                    // (stat calls), so run them on a background thread rather than
-                    // blocking the UI thread inside the entity update.
-                    let processed = match search_result {
-                        Ok(res) => Ok(cx
-                            .background_spawn(async move {
-                                let grouped = group_results(res);
-                                let entries = results_to_entries(&grouped);
-                                (grouped, entries)
-                            })
-                            .await),
-                        Err(error) => Err(error),
-                    };
+                    // `SearchService::search` is synchronous, and grouping plus
+                    // `results_to_entries` resolve per-file metadata (stat calls).
+                    // Run the whole chain on GPUI's background executor so the UI
+                    // thread stays responsive (replaces tokio::task::spawn_blocking).
+                    let processed = cx
+                        .background_spawn(async move {
+                            match service.search(query, scope) {
+                                Ok(res) => {
+                                    let grouped = group_results(res);
+                                    let entries = results_to_entries(&grouped);
+                                    Ok((grouped, entries))
+                                }
+                                Err(error) => Err(error),
+                            }
+                        })
+                        .await;
 
                     this.update(&mut cx, |this, cx| {
                         // Discard results if a newer search has since been issued.

--- a/crates/nohrs-services/src/fs/listing.rs
+++ b/crates/nohrs-services/src/fs/listing.rs
@@ -3,7 +3,6 @@ use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
-use tokio::task;
 
 // `FileEntryDto` is a pure data type and lives in `nohrs-models`. It is
 // re-exported here so existing `nohrs_services::fs::listing::FileEntryDto`
@@ -21,20 +20,9 @@ pub struct ListResult {
     pub next_cursor: Option<String>,
 }
 
-pub async fn list_dir(params: ListParams<'_>) -> Result<ListResult> {
-    // Use a blocking task for filesystem IO to avoid blocking async executors.
-    let path = params.path.to_string();
-    let limit = params.limit;
-    let cursor = params.cursor.map(|s| s.to_string());
-
-    task::spawn_blocking(move || list_dir_impl(&path, limit, cursor.as_deref()))
-        .await
-        .map_err(|join_error| {
-            nohrs_core::errors::Error::Other(format!("list_dir task failed: {join_error}"))
-        })?
-}
-
-/// Synchronous variant for UI contexts where an async runtime is not available.
+/// Lists a directory. The work is synchronous filesystem IO; callers that must
+/// keep the UI thread responsive should run it on GPUI's background executor via
+/// `cx.background_spawn` (async-runtime.md §2).
 pub fn list_dir_sync(params: ListParams<'_>) -> Result<ListResult> {
     list_dir_impl(params.path, params.limit, params.cursor)
 }

--- a/crates/nohrs-services/src/search.rs
+++ b/crates/nohrs-services/src/search.rs
@@ -21,6 +21,7 @@ pub struct SearchResult {
 }
 
 pub use backend::SearchBackend;
+pub use engine::InitialIndexingJob;
 
 use anyhow::Result;
 use std::sync::Arc;
@@ -30,13 +31,21 @@ pub struct SearchService {
 }
 
 impl SearchService {
-    pub async fn new() -> Result<Self> {
-        let engine = Arc::new(engine::SearchEngine::new().await?);
+    pub fn new() -> Result<Self> {
+        let engine = Arc::new(engine::SearchEngine::new()?);
         Ok(Self { engine })
     }
 
-    pub async fn search(&self, query: String, scope: SearchScope) -> Result<Vec<SearchResult>> {
-        self.engine.search(query, scope).await
+    /// Search is synchronous; run it on GPUI's background executor
+    /// (`cx.background_spawn`) so the UI thread is not blocked.
+    pub fn search(&self, query: String, scope: SearchScope) -> Result<Vec<SearchResult>> {
+        self.engine.search(query, scope)
+    }
+
+    /// Hands off the one-shot initial-indexing job for the caller to run on a
+    /// background executor. Returns `None` once it has been taken.
+    pub fn take_initial_indexing_job(&self) -> Option<InitialIndexingJob> {
+        self.engine.take_initial_indexing_job()
     }
 
     pub fn progress_subscription(&self) -> tokio::sync::watch::Receiver<f32> {

--- a/crates/nohrs-services/src/search/engine.rs
+++ b/crates/nohrs-services/src/search/engine.rs
@@ -3,9 +3,69 @@ use super::watcher::FileWatcher;
 use super::{SearchBackend, SearchResult, SearchScope};
 use anyhow::{Context, Result};
 use nohrs_core::telemetry::LogErr;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
+
+/// Deferred initial-indexing work handed to the caller so it can run on GPUI's
+/// background executor (`cx.background_spawn`) instead of a `tokio::task::
+/// spawn_blocking` owned by the service (async-runtime.md §2). It carries only
+/// `Send` handles so the GUI can move it onto a worker thread.
+pub struct InitialIndexingJob {
+    index_manager: Arc<IndexManager>,
+    progress_tx: tokio::sync::watch::Sender<f32>,
+}
+
+impl InitialIndexingJob {
+    /// Runs initial indexing if the index is empty or its schema is outdated.
+    /// Synchronous and blocking — intended to be driven by `cx.background_spawn`.
+    pub fn run(self) {
+        let InitialIndexingJob {
+            index_manager,
+            progress_tx,
+        } = self;
+
+        // Check if schema has required fields (detects schema changes)
+        let schema = index_manager.index().schema();
+        let has_filename_field = schema.get_field("filename").is_ok();
+
+        if !has_filename_field {
+            tracing::info!("Schema outdated (missing filename field), forcing full indexing...");
+            progress_tx.send(0.0).log_err();
+            if let Err(e) = index_manager.index_home(Some(progress_tx)) {
+                tracing::error!("Initial indexing failed: {}", e);
+            }
+            return;
+        }
+
+        // Check if index already has documents
+        match index_manager.index().reader() {
+            Ok(reader) => {
+                let doc_count = reader.searcher().num_docs();
+                if doc_count == 0 {
+                    tracing::info!("Index is empty, starting full indexing...");
+                    progress_tx.send(0.0).log_err(); // Reset to 0 for indexing
+                    if let Err(e) = index_manager.index_home(Some(progress_tx)) {
+                        tracing::error!("Initial indexing failed: {}", e);
+                    }
+                } else {
+                    tracing::info!(
+                        "Index already has {} documents, skipping initial indexing",
+                        doc_count
+                    );
+                    // Progress stays at 1.0 (done)
+                }
+            }
+            Err(e) => {
+                tracing::warn!("Failed to read index, running full indexing: {}", e);
+                progress_tx.send(0.0).log_err();
+                if let Err(e) = index_manager.index_home(Some(progress_tx)) {
+                    tracing::error!("Initial indexing failed: {}", e);
+                }
+            }
+        }
+    }
+}
 
 pub struct SearchEngine {
     index_manager: Arc<IndexManager>,
@@ -13,10 +73,12 @@ pub struct SearchEngine {
     _watcher: FileWatcher, // Keep alive
     _watcher_task: JoinHandle<()>,
     progress_rx: tokio::sync::watch::Receiver<f32>,
+    // Taken once by `take_initial_indexing_job`; `None` afterwards.
+    initial_indexing_job: Mutex<Option<InitialIndexingJob>>,
 }
 
 impl SearchEngine {
-    pub async fn new() -> Result<Self> {
+    pub fn new() -> Result<Self> {
         let index_manager = Arc::new(IndexManager::new()?);
 
         #[cfg(target_os = "macos")]
@@ -28,14 +90,18 @@ impl SearchEngine {
             std::path::PathBuf::from("/"),
         ));
 
-        // Channel for watcher events
+        // Channel for watcher events.
+        // P2 (#56 follow-up): replace tokio::sync::mpsc with async-channel and
+        // the tokio::spawn consumer below with cx.background_spawn (async-runtime.md §2).
         let (tx, mut rx) = mpsc::channel(100);
 
         let home_dir = dirs::home_dir().context("Home directory not found")?;
         use std::time::Duration;
         let watcher = FileWatcher::new(home_dir, tx, Duration::from_secs(2))?;
 
-        // Spawn event handler task
+        // Spawn event handler task.
+        // P2: this tokio::spawn + rx.recv().await keeps the residual tokio runtime
+        // alive; move to cx.background_spawn over an async-channel receiver.
         let manager_clone = index_manager.clone();
         let watcher_task = tokio::spawn(async move {
             while let Some(paths) = rx.recv().await {
@@ -45,52 +111,16 @@ impl SearchEngine {
             }
         });
 
-        // Trigger initial indexing in background (only if index is empty or schema changed)
-        let (progress_tx, progress_rx) = tokio::sync::watch::channel(1.0); // Start at 1.0 (done)
-        let initial_manager = index_manager.clone();
-        tokio::task::spawn_blocking(move || {
-            // Check if schema has required fields (detects schema changes)
-            let schema = initial_manager.index().schema();
-            let has_filename_field = schema.get_field("filename").is_ok();
+        // Progress channel for initial indexing (starts at 1.0 == done).
+        // P2: replace tokio::sync::watch with postage::watch (async-runtime.md §2).
+        let (progress_tx, progress_rx) = tokio::sync::watch::channel(1.0);
 
-            if !has_filename_field {
-                tracing::info!(
-                    "Schema outdated (missing filename field), forcing full indexing..."
-                );
-                progress_tx.send(0.0).log_err();
-                if let Err(e) = initial_manager.index_home(Some(progress_tx)) {
-                    tracing::error!("Initial indexing failed: {}", e);
-                }
-                return;
-            }
-
-            // Check if index already has documents
-            match initial_manager.index().reader() {
-                Ok(reader) => {
-                    let doc_count = reader.searcher().num_docs();
-                    if doc_count == 0 {
-                        tracing::info!("Index is empty, starting full indexing...");
-                        progress_tx.send(0.0).log_err(); // Reset to 0 for indexing
-                        if let Err(e) = initial_manager.index_home(Some(progress_tx)) {
-                            tracing::error!("Initial indexing failed: {}", e);
-                        }
-                    } else {
-                        tracing::info!(
-                            "Index already has {} documents, skipping initial indexing",
-                            doc_count
-                        );
-                        // Progress stays at 1.0 (done)
-                    }
-                }
-                Err(e) => {
-                    tracing::warn!("Failed to read index, running full indexing: {}", e);
-                    progress_tx.send(0.0).log_err();
-                    if let Err(e) = initial_manager.index_home(Some(progress_tx)) {
-                        tracing::error!("Initial indexing failed: {}", e);
-                    }
-                }
-            }
-        });
+        // The actual indexing is deferred to the caller (the GUI) so it runs on
+        // GPUI's background executor instead of a service-owned spawn_blocking.
+        let initial_indexing_job = InitialIndexingJob {
+            index_manager: index_manager.clone(),
+            progress_tx,
+        };
 
         Ok(Self {
             index_manager,
@@ -98,6 +128,7 @@ impl SearchEngine {
             _watcher: watcher,
             _watcher_task: watcher_task,
             progress_rx,
+            initial_indexing_job: Mutex::new(Some(initial_indexing_job)),
         })
     }
 
@@ -109,18 +140,25 @@ impl SearchEngine {
         self.index_manager.clone()
     }
 
-    pub async fn search(&self, query: String, scope: SearchScope) -> Result<Vec<SearchResult>> {
-        // Dispatches search to appropriate backend.
-        // Doing this async to not block UI (though underlying backend is sync mostly, we can spawn_blocking if needed).
-        // Since both backends have synchronous search methods currently, we should wrap in spawn_blocking.
+    /// Hands off the one-shot initial-indexing job. Returns `None` if it has
+    /// already been taken. The caller runs `job.run()` on a background executor.
+    pub fn take_initial_indexing_job(&self) -> Option<InitialIndexingJob> {
+        match self.initial_indexing_job.lock() {
+            Ok(mut guard) => guard.take(),
+            Err(poisoned) => {
+                tracing::error!("initial indexing job lock poisoned: {poisoned}");
+                None
+            }
+        }
+    }
 
-        let index_manager = self.index_manager.clone();
-        let root_backend = self.root_backend.clone();
-
-        tokio::task::spawn_blocking(move || match scope {
-            SearchScope::Home => index_manager.as_ref().search(&query),
-            SearchScope::Root => root_backend.as_ref().search(&query),
-        })
-        .await?
+    /// Dispatches a search to the appropriate backend. Both backends are
+    /// synchronous, so callers should invoke this from `cx.background_spawn` to
+    /// keep the UI thread responsive (replaces the former spawn_blocking).
+    pub fn search(&self, query: String, scope: SearchScope) -> Result<Vec<SearchResult>> {
+        match scope {
+            SearchScope::Home => self.index_manager.search(&query),
+            SearchScope::Root => self.root_backend.search(&query),
+        }
     }
 }

--- a/crates/nohrs-services/src/search/watcher.rs
+++ b/crates/nohrs-services/src/search/watcher.rs
@@ -3,6 +3,10 @@ use notify::RecursiveMode;
 use notify_debouncer_mini::{new_debouncer, DebounceEventResult, Debouncer};
 use std::path::PathBuf;
 use std::time::Duration;
+// `notify` / `notify-debouncer-mini` are runtime-agnostic (they drive their own
+// std::thread), so the watcher itself needs no change for the tokio removal.
+// P2 (#56 follow-up): swap this tokio::sync::mpsc sender for an async-channel
+// sender once the consumer task moves off tokio (async-runtime.md §2).
 use tokio::sync::mpsc;
 
 pub struct FileWatcher {

--- a/crates/nohrs/src/app.rs
+++ b/crates/nohrs/src/app.rs
@@ -18,8 +18,6 @@ use nohrs_ui::assets::Assets;
 use nohrs_ui::components::layout::unified_toolbar::UNIFIED_TOOLBAR_HEIGHT;
 use nohrs_ui::window::{self, traffic_lights::TrafficLightsHook};
 use std::sync::Arc;
-use tokio::runtime::Handle;
-use tokio::task;
 
 pub struct NohrsApp;
 
@@ -42,6 +40,23 @@ impl NohrsApp {
         }
         let config_error = config::report_diagnostics(&diagnostics);
 
+        // GPUI drives the app (replacing `#[tokio::main]`; ADR 0004, async-runtime.md
+        // §7 P1). A small residual tokio runtime is kept and entered on this thread
+        // only so the watcher task (`tokio::spawn`) and channels (`tokio::sync::*`)
+        // inside `SearchService::new` still resolve a runtime. P2 removes those last
+        // tokio users and this runtime with them.
+        let runtime = match tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+        {
+            Ok(runtime) => runtime,
+            Err(error) => {
+                tracing::error!("failed to start async runtime: {error}");
+                return;
+            }
+        };
+        let _runtime_guard = runtime.enter();
+
         Application::new().with_assets(Assets).run(move |app: &mut App| {
             gpui_component::init(app);
             let resizable = ResizableState::new(app);
@@ -61,18 +76,25 @@ impl NohrsApp {
                 move |window, cx| {
                     // Initialize SearchService. Failure is non-fatal: the app starts
                     // with full-text search disabled rather than crashing.
-                    let handle = Handle::current();
-                    let search_service: Option<Arc<SearchService>> =
-                        task::block_in_place(move || match handle.block_on(SearchService::new()) {
-                            Ok(service) => Some(Arc::new(service)),
-                            Err(e) => {
-                                tracing::error!(
-                                    "Failed to initialize search service; starting with search disabled: {}",
-                                    e
-                                );
-                                None
-                            }
-                        });
+                    let search_service: Option<Arc<SearchService>> = match SearchService::new() {
+                        Ok(service) => Some(Arc::new(service)),
+                        Err(e) => {
+                            tracing::error!(
+                                "Failed to initialize search service; starting with search disabled: {}",
+                                e
+                            );
+                            None
+                        }
+                    };
+
+                    // Kick off initial indexing on GPUI's background executor, which
+                    // is a thread pool (replacing tokio::task::spawn_blocking;
+                    // async-runtime.md §2).
+                    if let Some(service) = &search_service {
+                        if let Some(job) = service.take_initial_indexing_job() {
+                            cx.background_spawn(async move { job.run() }).detach();
+                        }
+                    }
 
                     let view = cx.new(|cx| {
                         RootView::new(

--- a/crates/nohrs/src/main.rs
+++ b/crates/nohrs/src/main.rs
@@ -3,8 +3,7 @@ mod cli;
 
 use clap::Parser;
 
-#[tokio::main]
-async fn main() {
+fn main() {
     let cli = cli::Cli::parse();
 
     // `config` subcommands run headless and exit without opening a window.


### PR DESCRIPTION
Closes #56 (parent #40). P1 of the tokio removal — see [ADR 0004](docs/adr/0004-remove-tokio.md) and [async-runtime.md §7](docs/async-runtime.md).

## What changed

GPUI's `Application::new().run(...)` is now the entry point instead of `#[tokio::main]`, and `tokio::task::spawn_blocking` is replaced with `cx.background_spawn`.

- **`crates/nohrs/src/main.rs`** — drop `#[tokio::main]`; `main` is a plain `fn`.
- **`crates/nohrs/src/app.rs`** — GPUI drives the app. A small residual multi-thread tokio runtime is built and `enter()`-ed on the main thread **only** so the watcher `tokio::spawn` / `tokio::sync::*` that remain after P1 still resolve a runtime (mirrors the old `#[tokio::main]`; removed in P2). `SearchService` initializes synchronously, and initial indexing runs on `cx.background_spawn`.
- **`crates/nohrs-services/src/search/engine.rs`** — `SearchEngine::new` and `search` are now synchronous. The initial-indexing `spawn_blocking` becomes an `InitialIndexingJob` carrying only `Send` handles, handed to the GUI to run on GPUI's background executor.
- **`crates/nohrs-services/src/search.rs`** — `SearchService` methods made sync; adds `take_initial_indexing_job`.
- **`crates/nohrs-pages/src/explorer/search.rs`** — the now-synchronous search plus result grouping run together inside a single `cx.background_spawn`.
- **`crates/nohrs-services/src/fs/listing.rs`** — remove the unused async `list_dir` (its only `spawn_blocking` site); `list_dir_sync` remains the live path.

### Deferred to P2 (annotated in-code)
Residual `tokio::spawn` (watcher task) and `tokio::sync::{mpsc,watch}` stay only in `nohrs-services`, each with a P2 comment pointing at the replacement (`async-channel` / `postage::watch`). `notify` / `notify-debouncer-mini` are runtime-agnostic and unchanged. `axum` was already absent from every `Cargo.toml` (dropped in the earlier workspace split); removing `tokio` from `Cargo.toml` is P2.

## Verification

Local gate: `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo build`, and `cargo test --workspace` all pass (incl. the `nohrs-services` indexing + watcher tests).

Ran the binary headlessly to confirm it boots via GPUI main with no `#[tokio::main]` — the Explorer renders and directory listing works, and the log shows no "no reactor running" panic from the residual watcher `tokio::spawn`:

![gpui-main-boot](https://raw.githubusercontent.com/noh-rs/nohrs/pr-assets/screenshots/gpui-main-boot/2316395-13520/nohrs-gpui-main.png)

Release Notes:

- N/A

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the app to GPUI as the entry point and remove `#[tokio::main]`. Replace `tokio::task::spawn_blocking` with GPUI's `cx.background_spawn`, make search/listing synchronous, and hand off initial indexing as a background job.

- **Refactors**
  - `crates/nohrs/src/main.rs`: `main` is a plain `fn`; GPUI runs the app.
  - `crates/nohrs/src/app.rs`: init `SearchService` synchronously; start initial indexing via `cx.background_spawn`.
  - `crates/nohrs-services/src/search/engine.rs`: `SearchEngine::new` and `search` are sync; add `InitialIndexingJob` for GPUI background execution.
  - `crates/nohrs-services/src/search.rs`: sync API; add `take_initial_indexing_job`.
  - `crates/nohrs-pages/src/explorer/search.rs`: run sync search + grouping inside one `cx.background_spawn`.
  - `crates/nohrs-services/src/fs/listing.rs`: remove async `list_dir`; keep `list_dir_sync`.
  - Residual watcher uses `tokio::spawn`/channels and is marked for P2 replacement.

- **Dependencies**
  - `axum` is removed (it was already not in `Cargo.toml`).
  - `tokio` remains temporarily in `nohrs-services` for the watcher; full removal in P2.

<sup>Written for commit 9d38e73cda2d1ee69b9ec308ad6b58ce4a0865df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/noh-rs/nohrs/pull/141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured search pipeline for improved background task execution and responsiveness
  * Updated file system operations to use optimized synchronous patterns
  * Enhanced application runtime initialization and background task scheduling
  * Improved integration of search indexing operations with background executor

<!-- end of auto-generated comment: release notes by coderabbit.ai -->