### PR TITLE
nohrs-services: Fix TopDocs collector usage for tantivy 0.26

### DIFF
--- a/crates/nohrs-services/src/search/indexer.rs
+++ b/crates/nohrs-services/src/search/indexer.rs
@@ -338,7 +338,10 @@ impl super::backend::SearchBackend for IndexManager {
         let query = query_parser.parse_query(query_str)?;
 
         // Removed limit from TopDocs to return all results
-        let top_docs = searcher.search(&query, &tantivy::collector::TopDocs::with_limit(10000))?;
+        let top_docs = searcher.search(
+            &query,
+            &tantivy::collector::TopDocs::with_limit(10000).order_by_score(),
+        )?;
 
         let mut results = Vec::new();
         for (_score, doc_address) in top_docs {


### PR DESCRIPTION
## Summary

PR #121 bumped tantivy from 0.22.1 to 0.26.1, but was merged from an auto-rebased Dependabot branch that did not include the required source change, leaving `develop` unable to compile.

In tantivy 0.26, `TopDocs::with_limit(n)` no longer implements `Collector` directly; an ordering method such as `.order_by_score()` must be chained to obtain a `Collector`. This adds `.order_by_score()` at the search call site in `indexer.rs`.

Verified locally:
- `cargo build --locked`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --locked -p nohrs-services`

Release Notes:

- N/A

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix build break after upgrading `tantivy` to 0.26 by updating the search collector to use `TopDocs::with_limit(10000).order_by_score()`. This restores a valid collector and re-enables builds and tests in `nohrs-services`.

<sup>Written for commit 73ab7738f84185c733faa0b083d2d4cfc4b6b96d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/noh-rs/nohrs/pull/142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Search results are now ordered by relevance score, improving the discoverability of the most relevant items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->