### PR TITLE
Add Docker dev/CI environments with Xvnc and GPU support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+target/
+.git/
+.github/
+.claude/
+.factory/
+docs/
+flake.lock
+flake.nix
+.envrc
+.direnv/

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:trixie
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential pkg-config curl ca-certificates \
-    tigervnc-standalone-server xdotool x11-apps python3 procps \
+    tigervnc-standalone-server xdotool x11-apps python3 procps fvwm \
     libxkbcommon-dev libxkbcommon-x11-dev libwayland-dev \
     libxcb-shape0-dev libxcb-xfixes0-dev libxcb1-dev libx11-dev \
     libfontconfig1-dev libfreetype6-dev \

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -1,0 +1,20 @@
+FROM debian:bookworm
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential pkg-config curl ca-certificates \
+    tigervnc-standalone-server xdotool x11-apps xwd python3 \
+    libxkbcommon-dev libxkbcommon-x11-dev libwayland-dev \
+    libxcb-shape0-dev libxcb-xfixes0-dev libxcb1-dev libx11-dev \
+    libfontconfig1-dev libfreetype6-dev \
+    libgl1-mesa-dev libegl1-mesa-dev libvulkan-dev mesa-vulkan-drivers \
+    libssl-dev libsqlite3-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+WORKDIR /nohrs
+COPY rust-toolchain.toml .
+RUN rustup show
+
+CMD ["bash"]

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -1,8 +1,8 @@
-FROM debian:bookworm
+FROM debian:trixie
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential pkg-config curl ca-certificates \
-    tigervnc-standalone-server xdotool x11-apps xwd python3 \
+    tigervnc-standalone-server xdotool x11-apps python3 \
     libxkbcommon-dev libxkbcommon-x11-dev libwayland-dev \
     libxcb-shape0-dev libxcb-xfixes0-dev libxcb1-dev libx11-dev \
     libfontconfig1-dev libfreetype6-dev \

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:trixie
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential pkg-config curl ca-certificates \
-    tigervnc-standalone-server xdotool x11-apps python3 \
+    tigervnc-standalone-server xdotool x11-apps python3 procps \
     libxkbcommon-dev libxkbcommon-x11-dev libwayland-dev \
     libxcb-shape0-dev libxcb-xfixes0-dev libxcb1-dev libx11-dev \
     libfontconfig1-dev libfreetype6-dev \

--- a/docker/ci/docker-compose.gpu.yml
+++ b/docker/ci/docker-compose.gpu.yml
@@ -9,7 +9,7 @@ services:
       - ../..:/nohrs
       - ${HOME}/.cargo/registry:/root/.cargo/registry
       - nohrs-data:/root/.nohrs
-    entrypoint: ["/bin/bash", "-lc", "Xtigervnc :99 -geometry 1280x800 -depth 24 -SecurityTypes None >/tmp/vnc.log 2>&1 & sleep 1 && exec \"$@\"", "--"]
+    entrypoint: ["/bin/bash", "-lc", "Xtigervnc :99 -geometry 1280x800 -depth 24 -SecurityTypes None >/tmp/vnc.log 2>&1 & sleep 1 && DISPLAY=:99 fvwm >/tmp/fvwm.log 2>&1 & sleep 1 && exec \"$@\"", "--"]
     command: ["cargo", "test"]
     deploy:
       resources:

--- a/docker/ci/docker-compose.gpu.yml
+++ b/docker/ci/docker-compose.gpu.yml
@@ -8,7 +8,7 @@ services:
     volumes:
       - ../..:/nohrs
       - ${HOME}/.cargo/registry:/root/.cargo/registry
-    entrypoint: ["/bin/bash", "-lc", "mkdir -p /tmp/.vnc && echo '' | vncpasswd -f > /tmp/.vnc/passwd && chmod 600 /tmp/.vnc/passwd && vncserver :99 -geometry 1280x800 -depth 24 -SecurityTypes None >/tmp/vnc.log 2>&1 && sleep 1 && exec \"$@\"", "--"]
+    entrypoint: ["/bin/bash", "-lc", "Xtigervnc :99 -geometry 1280x800 -depth 24 -SecurityTypes None >/tmp/vnc.log 2>&1 & sleep 1 && exec \"$@\"", "--"]
     command: ["cargo", "test"]
     deploy:
       resources:

--- a/docker/ci/docker-compose.gpu.yml
+++ b/docker/ci/docker-compose.gpu.yml
@@ -8,6 +8,7 @@ services:
     volumes:
       - ../..:/nohrs
       - ${HOME}/.cargo/registry:/root/.cargo/registry
+      - nohrs-data:/root/.nohrs
     entrypoint: ["/bin/bash", "-lc", "Xtigervnc :99 -geometry 1280x800 -depth 24 -SecurityTypes None >/tmp/vnc.log 2>&1 & sleep 1 && exec \"$@\"", "--"]
     command: ["cargo", "test"]
     deploy:
@@ -17,3 +18,6 @@ services:
             - driver: nvidia
               count: all
               capabilities: [gpu]
+
+volumes:
+  nohrs-data:

--- a/docker/ci/docker-compose.gpu.yml
+++ b/docker/ci/docker-compose.gpu.yml
@@ -1,0 +1,19 @@
+services:
+  nohrs:
+    build:
+      context: ../..
+      dockerfile: docker/ci/Dockerfile
+    environment:
+      - DISPLAY=:99
+    volumes:
+      - ../..:/nohrs
+      - ${HOME}/.cargo/registry:/root/.cargo/registry
+    entrypoint: ["/bin/bash", "-lc", "mkdir -p /tmp/.vnc && echo '' | vncpasswd -f > /tmp/.vnc/passwd && chmod 600 /tmp/.vnc/passwd && vncserver :99 -geometry 1280x800 -depth 24 -SecurityTypes None >/tmp/vnc.log 2>&1 && sleep 1 && exec \"$@\"", "--"]
+    command: ["cargo", "test"]
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]

--- a/docker/ci/docker-compose.yml
+++ b/docker/ci/docker-compose.yml
@@ -8,5 +8,9 @@ services:
     volumes:
       - ../..:/nohrs
       - ${HOME}/.cargo/registry:/root/.cargo/registry
+      - nohrs-data:/root/.nohrs
     entrypoint: ["/bin/bash", "-lc", "Xtigervnc :99 -geometry 1280x800 -depth 24 -SecurityTypes None >/tmp/vnc.log 2>&1 & sleep 1 && exec \"$@\"", "--"]
     command: ["cargo", "test"]
+
+volumes:
+  nohrs-data:

--- a/docker/ci/docker-compose.yml
+++ b/docker/ci/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  nohrs:
+    build:
+      context: ../..
+      dockerfile: docker/ci/Dockerfile
+    environment:
+      - DISPLAY=:99
+    volumes:
+      - ../..:/nohrs
+      - ${HOME}/.cargo/registry:/root/.cargo/registry
+    entrypoint: ["/bin/bash", "-lc", "mkdir -p /tmp/.vnc && echo '' | vncpasswd -f > /tmp/.vnc/passwd && chmod 600 /tmp/.vnc/passwd && vncserver :99 -geometry 1280x800 -depth 24 -SecurityTypes None >/tmp/vnc.log 2>&1 && sleep 1 && exec \"$@\"", "--"]
+    command: ["cargo", "test"]

--- a/docker/ci/docker-compose.yml
+++ b/docker/ci/docker-compose.yml
@@ -8,5 +8,5 @@ services:
     volumes:
       - ../..:/nohrs
       - ${HOME}/.cargo/registry:/root/.cargo/registry
-    entrypoint: ["/bin/bash", "-lc", "mkdir -p /tmp/.vnc && echo '' | vncpasswd -f > /tmp/.vnc/passwd && chmod 600 /tmp/.vnc/passwd && vncserver :99 -geometry 1280x800 -depth 24 -SecurityTypes None >/tmp/vnc.log 2>&1 && sleep 1 && exec \"$@\"", "--"]
+    entrypoint: ["/bin/bash", "-lc", "Xtigervnc :99 -geometry 1280x800 -depth 24 -SecurityTypes None >/tmp/vnc.log 2>&1 & sleep 1 && exec \"$@\"", "--"]
     command: ["cargo", "test"]

--- a/docker/ci/docker-compose.yml
+++ b/docker/ci/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - ../..:/nohrs
       - ${HOME}/.cargo/registry:/root/.cargo/registry
       - nohrs-data:/root/.nohrs
-    entrypoint: ["/bin/bash", "-lc", "Xtigervnc :99 -geometry 1280x800 -depth 24 -SecurityTypes None >/tmp/vnc.log 2>&1 & sleep 1 && exec \"$@\"", "--"]
+    entrypoint: ["/bin/bash", "-lc", "Xtigervnc :99 -geometry 1280x800 -depth 24 -SecurityTypes None >/tmp/vnc.log 2>&1 & sleep 1 && DISPLAY=:99 fvwm >/tmp/fvwm.log 2>&1 & sleep 1 && exec \"$@\"", "--"]
     command: ["cargo", "test"]
 
 volumes:

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -1,0 +1,19 @@
+FROM debian:bookworm
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential pkg-config curl ca-certificates \
+    libxkbcommon-dev libxkbcommon-x11-dev libwayland-dev \
+    libxcb-shape0-dev libxcb-xfixes0-dev libxcb1-dev libx11-dev \
+    libfontconfig1-dev libfreetype6-dev \
+    libgl1-mesa-dev libegl1-mesa-dev libvulkan-dev mesa-vulkan-drivers \
+    libssl-dev libsqlite3-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+WORKDIR /nohrs
+COPY rust-toolchain.toml .
+RUN rustup show
+
+CMD ["bash"]

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm
+FROM debian:trixie
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential pkg-config curl ca-certificates \

--- a/docker/dev/docker-compose.gpu.yml
+++ b/docker/dev/docker-compose.gpu.yml
@@ -1,0 +1,19 @@
+services:
+  nohrs:
+    build:
+      context: ../..
+      dockerfile: docker/dev/Dockerfile
+    environment:
+      - DISPLAY
+    volumes:
+      - /tmp/.X11-unix:/tmp/.X11-unix:rw
+      - ${XAUTHORITY:-/dev/null}:/root/.Xauthority:ro
+      - ../..:/nohrs
+      - ${HOME}/.cargo/registry:/root/.cargo/registry
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]

--- a/docker/dev/docker-compose.gpu.yml
+++ b/docker/dev/docker-compose.gpu.yml
@@ -10,6 +10,7 @@ services:
       - ${XAUTHORITY:-/dev/null}:/root/.Xauthority:ro
       - ../..:/nohrs
       - ${HOME}/.cargo/registry:/root/.cargo/registry
+    entrypoint: ["/bin/bash", "-lc", "cargo build -p nohrs && exec cargo run -p nohrs"]
     deploy:
       resources:
         reservations:

--- a/docker/dev/docker-compose.vnc.yml
+++ b/docker/dev/docker-compose.vnc.yml
@@ -1,0 +1,17 @@
+services:
+  nohrs:
+    build:
+      context: ../..
+      dockerfile: docker/ci/Dockerfile
+    environment:
+      - DISPLAY=:99
+    ports:
+      - "5999:5999"
+    volumes:
+      - ../..:/nohrs
+      - ${HOME}/.cargo/registry:/root/.cargo/registry
+      - nohrs-data:/root/.nohrs
+    entrypoint: ["/bin/bash", "-lc", "Xtigervnc :99 -geometry 1280x800 -depth 24 -SecurityTypes None -rfbport 5999 >/tmp/vnc.log 2>&1 & sleep 1 && fvwm >/tmp/fvwm.log 2>&1 & sleep 1 && cargo build -p nohrs && exec cargo run -p nohrs"]
+
+volumes:
+  nohrs-data:

--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  nohrs:
+    build:
+      context: ../..
+      dockerfile: docker/dev/Dockerfile
+    environment:
+      - DISPLAY
+    volumes:
+      - /tmp/.X11-unix:/tmp/.X11-unix:rw
+      - ${XAUTHORITY:-/dev/null}:/root/.Xauthority:ro
+      - ../..:/nohrs
+      - ${HOME}/.cargo/registry:/root/.cargo/registry

--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -10,3 +10,4 @@ services:
       - ${XAUTHORITY:-/dev/null}:/root/.Xauthority:ro
       - ../..:/nohrs
       - ${HOME}/.cargo/registry:/root/.cargo/registry
+    entrypoint: ["/bin/bash", "-lc", "cargo build -p nohrs && exec cargo run -p nohrs"]

--- a/docs/dev-environment.md
+++ b/docs/dev-environment.md
@@ -78,7 +78,8 @@ cargo run --features gui --bin nohrs
 
 | 環境 | GPU (NVIDIA PT) | CPU (llvmpipe) |
 |------|-----------------|----------------|
-| **dev** | ✅ X11 forwarding | ✅ VNC 接続 (port 5999) |
+| **dev X11 forwarding** | ✅ `docker-compose.gpu.yml` | ❌ UI描画されず |
+| **dev VNC 接続** | ✅ `docker-compose.vnc.yml` | ✅ `docker-compose.vnc.yml` |
 | **ci (test)** | ✅ | ✅ |
 | **ci (screenshot)** | ✅ | ✅ |
 

--- a/docs/dev-environment.md
+++ b/docs/dev-environment.md
@@ -15,7 +15,7 @@
 | **Linux native** | `rustup` + apt/pacman で gpui 依存 |
 | **Linux + Nix** | `nix develop` (devshell) |
 | **Linux + Docker (対話開発)** | `docker compose -f docker/dev/docker-compose.yml up` (X11 forwarding) |
-| **Linux + Docker (headless / CI)** | `docker compose -f docker/ci/docker-compose.yml run nohrs <cmd>` (Xvfb) |
+| **Linux + Docker (headless / CI)** | `docker compose -f docker/ci/docker-compose.yml run --rm nohrs <cmd>` (Xvnc) |
 | **macOS host + Docker** | **非推奨**。XQuartz 経由は遅い。native 開発を |
 | **Windows** | **非推奨**。WSL2 + Linux native か WSL2 + Docker |
 
@@ -69,20 +69,32 @@ cargo run --features gui --bin nohrs
 
 ## 4. Docker (Linux host)
 
+### 前提条件
+
+- ユーザーを `docker` グループに追加済み: `sudo usermod -aG docker $USER`（変更後は再ログイン）
+- GPU パススルーを使用する場合は `nvidia-container-toolkit` がインストール済みであること
+
 ### 4.1 docker/dev/ — 対話開発用 (X11 forwarding)
 
 **前提**: Linux host (host の X server を流用)。macOS / Windows host は非推奨。
 
 ```text
 docker/dev/
-├── Dockerfile             # Rust toolchain + gpui 依存をプリインストール
-└── docker-compose.yml     # X11 mount, source mount
+├── Dockerfile                # Rust toolchain + gpui 依存をプリインストール
+├── docker-compose.yml        # X11 mount, source mount（llvmpipe ソフトウェア描画）
+└── docker-compose.gpu.yml    # NVIDIA GPU パススルー付き
 ```
 
 **起動**:
 ```bash
 xhost +local:docker        # host の X server 利用を許可
+
+# GPU あり（推奨）
+docker compose -f docker/dev/docker-compose.gpu.yml up
+
+# GPU なし（llvmpipe）※ ERROR_SURFACE_LOST_KHR でクラッシュする場合あり
 docker compose -f docker/dev/docker-compose.yml up
+
 # コンテナ内で:
 cargo run --features gui --bin nohrs
 ```
@@ -95,23 +107,33 @@ cargo run --features gui --bin nohrs
 | `~/.cargo/registry` | Cargo cache の永続化 |
 | 環境変数 `DISPLAY` | host の display を渡す |
 
-### 4.2 docker/ci/ — Xvfb headless
+> **注意**: GPU なし（llvmpipe）環境では `ERROR_SURFACE_LOST_KHR` でクラッシュすることがあります。GPU パススルーを推奨します。
 
-CI / AI agent / 自動スクリーンショット用。
+### 4.2 docker/ci/ — Xvnc headless
+
+CI / AI agent / 自動スクリーンショット用。Xvfb ではなく Xvnc（実フレームバッファ）を使用し、スクリーンショットの黒画面問題を回避します。
 
 ```text
 docker/ci/
-├── Dockerfile             # Xvfb + Rust toolchain + nohrs ビルド依存
-└── docker-compose.yml
+├── Dockerfile                # Xvnc + Rust toolchain + nohrs ビルド依存 + スクショツール
+├── docker-compose.yml        # Xvnc + llvmpipe（GPU なし）
+└── docker-compose.gpu.yml    # NVIDIA GPU パススルー付き
 ```
 
 **使用例**:
 ```bash
-docker compose -f docker/ci/docker-compose.yml run nohrs cargo test
-docker compose -f docker/ci/docker-compose.yml run nohrs bash script/ui-run.sh shot
+# GPU あり（cargo test）
+docker compose -f docker/ci/docker-compose.gpu.yml run --rm nohrs cargo test
+
+# GPU なし（cargo test）
+docker compose -f docker/ci/docker-compose.yml run --rm nohrs cargo test
+
+# スクリーンショット
+docker compose -f docker/ci/docker-compose.gpu.yml run --rm \
+  nohrs bash -c "cargo build -p nohrs && script/ui-run.sh shot /nohrs/screenshot.png"
 ```
 
-GitHub Actions では Ubuntu runner で同 image を使用。
+GitHub Actions では Ubuntu runner で同 image を使用（#50 と連携）。
 
 ---
 

--- a/docs/dev-environment.md
+++ b/docs/dev-environment.md
@@ -14,7 +14,7 @@
 | **macOS native** | `rustup` + Xcode + Metal toolchain |
 | **Linux native** | `rustup` + apt/pacman で gpui 依存 |
 | **Linux + Nix** | `nix develop` (devshell) |
-| **Linux + Docker (対話開発)** | `docker compose -f docker/dev/docker-compose.yml up` (X11 forwarding) |
+| **Linux + Docker (対話開発)** | `docker compose -f docker/dev/docker-compose.gpu.yml up` (GPU) / `docker-compose.vnc.yml up` (CPU) |
 | **Linux + Docker (headless / CI)** | `docker compose -f docker/ci/docker-compose.yml run --rm nohrs <cmd>` (Xvnc) |
 | **macOS host + Docker** | **非推奨**。XQuartz 経由は遅い。native 開発を |
 | **Windows** | **非推奨**。WSL2 + Linux native か WSL2 + Docker |
@@ -74,49 +74,47 @@ cargo run --features gui --bin nohrs
 - ユーザーを `docker` グループに追加済み: `sudo usermod -aG docker $USER`（変更後は再ログイン）
 - GPU パススルーを使用する場合は `nvidia-container-toolkit` がインストール済みであること
 
-### 4.1 docker/dev/ — 対話開発用 (X11 forwarding)
+### 動作対応表
 
-**前提**: Linux host (host の X server を流用)。macOS / Windows host は非推奨。
+| 環境 | GPU (NVIDIA PT) | CPU (llvmpipe) |
+|------|-----------------|----------------|
+| **dev** | ✅ X11 forwarding | ✅ VNC 接続 (port 5999) |
+| **ci (test)** | ✅ | ✅ |
+| **ci (screenshot)** | ✅ | ✅ |
+
+### 4.1 docker/dev/ — 対話開発用
+
+**前提**: Linux host。macOS / Windows host は非推奨。
 
 ```text
 docker/dev/
 ├── Dockerfile                # Rust toolchain + gpui 依存をプリインストール
-├── docker-compose.yml        # X11 mount, source mount（llvmpipe ソフトウェア描画）
-└── docker-compose.gpu.yml    # NVIDIA GPU パススルー付き
+├── docker-compose.gpu.yml    # NVIDIA GPU パススルー（X11 forwarding）
+├── docker-compose.vnc.yml    # TigerVNC + fvwm（GPU なし / llvmpipe 用）
+└── docker-compose.yml        # X11 forwarding（llvmpipe ⚠ UI 描画されず）
 ```
 
 **起動**:
 ```bash
-xhost +local:docker        # host の X server 利用を許可
-
-# GPU あり（推奨）
+# GPU あり（X11 forwarding、推奨）
+xhost +local:docker
 docker compose -f docker/dev/docker-compose.gpu.yml up
 
-# GPU なし（llvmpipe）※ ERROR_SURFACE_LOST_KHR でクラッシュする場合あり
-docker compose -f docker/dev/docker-compose.yml up
-
-# コンテナ内で:
-cargo run --features gui --bin nohrs
+# GPU なし（VNC 接続）
+docker compose -f docker/dev/docker-compose.vnc.yml up
+# → VNC クライアントで localhost:5999 に接続
 ```
 
-| マウント | 用途 |
-|---------|------|
-| `/tmp/.X11-unix:/tmp/.X11-unix:rw` | X11 socket |
-| `$XAUTHORITY:/root/.Xauthority:ro` | X11 認証 |
-| プロジェクトルート | source code |
-| `~/.cargo/registry` | Cargo cache の永続化 |
-| 環境変数 `DISPLAY` | host の display を渡す |
-
-> **注意**: GPU なし（llvmpipe）環境では `ERROR_SURFACE_LOST_KHR` でクラッシュすることがあります。GPU パススルーを推奨します。
+> **注意**: `docker-compose.yml`（X11 forwarding + llvmpipe）は GPUI の Vulkan WSI present がホスト X11 で正しく動作しないため、GPU なし環境では `docker-compose.vnc.yml` を使用してください。
 
 ### 4.2 docker/ci/ — Xvnc headless
 
-CI / AI agent / 自動スクリーンショット用。Xvfb ではなく Xvnc（実フレームバッファ）を使用し、スクリーンショットの黒画面問題を回避します。
+CI / AI agent / 自動スクリーンショット用。TigerVNC + fvwm を使用し、Xvfb の黒画面問題を回避します。
 
 ```text
 docker/ci/
-├── Dockerfile                # Xvnc + Rust toolchain + nohrs ビルド依存 + スクショツール
-├── docker-compose.yml        # Xvnc + llvmpipe（GPU なし）
+├── Dockerfile                # TigerVNC + fvwm + Rust toolchain + スクショツール
+├── docker-compose.yml        # TigerVNC + fvwm + llvmpipe（GPU なし）
 └── docker-compose.gpu.yml    # NVIDIA GPU パススルー付き
 ```
 


### PR DESCRIPTION
## Summary
- Add `docker/dev/` for interactive development (X11 forwarding for GPU, VNC for llvmpipe)
- Add `docker/ci/` for headless CI/screenshot using **TigerVNC** + **fvwm** instead of Xvfb
- Add `.dockerignore` to exclude target/, .git/, nix artifacts from build context
- Update `docs/dev-environment.md` §4 to reflect actual file structure and GPU/non-GPU usage

Closes #52 (Docker portion; Nix devshell was already merged in #137)

## File structure
```
docker/
├── dev/
│   ├── Dockerfile                # Rust toolchain + gpui deps (debian:trixie)
│   ├── docker-compose.yml        # X11 forwarding（llvmpipe ⚠ UI出ない）
│   ├── docker-compose.gpu.yml    # NVIDIA GPU パススルー
│   └── docker-compose.vnc.yml    # TigerVNC + fvwm（llvmpipe ✅）
└── ci/
    ├── Dockerfile                # TigerVNC + fvwm + Rust toolchain + screenshot tools
    ├── docker-compose.yml        # Xvnc + fvwm + llvmpipe
    └── docker-compose.gpu.yml    # NVIDIA GPU パススルー
```

## 動作確認結果

| 環境 | GPU | CPU (llvmpipe) |
|------|-----|----------------|
| **dev** | ✅ X11 forwarding | ✅ VNC接続 (port 5999) |
| **ci (test)** | ✅ 20/20 passed | ✅ 20/20 passed |
| **ci (screenshot)** | ✅ 78KB 正常UI | ✅ 79KB 正常UI |

### dev + llvmpipe の注意事項
ホストX11転送では llvmpipe の Vulkan WSI present がウィンドウを更新しないため、`docker-compose.vnc.yml`（TigerVNC + fvwm）を使用する必要がある。VNCクライアントで `localhost:5999` に接続。

### CI に fvwm が必須な理由
GPUI の X11 バックエンドは `MapNotify` / `VisibilityNotify` イベントがないとレンダリングループを開始しない。WM なしでは黒画面になる。

## Test plan
- [x] `docker compose -f docker/dev/docker-compose.gpu.yml up` で GUI が起動する
- [x] `docker compose -f docker/dev/docker-compose.vnc.yml up` + VNC接続で llvmpipe が表示される
- [x] `docker compose -f docker/ci/docker-compose.gpu.yml run --rm nohrs cargo test` が動作する
- [x] `docker compose -f docker/ci/docker-compose.yml run --rm nohrs cargo test` が動作する（llvmpipe）
- [x] `docker compose -f docker/ci/docker-compose.gpu.yml run --rm nohrs bash -c "cargo build -p nohrs && script/ui-run.sh shot /nohrs/screenshot.png"` でスクショ取得
- [x] `docker compose -f docker/ci/docker-compose.yml run --rm nohrs bash -c "cargo build -p nohrs && script/ui-run.sh shot /nohrs/screenshot.png"` でスクショ取得（llvmpipe）

## Suggested .rules additions
_None_

Release Notes:

- Added Docker dev environment (X11 forwarding + VNC) and CI environment (Xvnc headless) with NVIDIA GPU passthrough support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Docker containerization for development and CI environments with CPU and GPU support options
  * Implemented VNC server integration for remote desktop access during containerized testing and development
  * Established shared volume mounts for Rust build artifacts and dependencies across containers
  * Updated development environment documentation with detailed Docker setup instructions and usage guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->