### PR TITLE
Add CI matrix, cargo-deny, and coverage jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,17 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Least privilege by default; the coverage job opts into `code-quality: write`.
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-D warnings"
 
 jobs:
-  check:
-    name: fmt / clippy / test
+  fmt:
+    name: fmt
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -33,21 +37,175 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
-          components: rustfmt, clippy
-
-      - name: Cache cargo artifacts
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+          components: rustfmt
 
       - name: Format
         run: cargo fmt --all --check
 
-      # gpui renders with Metal and only builds on macOS, so the `gui`
-      # feature (and its `[[bin]]`) is excluded from the Linux CI build.
-      - name: Clippy
-        run: cargo clippy --all-targets -- -D warnings
+  # gpui renders with Metal/Blade and the GUI stack is only exercised on macOS.
+  # Linux therefore lints/tests/builds the headless `default-members` subset
+  # (nohrs-core / nohrs-models / nohrs-services without its `gui` feature), while
+  # macOS covers the full workspace with `--all-features` (pulling in gpui). This
+  # mirrors the `default-members` split documented in the workspace Cargo.toml.
+  clippy:
+    name: clippy (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            args: "--all-targets"
+          - os: macos-latest
+            args: "--workspace --all-targets --all-features"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
-      - name: Build
-        run: cargo build --locked
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          components: clippy
+
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
+      # `unwrap_used` / `expect_used` are enforced as warn-level workspace lints
+      # (see [workspace.lints.clippy] in Cargo.toml), promoted to errors here by
+      # `-D warnings`. Tests are exempt via clippy.toml.
+      - name: Clippy
+        run: cargo clippy ${{ matrix.args }} --locked -- -D warnings
+
+  test:
+    name: test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            args: ""
+          - os: macos-latest
+            args: "--workspace --all-features"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Test
-        run: cargo test --locked
+        run: cargo test ${{ matrix.args }} --locked
+
+  build:
+    name: build (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # lib only (headless default-members)
+          - os: ubuntu-latest
+            args: ""
+          # full workspace including the gpui-backed `nohrs` binary
+          - os: macos-latest
+            args: "--workspace"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
+      - name: Build
+        run: cargo build ${{ matrix.args }} --locked
+
+  # `bans` / `licenses` / `sources` are the required gate. `advisories` runs as a
+  # separate informational step (continue-on-error) so transitive advisories from
+  # the gpui async stack are surfaced without blocking merge (see deny.toml).
+  deny:
+    name: cargo-deny
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install cargo-deny
+        uses: taiki-e/install-action@e49978b799e49ff429d162b7a30601a569ab6538 # v2.81.1
+        with:
+          tool: cargo-deny
+
+      - name: cargo-deny (bans / licenses / sources)
+        run: cargo deny check bans licenses sources
+
+      - name: cargo-deny (advisories, informational)
+        continue-on-error: true
+        run: cargo deny check advisories
+
+  # Coverage is informational during P1–P5 (target: core 80% / overall 50%); it
+  # never blocks merge. The Cobertura XML report feeds GitHub's native code
+  # coverage (PR diff inline; requires Code Quality enabled in repo settings);
+  # the browsable HTML report is uploaded as a downloadable CI artifact (no
+  # external hosting).
+  coverage:
+    name: coverage
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      contents: read
+      code-quality: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          components: llvm-tools-preview
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@e49978b799e49ff429d162b7a30601a569ab6538 # v2.81.1
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
+      # Headless libraries only (default-members); `--all-features` is omitted so
+      # the Linux runner does not pull in gpui. GUI coverage is a future macOS
+      # extension. The HTML report reuses the profile data collected here, so it
+      # does not re-run the tests.
+      - name: Generate Cobertura XML
+        run: cargo llvm-cov --locked --cobertura --output-path cobertura.xml
+
+      - name: Generate HTML report
+        run: cargo llvm-cov report --html --output-dir target/llvm-cov
+
+      # GitHub native code coverage (PR diff inline). Skipped for PRs from forks,
+      # which cannot write coverage data.
+      - name: Upload coverage to GitHub
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+        uses: actions/upload-code-coverage@abb5995db9e0199b0e2bb9dbd136fce4cb1ec4d3 # v1
+        with:
+          file: cobertura.xml
+          language: Rust
+          label: code-coverage/cargo-llvm-cov
+
+      # Browsable line-by-line report. Download the artifact and open index.html.
+      - name: Upload HTML report artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-html
+          path: target/llvm-cov/html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,7 @@ jobs:
     permissions:
       contents: read
       code-quality: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -208,7 +209,43 @@ jobs:
 
       # Browsable line-by-line report. Download the artifact and open index.html.
       - name: Upload HTML report artifact
+        id: html
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-html
           path: target/llvm-cov/html
+
+      # Post (or update) a PR comment with the line coverage and a link to
+      # download the HTML report artifact. Skipped for fork PRs (read-only token).
+      - name: Comment coverage summary on PR
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          ARTIFACT_URL: ${{ steps.html.outputs.artifact-url }}
+        with:
+          script: |
+            const fs = require('fs');
+            const xml = fs.readFileSync('cobertura.xml', 'utf8');
+            const match = xml.match(/line-rate="([0-9.]+)"/);
+            const pct = match ? (parseFloat(match[1]) * 100).toFixed(2) : 'n/a';
+            const marker = '<!-- coverage-report -->';
+            const body = `${marker}\n`
+              + `📊 **Coverage: ${pct}%** (line-rate, headless library subset)\n\n`
+              + `[⬇️ Download the HTML report](${process.env.ARTIFACT_URL}) — `
+              + `unzip and open \`index.html\` for the line-by-line view.\n\n`
+              + `> Informational during P1–P5 (target: core 80% / overall 50%). `
+              + `Does not block merge.`;
+            const { data: comments } = await github.rest.issues.listComments({
+              ...context.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find((c) => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                ...context.repo, comment_id: existing.id, body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                ...context.repo, issue_number: context.issue.number, body,
+              });
+            }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,9 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
+          # Check out the PR head (not the synthetic merge commit) so coverage
+          # line mapping matches GitHub's native diff annotations.
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,12 @@ Run these before pushing — they mirror what CI enforces:
 cargo fmt --all --check
 cargo clippy --all-targets -- -D warnings
 cargo test
+cargo deny check bans licenses sources   # license / dependency policy
 ```
+
+CI runs these on Linux against the headless library subset and additionally on
+macOS across the full workspace (`--workspace --all-features`, which builds the
+gpui GUI). `cargo deny check advisories` also runs in CI but is informational.
 
 Coding conventions (error handling, naming, avoiding panics, GPUI patterns) are
 documented in [`.rules`](.rules) / `CLAUDE.md`. Highlights:
@@ -89,6 +94,22 @@ documented in [`.rules`](.rules) / `CLAUDE.md`. Highlights:
   executor timer (`cx.background_executor.timer(...).await`) and
   `run_until_parked()` — **not** `smol::Timer` / `tokio::time::sleep`, which the
   GPUI scheduler doesn't track. See [`docs/testing.md`](docs/testing.md).
+
+### Coverage
+
+Generate an HTML coverage report locally with
+[`cargo-llvm-cov`](https://github.com/taiki-e/cargo-llvm-cov)
+(`cargo install cargo-llvm-cov`):
+
+```sh
+cargo llvm-cov --all-features --html
+open target/llvm-cov/html/index.html   # xdg-open on Linux
+```
+
+CI feeds a Cobertura XML report into GitHub's native code coverage (inline PR
+diff coverage) and uploads the HTML report as a downloadable `coverage-html`
+artifact on each run. Coverage is informational during P1–P5 (target: core 80%
+/ overall 50%) and does not block merge.
 
 ## License
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,8 +108,9 @@ open target/llvm-cov/html/index.html   # xdg-open on Linux
 
 CI feeds a Cobertura XML report into GitHub's native code coverage (inline PR
 diff coverage) and uploads the HTML report as a downloadable `coverage-html`
-artifact on each run. Coverage is informational during P1–P5 (target: core 80%
-/ overall 50%) and does not block merge.
+artifact, linked from a PR comment alongside the overall line coverage. Coverage
+is informational during P1–P5 (target: core 80% / overall 50%) and does not
+block merge.
 
 ## License
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,55 @@
+# cargo-deny configuration — licenses, advisories, dependency bans, sources.
+# Mirrors docs/testing.md §3. The CI `deny` job runs `cargo deny check`.
+# Detailed tuning of this file is tracked in #54.
+
+[advisories]
+# In CI, `bans`/`licenses`/`sources` are the required gate; `advisories` runs as
+# an informational (non-blocking) step — see .github/workflows/ci.yml. The gpui
+# async stack pulls several crates with open advisories that we cannot fix until
+# upstream bumps; surfacing them without blocking matches testing.md's
+# "informational early" stance. Tracked in #54.
+db-urls = ["https://github.com/RustSec/advisory-db"]
+# Only flag unmaintained crates we depend on directly; transitive ones from the
+# gpui stack are out of our control.
+unmaintained = "workspace"
+yanked = "deny"
+ignore = []
+
+[licenses]
+# Permissive licenses only. Extend deliberately (a new entry means a new license
+# is now allowed across the whole dependency tree).
+allow = [
+  "MIT",
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "ISC",
+  "Zlib",
+  "0BSD",
+  "Unicode-3.0",
+  "MPL-2.0",
+  "CC0-1.0",
+  # NCSA (University of Illinois/NCSA): OSI-approved permissive license, reached
+  # via gpui → image → ravif → rav1e → libfuzzer-sys.
+  "NCSA",
+]
+confidence-threshold = 0.93
+
+[bans]
+multiple-versions = "warn"
+wildcards = "allow"
+deny = [
+  # rustls unification — no OpenSSL in the tree.
+  { name = "openssl-sys" },
+  # NOTE: testing.md §3 also bans tokio outside the WASI plugin-execution layer
+  # (nohrs-plugin-host, P4+). It cannot be enforced yet: gpui pulls a full async
+  # reqwest stack (h2/hyper/tokio-util/...) that transitively depends on tokio,
+  # which the `wrappers` mechanism cannot express. App-core tokio removal (ADR
+  # 0004) and re-introducing this ban are tracked in #54.
+]
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-git = []


### PR DESCRIPTION
Restructures CI and adds the coverage pipeline. Implements #50 and #51.

## What changed

**CI workflow (`ci.yml`) — #50**
- Split the single `check` job into per-tool jobs: `fmt`, `clippy`, `test`, `build`, `deny`, `coverage`.
- macOS + Linux matrix for `clippy` / `test` / `build`. gpui renders with Metal/Blade and only builds on macOS, so Linux runs the headless `default-members` subset and macOS runs the full workspace with `--all-features` (mirrors the `default-members` split in the workspace `Cargo.toml`). The completion-criterion `cargo test --all-features --workspace` is satisfied on the macOS leg.
- `unwrap_used` / `expect_used` are already enforced as warn-level `[workspace.lints.clippy]` (tests exempt via `clippy.toml`) and promoted to errors by `-D warnings`, so no extra clippy flags are needed.
- Added `permissions: contents: read` at the workflow level (least privilege).

**`deny.toml` (new) — #50 / coordinates with #54**
- Licenses / bans / sources are the required gate (`cargo deny check bans licenses sources`, verified green locally). Allow-list tuned to the actual tree (adds NCSA, 0BSD, etc., reached via the gpui image stack).
- `advisories` runs as a separate **informational** step (`continue-on-error`): the gpui async stack (vendored reqwest/rustls/webpki) carries several transitive advisories we cannot fix until upstream bumps. They are surfaced without blocking, matching `testing.md`'s "informational early" stance.
- The `tokio` ban from `testing.md §3` is intentionally omitted: gpui pulls a full async reqwest stack that transitively depends on tokio, which the `wrappers` mechanism cannot express. App-core tokio removal (ADR 0004) and re-introducing this ban are left to #54.

**Coverage job — #51**
- `cargo llvm-cov` emits a **Cobertura XML** report for GitHub's native code coverage (inline PR diff), uploaded via `actions/upload-code-coverage@v1` with `code-quality: write` and a fork guard.
- The browsable HTML report is uploaded as a downloadable `coverage-html` artifact.
- Coverage is informational during P1–P5 (target: core 80% / overall 50%) and never blocks merge (`continue-on-error`).

This trades the issue's R2 / `coverage.nohrs.app` / Worker hosting for GitHub-native coverage + a CI artifact (no external infra, no Cloudflare secrets). The R2 HTML hosting can be revisited under #55 if a public browsable URL is wanted later.

## Required repository setup
- Enable **Code Quality** in repo settings so GitHub native coverage ingests the Cobertura report. Until then the upload step no-ops (the coverage job is `continue-on-error`).

## Verification
Not a UI change. Verified locally on Linux:
- `cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, `cargo build`, `cargo test` — all green.
- `cargo deny check bans licenses sources` — `bans ok, licenses ok, sources ok` (cargo-deny 0.19.8).
- `cargo llvm-cov --cobertura` produces valid Cobertura XML (line-rate ~0.59) and `cargo llvm-cov report --html` produces the HTML report.
- The macOS matrix legs and `actions/upload-code-coverage` could not be exercised locally; they run on first CI.

Release Notes:

- N/A

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restructures CI into per-tool matrix jobs, adds `cargo-deny` policy, and enables code coverage with `cargo-llvm-cov` + GitHub-native reporting, including a PR coverage comment with an HTML report link. Implements #50 and #51.

- **New Features**
  - Split CI into `fmt`, `clippy`, `test`, `build`, `deny`, `coverage` with least-privilege.
  - Matrix: Linux lints/tests/builds headless default-members; macOS runs `--workspace --all-features` (includes gpui).
  - `deny.toml`: enforce bans/licenses/sources; `advisories` is informational.
  - Coverage: Cobertura XML via `actions/upload-code-coverage`; HTML `coverage-html` artifact; upserts a PR comment showing line coverage and a download link; checks out PR head SHA for correct diff; coverage is informational.

- **Migration**
  - Enable Code Quality in repo settings to ingest Cobertura reports for inline PR coverage.

<sup>Written for commit 6d128b38d09ca19f492123453513c1069392b3ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/noh-rs/nohrs/pull/144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI reorganized into focused jobs (format, lint, test, build) with tighter default permissions.
  * Added automated dependency/license/source compliance checks with non-blocking advisories and explicit bans/policies.
  * Added coverage generation, upload of an HTML artifact, and a PR coverage summary comment (skipped for forked PRs).

* **Documentation**
  * Updated contribution guide with compliance checklist and local/CI coverage instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->