### PR TITLE
Add static-analysis config and enforce workspace doc coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,25 @@ jobs:
       - name: Format
         run: cargo fmt --all --check
 
+  # Spell check (required). Project proper nouns are allow-listed in typos.toml.
+  # Note: this workflow skips doc-only changes via `paths-ignore`, so typos gates
+  # code/comment spelling; prose in `docs/**` / `**.md` is not checked here.
+  typos:
+    name: typos
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install typos
+        uses: taiki-e/install-action@e49978b799e49ff429d162b7a30601a569ab6538 # v2.81.1
+        with:
+          tool: typos
+
+      - name: Spell check
+        run: typos
+
   # gpui renders with Metal/Blade and the GUI stack is only exercised on macOS.
   # Linux therefore lints/tests/builds the headless `default-members` subset
   # (nohrs-core / nohrs-models / nohrs-services without its `gui` feature), while

--- a/.github/workflows/machete.yml
+++ b/.github/workflows/machete.yml
@@ -1,0 +1,31 @@
+# Unused-dependency check (docs/testing.md §3). Run weekly rather than per-PR:
+# cargo-machete is advisory and occasionally false-positives on deps used only
+# behind a feature or in a macro, so it should not gate every merge. Also runs on
+# demand via the Actions "Run workflow" button.
+name: machete
+
+on:
+  schedule:
+    # Mondays at 06:00 UTC.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  machete:
+    name: cargo-machete
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install cargo-machete
+        uses: taiki-e/install-action@e49978b799e49ff429d162b7a30601a569ab6538 # v2.81.1
+        with:
+          tool: cargo-machete
+
+      - name: Check for unused dependencies
+        run: cargo machete

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,10 +46,9 @@ time               = { version = "0.3", features = ["formatting", "macros"] }
 
 [workspace.lints.rust]
 unsafe_code  = "deny"
-missing_docs = "allow"   # TODO(#48): raise to "warn" (P1 target) once public APIs are
-                         # documented, then to "deny" (P7). Kept at "allow" for now so the
-                         # CI gate `cargo clippy -- -D warnings` stays green through the
-                         # workspace split, which does not add docs to the ~5k LOC surface.
+# Every public item must carry a doc comment (testing.md §3). Promoted to an
+# error in CI by `-D warnings`; to be raised to "deny" in P7 (#48).
+missing_docs = "warn"
 
 [workspace.lints.clippy]
 unwrap_used = "warn"

--- a/clippy.toml
+++ b/clippy.toml
@@ -3,3 +3,16 @@
 # docs/architecture.md §5, so allow them in test code.
 allow-unwrap-in-tests = true
 allow-expect-in-tests = true
+
+# Synchronous filesystem calls are banned in app code: blocking I/O on the GPUI
+# foreground thread stalls rendering. Route reads/writes through
+# `nohrs-services::fs` or move them onto a background task
+# (`cx.background_spawn` / `spawn_blocking`). The few legitimate exceptions
+# (startup config load before the UI exists, reads already on a background
+# thread) carry an explicit `#[allow(clippy::disallowed_methods)]` with a
+# reason; test fixtures allow the lint at the `mod tests` level.
+disallowed-methods = [
+  { path = "std::fs::read", reason = "use nohrs-services::fs or cx.background_spawn" },
+  { path = "std::fs::write", reason = "use nohrs-services::fs or cx.background_spawn" },
+  { path = "std::fs::read_to_string", reason = "use nohrs-services::fs or cx.background_spawn" },
+]

--- a/crates/nohrs-core/src/config.rs
+++ b/crates/nohrs-core/src/config.rs
@@ -23,15 +23,20 @@ pub use settings::{
 };
 pub use watcher::ConfigWatcher;
 
-/// Default window dimensions on first launch (logical pixels).
+/// Default window width on first launch (logical pixels).
 pub const WINDOW_WIDTH: f32 = 1280.0;
+/// Default window height on first launch (logical pixels).
 pub const WINDOW_HEIGHT: f32 = 780.0;
 
-/// Initial widths of the explorer table columns (logical pixels).
+/// Initial width of the name column in the explorer table (logical pixels).
 pub const COL_NAME_WIDTH: f32 = 400.0;
+/// Initial width of the type column in the explorer table (logical pixels).
 pub const COL_TYPE_WIDTH: f32 = 120.0;
+/// Initial width of the size column in the explorer table (logical pixels).
 pub const COL_SIZE_WIDTH: f32 = 120.0;
+/// Initial width of the modified column in the explorer table (logical pixels).
 pub const COL_MODIFIED_WIDTH: f32 = 180.0;
+/// Initial width of the action column in the explorer table (logical pixels).
 pub const COL_ACTION_WIDTH: f32 = 60.0;
 
 /// Smallest width a column may be resized to (logical pixels).
@@ -41,9 +46,11 @@ pub const MIN_COLUMN_WIDTH: f32 = 80.0;
 /// total table width (left + right row padding).
 pub const TABLE_HORIZONTAL_PADDING: f32 = 48.0;
 
-/// Heights of the rows rendered in the explorer table (logical pixels).
+/// Height of the header row in the explorer table (logical pixels).
 pub const HEADER_ROW_HEIGHT: f32 = 48.0;
+/// Height of a regular entry row in the explorer table (logical pixels).
 pub const BASE_ROW_HEIGHT: f32 = 32.0;
+/// Height of a match snippet row under an expanded result (logical pixels).
 pub const SNIPPET_ROW_HEIGHT: f32 = 24.0;
 
 /// Maximum number of match snippets shown under an expanded search result.

--- a/crates/nohrs-core/src/config/loader.rs
+++ b/crates/nohrs-core/src/config/loader.rs
@@ -25,6 +25,9 @@ fn ensure_parent_dir(path: &Path) -> io::Result<()> {
 /// must preserve the old contents should [`backup`] first.
 pub fn write_default(path: &Path) -> io::Result<()> {
     ensure_parent_dir(path)?;
+    // Config is loaded/written synchronously at startup, before the GPUI
+    // foreground loop runs, so blocking I/O here cannot stall rendering.
+    #[allow(clippy::disallowed_methods)]
     std::fs::write(path, Config::default_toml_template())
 }
 
@@ -74,7 +77,7 @@ pub fn needs_migration(version: u64) -> bool {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[allow(clippy::unwrap_used, clippy::disallowed_methods)]
 mod tests {
     use super::*;
     use tempfile::tempdir;

--- a/crates/nohrs-core/src/config/settings.rs
+++ b/crates/nohrs-core/src/config/settings.rs
@@ -113,7 +113,7 @@ impl ThemeMode {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
-/// Column a directory listing is sorted by.
+/// The column a directory listing is ordered by.
 pub enum SortOrder {
     /// Sort alphabetically by entry name.
     #[default]

--- a/crates/nohrs-core/src/config/settings.rs
+++ b/crates/nohrs-core/src/config/settings.rs
@@ -30,7 +30,9 @@ pub const SCHEMA_URL: &str = "https://nohrs.app/schema/config.schema.json";
 pub struct Config {
     /// On-disk schema version. Must be [`CURRENT_SCHEMA_VERSION`] for this build.
     pub schema_version: u64,
+    /// Appearance settings.
     pub theme: Theme,
+    /// Explorer / view settings.
     pub ui: Ui,
 }
 
@@ -86,10 +88,14 @@ impl Default for Ui {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
+/// Light/dark appearance selection.
 pub enum ThemeMode {
+    /// Follow the operating system's light/dark preference.
     #[default]
     System,
+    /// Always use the light appearance.
     Light,
+    /// Always use the dark appearance.
     Dark,
 }
 
@@ -107,11 +113,16 @@ impl ThemeMode {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
+/// Column a directory listing is sorted by.
 pub enum SortOrder {
+    /// Sort alphabetically by entry name.
     #[default]
     Name,
+    /// Sort by last-modified time.
     Modified,
+    /// Sort by file size.
     Size,
+    /// Sort by entry kind (file/directory/...).
     Kind,
 }
 
@@ -142,7 +153,9 @@ pub enum DiagnosticLevel {
 /// A single message produced while loading configuration.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Diagnostic {
+    /// Severity of the message.
     pub level: DiagnosticLevel,
+    /// Human-readable description of the problem.
     pub message: String,
 }
 
@@ -167,10 +180,15 @@ impl Diagnostic {
 /// actually provided should take effect.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct ConfigOverride {
+    /// Override for [`Theme::mode`].
     pub theme_mode: Option<ThemeMode>,
+    /// Override for [`Theme::accent`].
     pub theme_accent: Option<String>,
+    /// Override for [`Ui::default_sort`].
     pub ui_default_sort: Option<SortOrder>,
+    /// Override for [`Ui::show_hidden`].
     pub ui_show_hidden: Option<bool>,
+    /// Override for [`Ui::icon_pack`].
     pub ui_icon_pack: Option<String>,
 }
 
@@ -469,6 +487,9 @@ fn normalize_schema(value: serde_json::Value) -> serde_json::Value {
 /// Read `path` and parse it, returning [`Config::default`] with no diagnostics
 /// when the file does not exist (a missing config is normal, not an error).
 pub fn load_from_path(path: &Path) -> (Config, Vec<Diagnostic>) {
+    // Config is read synchronously at startup, before the GPUI foreground loop
+    // runs, so blocking I/O here cannot stall rendering.
+    #[allow(clippy::disallowed_methods)]
     match std::fs::read_to_string(path) {
         Ok(contents) => Config::from_toml_str(&contents),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
@@ -503,7 +524,7 @@ pub fn report_diagnostics(diagnostics: &[Diagnostic]) -> Option<String> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[allow(clippy::unwrap_used, clippy::disallowed_methods)]
 mod tests {
     use super::*;
 

--- a/crates/nohrs-core/src/config/watcher.rs
+++ b/crates/nohrs-core/src/config/watcher.rs
@@ -50,7 +50,7 @@ fn is_relevant(event: &Event) -> bool {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[allow(clippy::unwrap_used, clippy::disallowed_methods)]
 mod tests {
     use super::*;
     use notify::event::{AccessKind, CreateKind, ModifyKind};

--- a/crates/nohrs-core/src/errors.rs
+++ b/crates/nohrs-core/src/errors.rs
@@ -1,13 +1,18 @@
 use thiserror::Error;
 
+/// Convenience alias for results that fail with this crate's [`Error`].
 pub type Result<T> = std::result::Result<T, Error>;
 
+/// Errors produced by `nohrs-core`.
 #[derive(Debug, Error)]
 pub enum Error {
+    /// A requested feature has not been implemented yet.
     #[error("not implemented: {0}")]
     NotImplemented(&'static str),
+    /// An underlying I/O operation failed.
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
+    /// A failure that does not fit the other variants.
     #[error("other error: {0}")]
     Other(String),
 }

--- a/crates/nohrs-core/src/nohrs_core.rs
+++ b/crates/nohrs-core/src/nohrs_core.rs
@@ -1,3 +1,9 @@
+//! Shared foundations for the nohrs application: configuration, error types,
+//! and telemetry, kept app-agnostic so they can be reused across binaries.
+
+/// Configuration: UI layout constants and the user-facing `config.toml` system.
 pub mod config;
+/// Crate-wide error and `Result` types.
 pub mod errors;
+/// Logging and other telemetry setup.
 pub mod telemetry;

--- a/crates/nohrs-core/src/telemetry.rs
+++ b/crates/nohrs-core/src/telemetry.rs
@@ -1,3 +1,4 @@
+/// Logging subscriber setup.
 pub mod logging;
 
 use std::fmt::Display;

--- a/crates/nohrs-core/src/telemetry/logging.rs
+++ b/crates/nohrs-core/src/telemetry/logging.rs
@@ -1,6 +1,8 @@
 use super::LogErr;
 use tracing_subscriber::{fmt, EnvFilter};
 
+/// Install the global `tracing` subscriber, writing logs to stderr and honoring
+/// `RUST_LOG` (defaulting to `info`). A no-op if a subscriber is already set.
 pub fn init_logging() {
     let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
     // Logs go to stderr so machine-readable command output (e.g.

--- a/crates/nohrs-models/src/file_entry.rs
+++ b/crates/nohrs-models/src/file_entry.rs
@@ -7,24 +7,38 @@ use serde::Serialize;
 /// dependency graph in `nohrs-models`.
 #[derive(Debug, Serialize, Clone)]
 pub struct FileEntryDto {
+    /// File or directory name (final path component).
     pub name: String,
+    /// Full path to the entry.
     pub path: String,
+    /// Entry kind as a string (e.g. `"file"`, `"dir"`, `"link"`).
     pub kind: String,
+    /// Size in bytes.
     pub size: u64,
+    /// Last modification time as a Unix timestamp in seconds.
     pub modified: u64,
 }
 
+/// A filesystem entry with a strongly typed [`FileKind`].
 #[derive(Debug, Clone)]
 pub struct FileEntry {
+    /// File or directory name (final path component).
     pub name: String,
+    /// Full path to the entry.
     pub path: String,
+    /// Kind of filesystem entry.
     pub kind: FileKind,
+    /// Size in bytes.
     pub size: u64,
 }
 
+/// The kind of a filesystem entry.
 #[derive(Debug, Clone)]
 pub enum FileKind {
+    /// A regular file.
     File,
+    /// A directory.
     Dir,
+    /// A symbolic link.
     Link,
 }

--- a/crates/nohrs-models/src/file_entry.rs
+++ b/crates/nohrs-models/src/file_entry.rs
@@ -11,7 +11,8 @@ pub struct FileEntryDto {
     pub name: String,
     /// Full path to the entry.
     pub path: String,
-    /// Entry kind as a string (e.g. `"file"`, `"dir"`, `"link"`).
+    /// Entry kind as a string (`"file"`, `"dir"`, or `"symlink"`), matching the
+    /// values emitted by the listing service.
     pub kind: String,
     /// Size in bytes.
     pub size: u64,

--- a/crates/nohrs-models/src/nohrs_models.rs
+++ b/crates/nohrs-models/src/nohrs_models.rs
@@ -1,1 +1,4 @@
+//! Toolkit- and service-agnostic data models shared across the `nohrs` crates.
+
+/// Filesystem entry models shared between the services layer and the UI.
 pub mod file_entry;

--- a/crates/nohrs-pages/src/explorer.rs
+++ b/crates/nohrs-pages/src/explorer.rs
@@ -5,6 +5,7 @@ mod preview;
 mod search;
 mod state;
 mod types;
+/// Rendering of the explorer page: header, sidebar, listing, and preview.
 pub mod view;
 
 #[cfg(test)]

--- a/crates/nohrs-pages/src/explorer/preview.rs
+++ b/crates/nohrs-pages/src/explorer/preview.rs
@@ -67,6 +67,9 @@ fn is_binary_image_path(path: &str) -> bool {
 
 /// Reads `path` and classifies it for preview. Runs on a background thread, so
 /// it must not touch any GPUI state.
+// Always invoked from `cx.background_spawn` (see `open_preview`), so its
+// blocking reads run off the GPUI foreground thread.
+#[allow(clippy::disallowed_methods)]
 fn read_preview(path: &str) -> PreviewOutcome {
     let metadata = match std::fs::metadata(path) {
         Ok(metadata) => metadata,
@@ -248,6 +251,7 @@ impl ExplorerPage {
 }
 
 #[cfg(test)]
+#[allow(clippy::disallowed_methods)]
 mod tests {
     use super::*;
 

--- a/crates/nohrs-pages/src/explorer/search.rs
+++ b/crates/nohrs-pages/src/explorer/search.rs
@@ -212,6 +212,7 @@ pub fn results_to_entries(results: &[SearchFileResult]) -> Vec<FileEntryDto> {
 }
 
 #[cfg(test)]
+#[allow(clippy::disallowed_methods)]
 mod tests {
     use super::*;
     use std::path::PathBuf;

--- a/crates/nohrs-pages/src/explorer/state.rs
+++ b/crates/nohrs-pages/src/explorer/state.rs
@@ -15,66 +15,114 @@ use super::entries;
 use super::types::*;
 use super::view::preview::editor::PreviewEditor;
 
+/// State for the file explorer page: the current directory listing, navigation
+/// history, sorting and filtering, search, preview, and view layout.
 pub struct ExplorerPage {
+    /// Absolute path of the currently displayed directory.
     pub cwd: String,
+    /// Navigation history of visited directories for back/forward.
     pub history: Vec<String>,
+    /// Index of the current position within `history`.
     pub history_index: usize,
+    /// All entries read from `cwd`, before filtering.
     pub entries: Vec<FileEntryDto>,
+    /// Entries currently shown after applying hidden/search filters and sorting.
     pub filtered_entries: Vec<FileEntryDto>,
     // Whether the current directory has been loaded. Tracked explicitly rather
     // than via `entries.is_empty()` so an empty (or failed-to-read) directory is
     // not reloaded on every render.
+    /// Whether `cwd` has been loaded into `entries` at least once.
     pub loaded: bool,
+    /// Column the listing is sorted by.
     pub sort_key: SortKey,
+    /// Whether the sort is ascending.
     pub sort_asc: bool,
     // Whether dotfiles are listed; driven by `ui.show_hidden` (config.md §5).
+    /// Whether dotfiles are listed; driven by `ui.show_hidden`.
     pub show_hidden: bool,
     // Identifier of the active icon pack; driven by `ui.icon_pack`.
+    /// Identifier of the active icon pack; driven by `ui.icon_pack`.
     pub icon_pack: String,
+    /// Current name-filter query for the in-directory listing.
     pub search_query: String,
+    /// Whether the search bar is visible.
     pub search_visible: bool,
+    /// Input state backing the search field.
     pub search_input: Entity<InputState>,
+    /// State of the resizable split between listing and preview.
     pub resizable: Entity<ResizableState>,
+    /// The listing's virtualized list entity, once initialized.
     pub list: Option<Entity<List<FileListDelegate>>>,
+    /// GPUI subscriptions kept alive for the lifetime of the page.
     pub subs: Vec<gpui::Subscription>,
+    /// Path of the file currently shown in the preview pane.
     pub preview_path: Option<String>,
+    /// Text content of the previewed file, when it is textual.
     pub preview_text: Option<String>,
+    /// Index of the selected row within `filtered_entries`.
     pub selected_index: Option<usize>,
+    /// Scroll handle for the virtualized listing.
     pub virtual_scroll_handle: VirtualListScrollHandle,
+    /// Per-row sizes for the virtualized listing.
     pub item_sizes: Rc<Vec<gpui::Size<gpui::Pixels>>>,
     // Column widths (resizable)
+    /// Width of the name column.
     pub col_name_width: f32,
+    /// Width of the type column.
     pub col_type_width: f32,
+    /// Width of the size column.
     pub col_size_width: f32,
+    /// Width of the modified-time column.
     pub col_modified_width: f32,
+    /// Width of the action column.
     pub col_action_width: f32,
     // Resize state
+    /// The column currently being resized by a drag, if any.
     pub resizing_column: Option<ResizingColumn>,
+    /// Focus handle for the explorer page.
     pub focus_handle: FocusHandle,
+    /// Whether focus should be requested on the next render.
     pub focus_requested: bool,
+    /// Information about the most recent row click, used for double-click detection.
     pub last_click_info: Option<LastClickInfo>,
+    /// Whether the listing is shown as a list or a grid.
     pub view_mode: ViewMode,
 
     // Search
+    /// The full-text search service, when available.
     pub search_service: Option<Arc<SearchService>>,
+    /// The directory scope for full-text search.
     pub search_scope: SearchScope,
+    /// The kind of items full-text search targets.
     pub search_type: SearchType,
+    /// Whether full-text search is case-sensitive.
     pub match_case: bool,
+    /// Whether full-text search matches whole words only.
     pub match_whole_word: bool,
+    /// Whether the full-text search query is treated as a regular expression.
     pub use_regex: bool,
+    /// Results of the active full-text search, when one is displayed.
     pub search_results: Option<Vec<SearchFileResult>>,
+    /// Whether a full-text search is currently running.
     pub is_performing_search: bool,
     // Monotonic counter incremented on every search request; used to discard
     // results from a stale in-flight search that completes after a newer one.
+    /// Monotonic counter used to discard results from stale in-flight searches.
     pub search_generation: u64,
+    /// Paths of search-result files whose match snippets are expanded.
     pub expanded_search_files: std::collections::HashSet<String>,
     // Syntax
+    /// Service providing syntax highlighting for previews.
     pub syntax_service: Arc<SyntaxService>,
     // Preview State
+    /// Path of the image currently shown in the preview pane.
     pub preview_image_path: Option<String>,
+    /// Message shown in the preview pane when a file cannot be previewed.
     pub preview_message: Option<String>,
+    /// The editor entity backing a text preview.
     pub preview_editor: Option<Entity<PreviewEditor>>,
     // Transient message shown in the footer status bar.
+    /// Transient message shown in the footer status bar.
     pub status_message: Option<StatusMessage>,
 }
 
@@ -85,6 +133,8 @@ impl Focusable for ExplorerPage {
 }
 
 impl ExplorerPage {
+    /// Creates a new explorer page rooted at the current working directory,
+    /// wired to the given resizable, search input, and optional search service.
     pub fn new(
         resizable: Entity<ResizableState>,
         search_input: Entity<InputState>,

--- a/crates/nohrs-pages/src/explorer/tests.rs
+++ b/crates/nohrs-pages/src/explorer/tests.rs
@@ -6,6 +6,9 @@
 //! timer + `run_until_parked`, and assert state with `window.read_with` — never
 //! `smol::Timer` / `tokio` sleeps, which the GPUI scheduler does not track.
 
+// Test fixtures write files directly; the synchronous-fs ban targets app code.
+#![allow(clippy::disallowed_methods)]
+
 use std::time::Duration;
 
 use gpui::{point, px, AppContext, TestAppContext, WindowHandle};

--- a/crates/nohrs-pages/src/explorer/view.rs
+++ b/crates/nohrs-pages/src/explorer/view.rs
@@ -2,11 +2,16 @@ use crate::explorer::ExplorerPage;
 use gpui::*;
 use nohrs_ui::theme::theme;
 
+/// The explorer header with navigation controls and the path bar.
 pub mod header;
+/// The main file listing, in list or grid mode, with the search bar.
 pub mod listing;
+/// The file preview pane.
 pub mod preview;
+/// The explorer sidebar with quick-access locations.
 pub mod sidebar;
 
+/// Renders the explorer page: header, sidebar, listing, and preview panes.
 pub fn render(
     page: &mut ExplorerPage,
     window: &mut Window,
@@ -100,6 +105,8 @@ pub fn render(
         )
 }
 
+/// Returns highlight ranges for every case-insensitive occurrence of `query`
+/// within `text`, for emphasizing search matches.
 pub fn find_query_highlights(
     text: &str,
     query: &str,

--- a/crates/nohrs-pages/src/explorer/view/header.rs
+++ b/crates/nohrs-pages/src/explorer/view/header.rs
@@ -6,6 +6,8 @@ use gpui_component::breadcrumb::{Breadcrumb, BreadcrumbItem};
 use gpui_component::{Icon, IconName, ListItem};
 use nohrs_ui::theme::theme;
 
+/// Renders the explorer header with navigation buttons, the breadcrumb path
+/// bar, and view-mode controls.
 pub fn render(
     page: &mut ExplorerPage,
     _window: &mut Window,

--- a/crates/nohrs-pages/src/explorer/view/listing.rs
+++ b/crates/nohrs-pages/src/explorer/view/listing.rs
@@ -2,11 +2,17 @@ use super::super::types::ViewMode;
 use crate::explorer::ExplorerPage;
 use gpui::*;
 
+/// Grid-mode rendering of the listing.
 pub mod grid;
+/// List-mode rendering of the listing.
 pub mod list;
+/// Rendering of a single listing row.
 pub mod row;
+/// The full-text search bar shown above the listing.
 pub mod search_bar;
 
+/// Renders the file listing in the active view mode, with the search bar when
+/// search is visible.
 pub fn render(
     page: &mut ExplorerPage,
     window: &mut Window,
@@ -32,6 +38,8 @@ pub fn render(
     }
 }
 
+/// Truncates `text` to at most `max_len` characters by eliding the middle,
+/// preserving the file extension where possible.
 pub fn truncate_middle(text: &str, max_len: usize) -> String {
     let char_count = text.chars().count();
 

--- a/crates/nohrs-pages/src/explorer/view/listing/grid.rs
+++ b/crates/nohrs-pages/src/explorer/view/listing/grid.rs
@@ -6,6 +6,7 @@ use gpui_component::{Icon, IconName};
 use nohrs_services::fs::listing::FileEntryDto;
 use nohrs_ui::theme::theme;
 
+/// Renders the file listing as a grid of icon tiles.
 pub fn render(
     page: &mut ExplorerPage,
     window: &mut Window,

--- a/crates/nohrs-pages/src/explorer/view/listing/list.rs
+++ b/crates/nohrs-pages/src/explorer/view/listing/list.rs
@@ -7,6 +7,7 @@ use gpui_component::{v_virtual_list, ListItem};
 use nohrs_ui::theme::theme;
 use std::rc::Rc;
 
+/// Renders the file listing as a virtualized multi-column table.
 pub fn render(page: &mut ExplorerPage, cx: &mut Context<ExplorerPage>) -> AnyElement {
     let table_width = page.total_table_width();
     let col_name = page.col_name_width;

--- a/crates/nohrs-pages/src/explorer/view/listing/row.rs
+++ b/crates/nohrs-pages/src/explorer/view/listing/row.rs
@@ -7,6 +7,7 @@ use gpui_component::{Icon, IconName, ListItem};
 use nohrs_services::fs::listing::FileEntryDto;
 use nohrs_ui::theme::theme;
 
+/// Renders a single listing row for the given entry at row index `ix`.
 pub fn render(
     page: &ExplorerPage,
     item: &FileEntryDto,

--- a/crates/nohrs-pages/src/explorer/view/listing/search_bar.rs
+++ b/crates/nohrs-pages/src/explorer/view/listing/search_bar.rs
@@ -7,6 +7,7 @@ use gpui_component::{Icon, IconName, ListItem};
 use nohrs_services::search::SearchScope;
 use nohrs_ui::theme::theme;
 
+/// Renders the search bar with the query input and search option toggles.
 pub fn render(page: &mut ExplorerPage, cx: &mut Context<ExplorerPage>) -> impl IntoElement {
     let current_text = page.search_input.read(cx).text().to_string();
     if current_text != page.search_query {

--- a/crates/nohrs-pages/src/explorer/view/preview.rs
+++ b/crates/nohrs-pages/src/explorer/view/preview.rs
@@ -4,6 +4,8 @@ use gpui::*;
 use nohrs_ui::theme::theme;
 
 // Calculate the maximum line width in characters for horizontal scroll sizing
+/// Renders the preview pane for the selected file, showing a text editor,
+/// image, status message, or an empty placeholder.
 pub fn render(page: &mut ExplorerPage, _window: &mut Window) -> impl IntoElement {
     let title = page
         .preview_path
@@ -77,4 +79,5 @@ fn path_name(p: &str) -> String {
         .unwrap_or_else(|| p.to_string())
 }
 
+/// The text editor used to render file previews.
 pub mod editor;

--- a/crates/nohrs-pages/src/explorer/view/preview/editor.rs
+++ b/crates/nohrs-pages/src/explorer/view/preview/editor.rs
@@ -3,15 +3,23 @@ use gpui::*;
 use gpui_component::input::{InputState, RopeExt, TextInput};
 use std::sync::Once;
 
-actions!(preview, [SafeSearch]);
+actions!(
+    preview,
+    [
+        /// Opens the editor's built-in search panel without triggering a double-borrow panic.
+        SafeSearch
+    ]
+);
 
 static BIND_SEARCH_ONCE: Once = Once::new();
 
+/// A read-only code editor view used to render textual file previews.
 pub struct PreviewEditor {
     editor_state: Entity<InputState>,
 }
 
 impl PreviewEditor {
+    /// Creates a new preview editor, binding a panic-safe search keybinding once.
     pub fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
         BIND_SEARCH_ONCE.call_once(|| {
             // Override the default search keybinding to prevent panic in gpui-component
@@ -33,18 +41,21 @@ impl PreviewEditor {
         Self { editor_state }
     }
 
+    /// Replaces the editor's contents with `text`.
     pub fn set_text(&mut self, text: String, window: &mut Window, cx: &mut Context<Self>) {
         self.editor_state.update(cx, |state, cx| {
             state.set_value(text, window, cx);
         });
     }
 
+    /// Sets the syntax-highlighting language for the editor.
     pub fn set_language(&mut self, language: String, _window: &mut Window, cx: &mut Context<Self>) {
         self.editor_state.update(cx, |state, cx| {
             state.set_highlighter(language, cx);
         });
     }
 
+    /// Applies custom highlight ranges to the editor (currently a no-op).
     pub fn set_highlights(
         &mut self,
         _highlights: Vec<(std::ops::Range<usize>, HighlightStyle)>,
@@ -56,6 +67,7 @@ impl PreviewEditor {
         // For search results, we might need a different approach or see if `search` functionality covers it.
     }
 
+    /// Scrolls the editor so the byte `offset` is brought into view.
     pub fn scroll_to(&mut self, offset: usize, window: &mut Window, cx: &mut Context<Self>) {
         // `InputState::scroll_to` is private; moving the cursor to the offset triggers the
         // same scroll-into-view logic through the public `set_cursor_position` API.
@@ -65,6 +77,7 @@ impl PreviewEditor {
         });
     }
 
+    /// Syncs the explorer's search query into the editor (currently a no-op).
     pub fn set_search_query(
         &mut self,
         _query: String,

--- a/crates/nohrs-pages/src/explorer/view/sidebar.rs
+++ b/crates/nohrs-pages/src/explorer/view/sidebar.rs
@@ -4,6 +4,7 @@ use gpui::*;
 use gpui_component::{Icon, IconName, ListItem};
 use nohrs_ui::theme::theme; // Assuming theme is accessible
 
+/// Renders the explorer sidebar listing quick-access locations.
 pub fn render(
     page: &mut ExplorerPage,
     _window: &mut Window,

--- a/crates/nohrs-pages/src/extensions.rs
+++ b/crates/nohrs-pages/src/extensions.rs
@@ -1,6 +1,7 @@
 use gpui::{div, prelude::*, px, rgb, AnyElement, Context, Render, Window};
 use nohrs_ui::theme::theme;
 
+/// The extensions page, a placeholder for a future extension store.
 pub struct ExtensionsPage;
 
 impl Default for ExtensionsPage {
@@ -10,6 +11,7 @@ impl Default for ExtensionsPage {
 }
 
 impl ExtensionsPage {
+    /// Creates a new extensions page.
     pub fn new() -> Self {
         Self
     }

--- a/crates/nohrs-pages/src/git.rs
+++ b/crates/nohrs-pages/src/git.rs
@@ -1,6 +1,7 @@
 use gpui::{div, prelude::*, px, rgb, AnyElement, Context, Render, Window};
 use nohrs_ui::theme::theme;
 
+/// The git page, a placeholder for future version-control functionality.
 pub struct GitPage;
 
 impl Default for GitPage {
@@ -10,6 +11,7 @@ impl Default for GitPage {
 }
 
 impl GitPage {
+    /// Creates a new git page.
     pub fn new() -> Self {
         Self
     }

--- a/crates/nohrs-pages/src/nohrs_pages.rs
+++ b/crates/nohrs-pages/src/nohrs_pages.rs
@@ -1,26 +1,43 @@
+//! Top-level page views for the nohrs application, including the explorer,
+//! git, S3, extensions, and settings pages, along with the root view that
+//! hosts them.
+
 use gpui::AnyElement;
 
+/// The file explorer page and its supporting state and views.
 pub mod explorer;
+/// The extensions management page.
 pub mod extensions;
+/// The git page.
 pub mod git;
+/// The application root view that hosts the sidebar and active page.
 pub mod root;
+/// The S3 page.
 pub mod s3;
 // removed search
+/// The settings page.
 pub mod settings;
 
 pub use root::RootView;
 
+/// Identifies which top-level page is currently selected.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum PageKind {
+    /// The file explorer page.
     Explorer,
 
+    /// The git page.
     Git,
+    /// The S3 page.
     S3,
+    /// The extensions page.
     Extensions,
+    /// The settings page.
     Settings,
 }
 
 impl PageKind {
+    /// Returns the human-readable label for this page.
     pub fn label(&self) -> &'static str {
         match self {
             PageKind::Explorer => "Explorer",
@@ -31,6 +48,7 @@ impl PageKind {
         }
     }
 
+    /// Returns the asset path of the icon representing this page.
     pub fn icon_path(&self) -> &'static str {
         match self {
             PageKind::Explorer => "icons/folder.svg",
@@ -42,6 +60,7 @@ impl PageKind {
         }
     }
 
+    /// Returns all page kinds in display order.
     pub fn all() -> Vec<PageKind> {
         vec![
             PageKind::Explorer,
@@ -55,6 +74,7 @@ impl PageKind {
 
 /// Trait for page rendering
 pub trait Page {
+    /// Renders the page into an element tree.
     fn render(&mut self, window: &mut gpui::Window, cx: &mut gpui::Context<Self>) -> AnyElement
     where
         Self: Sized;

--- a/crates/nohrs-pages/src/root.rs
+++ b/crates/nohrs-pages/src/root.rs
@@ -32,6 +32,8 @@ use std::sync::Arc;
 use std::time::Duration;
 use tracing::info;
 
+/// The application root view that hosts the page sidebar, the active page, and
+/// the shared configuration and search state.
 pub struct RootView {
     current_page: PageKind,
     focus_handle: FocusHandle,
@@ -212,6 +214,7 @@ impl RootView {
         .detach();
     }
 
+    /// Switches the active page, notifying for a redraw only if it changed.
     pub fn set_page(&mut self, page: PageKind, cx: &mut Context<Self>) {
         if self.current_page != page {
             self.current_page = page;

--- a/crates/nohrs-pages/src/s3.rs
+++ b/crates/nohrs-pages/src/s3.rs
@@ -1,6 +1,7 @@
 use gpui::{div, prelude::*, px, rgb, AnyElement, Context, Render, Window};
 use nohrs_ui::theme::theme;
 
+/// The S3 page, a placeholder for future object-storage browsing.
 pub struct S3Page;
 
 impl Default for S3Page {
@@ -10,6 +11,7 @@ impl Default for S3Page {
 }
 
 impl S3Page {
+    /// Creates a new S3 page.
     pub fn new() -> Self {
         Self
     }

--- a/crates/nohrs-pages/src/settings.rs
+++ b/crates/nohrs-pages/src/settings.rs
@@ -1,6 +1,7 @@
 use gpui::{div, prelude::*, px, rgb, AnyElement, Context, Render, Window};
 use nohrs_ui::theme::theme;
 
+/// The settings page, a placeholder for future application configuration.
 pub struct SettingsPage;
 
 impl Default for SettingsPage {
@@ -10,6 +11,7 @@ impl Default for SettingsPage {
 }
 
 impl SettingsPage {
+    /// Creates a new settings page.
     pub fn new() -> Self {
         Self
     }

--- a/crates/nohrs-services/src/fs.rs
+++ b/crates/nohrs-services/src/fs.rs
@@ -1,1 +1,4 @@
+//! Directory listing with stable, case-insensitive ordering and cursor paging.
+
+/// Synchronous directory listing.
 pub mod listing;

--- a/crates/nohrs-services/src/fs/listing.rs
+++ b/crates/nohrs-services/src/fs/listing.rs
@@ -9,14 +9,21 @@ use std::time::UNIX_EPOCH;
 // references keep resolving without forcing callers through `nohrs-models`.
 pub use nohrs_models::file_entry::FileEntryDto;
 
+/// Parameters for a single directory-listing request.
 pub struct ListParams<'a> {
+    /// Absolute or relative path of the directory to list.
     pub path: &'a str,
+    /// Maximum number of entries to return for this page.
     pub limit: usize,
+    /// Opaque cursor (a decimal offset) from a previous `next_cursor`, or `None` for the first page.
     pub cursor: Option<&'a str>,
 }
 
+/// One page of directory entries plus a cursor for the next page.
 pub struct ListResult {
+    /// The entries in this page, sorted case-insensitively by name.
     pub entries: Vec<FileEntryDto>,
+    /// Cursor to fetch the following page, or `None` when the directory is exhausted.
     pub next_cursor: Option<String>,
 }
 
@@ -98,7 +105,7 @@ fn os_str_to_string(s: impl AsRef<OsStr>) -> String {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+#[allow(clippy::unwrap_used, clippy::disallowed_methods)]
 mod tests {
     use super::*;
     use tempfile::tempdir;

--- a/crates/nohrs-services/src/nohrs_services.rs
+++ b/crates/nohrs-services/src/nohrs_services.rs
@@ -1,4 +1,10 @@
+//! Application services: filesystem listing, full-text/regex search, and
+//! optional syntax highlighting.
+
+/// Synchronous filesystem listing services.
 pub mod fs;
+/// Full-text and regex file search services.
 pub mod search;
+/// Syntax highlighting backed by `syntect`, mapped to GPUI colors.
 #[cfg(feature = "gui")]
 pub mod syntax;

--- a/crates/nohrs-services/src/search.rs
+++ b/crates/nohrs-services/src/search.rs
@@ -1,22 +1,38 @@
+//! File search: a tantivy-backed full-text index over the home directory plus
+//! a platform regex backend for whole-system scans.
+
+/// Trait abstracting a search backend.
 pub mod backend;
+/// The search engine wiring together the index, watcher, and root backend.
 pub mod engine;
+/// Tantivy index management and incremental updates.
 pub mod indexer;
+/// Ripgrep/`grep`-crate based regex search backend (non-macOS root scans).
 pub mod ripgrep;
+/// macOS Spotlight (`mdfind`) based search backend.
 pub mod spotlight;
+/// Filesystem change watcher feeding incremental index updates.
 pub mod watcher;
 
 use std::path::PathBuf;
 
+/// Which part of the filesystem a search covers.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SearchScope {
+    /// The indexed home directory.
     Home,
+    /// The whole filesystem from root, via the platform regex backend.
     Root,
 }
 
+/// A single match: the file, the matching line number, and its content.
 #[derive(Debug, Clone)]
 pub struct SearchResult {
+    /// Path of the file containing the match.
     pub path: PathBuf,
+    /// 1-based line number of the match within the file.
     pub line_number: usize,
+    /// The full text of the matching line.
     pub line_content: String,
 }
 
@@ -26,11 +42,13 @@ pub use engine::InitialIndexingJob;
 use anyhow::Result;
 use std::sync::Arc;
 
+/// Entry point for performing searches and managing the index lifecycle.
 pub struct SearchService {
     engine: Arc<engine::SearchEngine>,
 }
 
 impl SearchService {
+    /// Builds the service, initializing the index, file watcher, and root backend.
     pub fn new() -> Result<Self> {
         let engine = Arc::new(engine::SearchEngine::new()?);
         Ok(Self { engine })
@@ -48,6 +66,7 @@ impl SearchService {
         self.engine.take_initial_indexing_job()
     }
 
+    /// Returns a receiver for initial-indexing progress in the range `0.0..=1.0`.
     pub fn progress_subscription(&self) -> tokio::sync::watch::Receiver<f32> {
         self.engine.progress_subscription()
     }

--- a/crates/nohrs-services/src/search/backend.rs
+++ b/crates/nohrs-services/src/search/backend.rs
@@ -1,6 +1,8 @@
 use super::SearchResult;
 use anyhow::Result;
 
+/// A pluggable source of search results for a given query.
 pub trait SearchBackend: Send + Sync {
+    /// Runs `query` and returns the matching results.
     fn search(&self, query: &str) -> Result<Vec<SearchResult>>;
 }

--- a/crates/nohrs-services/src/search/engine.rs
+++ b/crates/nohrs-services/src/search/engine.rs
@@ -67,6 +67,7 @@ impl InitialIndexingJob {
     }
 }
 
+/// Coordinates the home-directory index, its file watcher, and the root-scope backend.
 pub struct SearchEngine {
     index_manager: Arc<IndexManager>,
     root_backend: Arc<dyn SearchBackend>,
@@ -78,6 +79,7 @@ pub struct SearchEngine {
 }
 
 impl SearchEngine {
+    /// Builds the engine, opening the index and starting the file watcher.
     pub fn new() -> Result<Self> {
         let index_manager = Arc::new(IndexManager::new()?);
 
@@ -132,10 +134,12 @@ impl SearchEngine {
         })
     }
 
+    /// Returns a receiver for initial-indexing progress in the range `0.0..=1.0`.
     pub fn progress_subscription(&self) -> tokio::sync::watch::Receiver<f32> {
         self.progress_rx.clone()
     }
 
+    /// Returns a shared handle to the underlying index manager.
     pub fn index_manager(&self) -> Arc<IndexManager> {
         self.index_manager.clone()
     }

--- a/crates/nohrs-services/src/search/indexer.rs
+++ b/crates/nohrs-services/src/search/indexer.rs
@@ -7,6 +7,7 @@ use tantivy::schema::{Field, Schema, Term, Value, FAST, STORED, STRING, TEXT};
 use tantivy::TantivyDocument;
 use tantivy::{Index, IndexWriter}; // Import trait for add_text etc? No, TantivyDocument implements it.
 
+/// Owns the tantivy index and its writer, and performs full and incremental indexing.
 pub struct IndexManager {
     index: Index,
     _index_path: PathBuf,
@@ -15,6 +16,7 @@ pub struct IndexManager {
 }
 
 impl IndexManager {
+    /// Opens (or creates) the default index under `~/.nohrs/index` rooted at `~/Documents`.
     pub fn new() -> Result<Self> {
         let home_dir = dirs::home_dir().context("Could not determine home directory")?;
         let nohrs_dir = home_dir.join(".nohrs");
@@ -93,6 +95,7 @@ impl IndexManager {
 
     // writer() helper removed as we use shared writer
 
+    /// Indexes the content root from scratch, reporting progress through `progress_tx` if given.
     pub fn index_home(&self, progress_tx: Option<tokio::sync::watch::Sender<f32>>) -> Result<()> {
         let mut writer_guard = self
             .writer
@@ -223,6 +226,9 @@ impl IndexManager {
         }
 
         // Try reading as string. If it fails (binary), we skip.
+        // Indexing runs on the search backend's own threads, never the GPUI
+        // foreground loop, so the blocking read is fine here.
+        #[allow(clippy::disallowed_methods)]
         match fs::read_to_string(path) {
             Ok(content) => {
                 // Check if it looks like binary (contains null byte) - crude check
@@ -255,6 +261,7 @@ impl IndexManager {
         Ok(())
     }
 
+    /// Removes the document for `path` from the index and commits.
     pub fn remove_file(&self, path: &Path) -> Result<()> {
         let mut writer_guard = self
             .writer
@@ -271,10 +278,12 @@ impl IndexManager {
         Ok(())
     }
 
+    /// Returns a reference to the underlying tantivy index.
     pub fn index(&self) -> &Index {
         &self.index
     }
 
+    /// Re-indexes or removes each of `paths` (depending on existence) and commits once.
     pub fn process_changes(&self, paths: &[PathBuf]) -> Result<()> {
         let mut writer_guard = self
             .writer
@@ -311,6 +320,7 @@ impl IndexManager {
         Ok(())
     }
 
+    /// Re-indexes (or removes if missing) the single file at `path`.
     pub fn update_file(&self, path: &Path) -> Result<()> {
         self.process_changes(&[path.to_path_buf()])
     }
@@ -400,6 +410,9 @@ impl super::backend::SearchBackend for IndexManager {
 }
 
 /// Find ALL lines in a file that match the query (case-insensitive)
+// Runs as part of the search backend, off the GPUI foreground loop, so the
+// blocking read does not stall rendering.
+#[allow(clippy::disallowed_methods)]
 fn find_all_match_lines(path: &Path, query: &str) -> Vec<(usize, String)> {
     let mut matches = Vec::new();
     if let Ok(content) = fs::read_to_string(path) {

--- a/crates/nohrs-services/src/search/ripgrep.rs
+++ b/crates/nohrs-services/src/search/ripgrep.rs
@@ -7,11 +7,13 @@ use ignore::WalkBuilder;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
+/// Search backend that walks the filesystem from `root` and matches lines with a regex.
 pub struct RipgrepBackend {
     root: PathBuf,
 }
 
 impl RipgrepBackend {
+    /// Creates a backend that searches recursively under `root`.
     pub fn new(root: PathBuf) -> Self {
         Self { root }
     }

--- a/crates/nohrs-services/src/search/spotlight.rs
+++ b/crates/nohrs-services/src/search/spotlight.rs
@@ -7,6 +7,8 @@ use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
 use std::process::Command;
 
+/// Search backend that uses macOS Spotlight (`mdfind`) to find candidate files,
+/// then greps their contents.
 pub struct SpotlightBackend;
 
 impl Default for SpotlightBackend {
@@ -16,6 +18,7 @@ impl Default for SpotlightBackend {
 }
 
 impl SpotlightBackend {
+    /// Creates a new Spotlight-backed search backend.
     pub fn new() -> Self {
         Self
     }

--- a/crates/nohrs-services/src/search/watcher.rs
+++ b/crates/nohrs-services/src/search/watcher.rs
@@ -9,12 +9,15 @@ use std::time::Duration;
 // sender once the consumer task moves off tokio (async-runtime.md §2).
 use tokio::sync::mpsc;
 
+/// Watches a directory tree and forwards debounced batches of changed paths.
 pub struct FileWatcher {
     // Keep debouncer alive
     _debouncer: Debouncer<notify::RecommendedWatcher>,
 }
 
 impl FileWatcher {
+    /// Starts watching `root` recursively, sending debounced change batches on `tx`
+    /// with the given debounce `timeout`.
     pub fn new(root: PathBuf, tx: mpsc::Sender<Vec<PathBuf>>, timeout: Duration) -> Result<Self> {
         // Create debouncer with specified timeout
         let mut debouncer = new_debouncer(timeout, move |res: DebounceEventResult| {

--- a/crates/nohrs-services/src/syntax.rs
+++ b/crates/nohrs-services/src/syntax.rs
@@ -5,9 +5,12 @@ use syntect::highlighting::ThemeSet;
 use syntect::parsing::SyntaxSet;
 use syntect::util::LinesWithEndings;
 
+/// Syntax highlighter that maps `syntect` styles onto GPUI colors.
 #[derive(Clone)]
 pub struct SyntaxService {
+    /// The loaded set of syntax definitions used to pick a grammar.
     pub syntax_set: Arc<SyntaxSet>,
+    /// The loaded set of color themes used for highlighting.
     pub theme_set: Arc<ThemeSet>,
 }
 
@@ -18,6 +21,7 @@ impl Default for SyntaxService {
 }
 
 impl SyntaxService {
+    /// Creates a service loaded with `syntect`'s default syntaxes and themes.
     pub fn new() -> Self {
         Self {
             syntax_set: Arc::new(SyntaxSet::load_defaults_newlines()),
@@ -25,6 +29,8 @@ impl SyntaxService {
         }
     }
 
+    /// Highlights `text`, returning contiguous byte ranges paired with their
+    /// color; `extension` selects the grammar, falling back to plain text.
     pub fn highlight(
         &self,
         text: &str,

--- a/crates/nohrs-ui/src/assets.rs
+++ b/crates/nohrs-ui/src/assets.rs
@@ -3,6 +3,7 @@ use rust_embed::RustEmbed;
 // Crate-local assets so `nohrs-ui` stays self-contained and publishable: the
 // folder is resolved relative to this crate's manifest dir and is included in
 // the packaged crate. Workspace-root `assets/doc/` (README images) is separate.
+/// GPUI `AssetSource` backed by the crate-local `assets/` directory embedded at compile time.
 #[derive(RustEmbed)]
 #[folder = "assets/"]
 pub struct Assets;

--- a/crates/nohrs-ui/src/components.rs
+++ b/crates/nohrs-ui/src/components.rs
@@ -1,4 +1,7 @@
 // Shared UI components
+/// File list view and its list delegate.
 pub mod file_list;
+/// Layout chrome components such as the footer and unified toolbar.
 pub mod layout;
+/// Resizable pane container component.
 pub mod pane;

--- a/crates/nohrs-ui/src/components/file_list.rs
+++ b/crates/nohrs-ui/src/components/file_list.rs
@@ -5,12 +5,17 @@ use gpui_component::{Icon, IconName, IndexPath};
 use nohrs_models::file_entry::FileEntryDto;
 use std::sync::Arc;
 
+/// Callback invoked when a file list entry is confirmed (clicked or activated).
 pub type ConfirmCallback = Arc<dyn Fn(&FileEntryDto) + 'static>;
 
+/// List delegate that renders file entries and tracks selection for the file list view.
 pub struct FileListDelegate {
+    /// File entries currently displayed in the list.
     pub items: Vec<FileEntryDto>,
+    /// Index path of the currently selected row, if any.
     pub selected: Option<IndexPath>,
     // Callback hooks
+    /// Callback invoked when an entry is confirmed.
     pub on_confirm: Option<ConfirmCallback>,
 }
 
@@ -21,6 +26,7 @@ impl Default for FileListDelegate {
 }
 
 impl FileListDelegate {
+    /// Create an empty delegate with no items, selection, or callbacks.
     pub fn new() -> Self {
         Self {
             items: Vec::new(),
@@ -29,11 +35,13 @@ impl FileListDelegate {
         }
     }
 
+    /// Replace the displayed entries and clear the current selection.
     pub fn set_items(&mut self, items: Vec<FileEntryDto>) {
         self.items = items;
         self.selected = None;
     }
 
+    /// Return the currently selected entry, if any.
     pub fn get_selected(&self) -> Option<&FileEntryDto> {
         self.selected.and_then(|ix| self.items.get(ix.row))
     }
@@ -193,6 +201,7 @@ impl ListDelegate for FileListDelegate {
     }
 }
 
+/// Format a byte count as a human-readable size string (B, KB, MB, or GB).
 pub fn human_bytes(size: u64) -> String {
     const KB: f64 = 1024.0;
     const MB: f64 = 1024.0 * KB;
@@ -209,6 +218,7 @@ pub fn human_bytes(size: u64) -> String {
     }
 }
 
+/// Format a Unix timestamp (seconds) as a `year/month/day` date, or `-` if invalid.
 pub fn format_date(timestamp: &u64) -> String {
     use time::macros::format_description;
     use time::OffsetDateTime;
@@ -220,6 +230,7 @@ pub fn format_date(timestamp: &u64) -> String {
     }
 }
 
+/// Derive a human-readable type label from an entry's name and kind (e.g. `Folder`, `PNG`, `Link`).
 pub fn get_file_type(name: &str, kind: &str) -> String {
     match kind {
         "dir" => "Folder".to_string(),

--- a/crates/nohrs-ui/src/components/layout.rs
+++ b/crates/nohrs-ui/src/components/layout.rs
@@ -1,2 +1,4 @@
+/// VSCode-like footer (status bar) component.
 pub mod footer;
+/// Unified toolbar (window title bar) component.
 pub mod unified_toolbar;

--- a/crates/nohrs-ui/src/components/layout/footer.rs
+++ b/crates/nohrs-ui/src/components/layout/footer.rs
@@ -2,18 +2,27 @@ use crate::theme::theme;
 use gpui::{div, prelude::*, px, rgb, Context, IntoElement};
 use gpui_component::{Icon, IconName};
 
+/// Properties controlling the contents of the footer status bar.
 #[derive(Clone)]
 pub struct FooterProps {
+    /// Number of currently selected items; shows a "N selected" indicator when greater than zero.
     pub selected_count: usize,
+    /// Total number of items in the current view.
     pub total_count: usize,
+    /// Pre-formatted total size of the items.
     pub total_size: String,
+    /// Current path, displayed (truncated) on the right side of the footer.
     pub current_path: String,
+    /// Active Git branch name, shown when present.
     pub git_branch: Option<String>,
+    /// Storage backend status (e.g. S3 connection), shown when present.
     pub storage_status: Option<String>,
+    /// Indexing progress in the range 0.0..=1.0; the indicator is hidden once it reaches 1.0.
     pub indexing_progress: Option<f32>,
     /// Transient message (e.g. an error) surfaced to the user. When
     /// `status_is_error` is set it is rendered in the error color.
     pub status_message: Option<String>,
+    /// Whether `status_message` should be rendered using the error color.
     pub status_is_error: bool,
 }
 

--- a/crates/nohrs-ui/src/components/layout/unified_toolbar.rs
+++ b/crates/nohrs-ui/src/components/layout/unified_toolbar.rs
@@ -11,12 +11,16 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::fmt;
 
+/// Fixed height of the unified toolbar.
 pub const UNIFIED_TOOLBAR_HEIGHT: Pixels = px(36.0);
 const ACCOUNT_BUTTON_ID: &str = "unified-toolbar-account-button";
 
+/// Properties for the unified toolbar's account button and menu.
 #[derive(Clone)]
 pub struct UnifiedToolbarProps {
+    /// Display name shown in the account menu header.
     pub account_name: String,
+    /// Account plan label shown beneath the name; hidden when empty.
     pub account_plan: String,
 }
 
@@ -29,6 +33,7 @@ impl Default for UnifiedToolbarProps {
     }
 }
 
+/// Build the unified toolbar element: a draggable window region plus an account button with menu.
 pub fn unified_toolbar<V: Render>(
     props: UnifiedToolbarProps,
     _cx: &mut Context<V>,
@@ -141,15 +146,23 @@ pub fn unified_toolbar<V: Render>(
         .child(account_button)
 }
 
+/// Commands dispatched from the account menu in the unified toolbar.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum AccountMenuCommand {
+    /// The disabled header entry showing the account summary.
     ProfileSummary,
+    /// Open the settings page.
     Settings,
+    /// Open the keymap editor.
     Keymap,
+    /// Open the theme picker.
     Themes,
+    /// Open the icon theme picker.
     IconThemes,
+    /// Open the extensions view.
     Extensions,
+    /// Sign out of the current account.
     SignOut,
 }
 
@@ -178,16 +191,20 @@ impl AccountMenuCommand {
     }
 }
 
+/// GPUI action wrapping an [`AccountMenuCommand`] dispatched from the account menu.
 #[derive(Clone)]
 pub struct AccountMenuAction {
+    /// The command this action carries.
     pub command: AccountMenuCommand,
 }
 
 impl AccountMenuAction {
+    /// Create an action for the given command.
     pub fn new(command: AccountMenuCommand) -> Self {
         Self { command }
     }
 
+    /// Create a boxed action for the given command, ready to dispatch.
     pub fn boxed(command: AccountMenuCommand) -> Box<dyn Action> {
         Box::new(Self::new(command))
     }

--- a/crates/nohrs-ui/src/nohrs_ui.rs
+++ b/crates/nohrs-ui/src/nohrs_ui.rs
@@ -6,9 +6,13 @@
 //! nohrs binary. It depends only on `nohrs-core` and `nohrs-models`; the app
 //! shell that orchestrates pages lives in the `nohrs` binary crate.
 
+/// Embedded crate-local assets (icons, fonts) exposed as a GPUI `AssetSource`.
 pub mod assets;
+/// Presentational UI components built on GPUI.
 pub mod components;
+/// Theme tokens (colors) shared across components.
 pub mod theme;
+/// Window construction helpers, including unified toolbar window options.
 pub mod window;
 
 pub use components::file_list;

--- a/crates/nohrs-ui/src/theme.rs
+++ b/crates/nohrs-ui/src/theme.rs
@@ -4,46 +4,76 @@
 #[allow(clippy::module_inception)]
 pub mod theme {
     // Base colors
+    /// Pure white.
     pub const WHITE: u32 = 0xFFFFFF;
+    /// Pure black.
     pub const BLACK: u32 = 0x000000;
 
     // Gray scale
+    /// Lightest gray, used for the lightest background.
     pub const GRAY_50: u32 = 0xF9FAFB; // Lightest background
+    /// Light gray, used for light backgrounds.
     pub const GRAY_100: u32 = 0xF3F4F6; // Light background
+    /// Gray used for default borders.
     pub const GRAY_200: u32 = 0xE5E7EB; // Border
+    /// Gray used for borders on hover.
     pub const GRAY_300: u32 = 0xD1D5DB; // Border hover
+    /// Gray used for muted text.
     pub const GRAY_400: u32 = 0x9CA3AF; // Muted text
+    /// Gray used for secondary text.
     pub const GRAY_500: u32 = 0x6B7280; // Secondary text
+    /// Gray used for primary text.
     pub const GRAY_600: u32 = 0x4B5563; // Primary text
+    /// Dark gray used for high-emphasis text.
     pub const GRAY_700: u32 = 0x374151; // Dark text
+    /// Darker gray, used for darker backgrounds.
     pub const GRAY_800: u32 = 0x1F2937; // Darker background
+    /// Darkest gray, used for the darkest background (e.g. toolbar).
     pub const GRAY_900: u32 = 0x111827; // Darkest background (toolbar)
 
     // Main background and text
+    /// Primary surface background color.
     pub const BG: u32 = WHITE;
+    /// Secondary surface background color.
     pub const BG_SECONDARY: u32 = GRAY_50;
+    /// Background color for hovered surfaces.
     pub const BG_HOVER: u32 = GRAY_100;
+    /// Primary foreground (text) color.
     pub const FG: u32 = GRAY_900;
+    /// Secondary foreground (text) color for less prominent content.
     pub const FG_SECONDARY: u32 = GRAY_500;
+    /// Muted foreground color for de-emphasized content.
     pub const MUTED: u32 = GRAY_400;
 
     // UI elements
+    /// Default border color.
     pub const BORDER: u32 = GRAY_200;
+    /// Border color on hover.
     pub const BORDER_HOVER: u32 = GRAY_300;
 
     // Toolbar (left side) - VSCode Light theme style
+    /// Toolbar background color.
     pub const TOOLBAR_BG: u32 = GRAY_100; // Light gray background
+    /// Toolbar item background color on hover.
     pub const TOOLBAR_HOVER: u32 = GRAY_200; // Slightly darker on hover
+    /// Toolbar text color.
     pub const TOOLBAR_TEXT: u32 = GRAY_600; // Dark gray text
+    /// Background color of the active toolbar item.
     pub const TOOLBAR_ACTIVE_BG: u32 = WHITE; // White background for active item
+    /// Text color of the active toolbar item.
     pub const TOOLBAR_ACTIVE_TEXT: u32 = ACCENT; // Blue text for active item
+    /// Toolbar border color.
     pub const TOOLBAR_BORDER: u32 = GRAY_200; // Border color
 
     // Accent colors
+    /// Primary accent color.
     pub const ACCENT: u32 = 0xDEA584; // Blue
+    /// Accent color on hover.
     pub const ACCENT_HOVER: u32 = 0x2563EB;
+    /// Light accent color, e.g. for subtle accent backgrounds.
     pub const ACCENT_LIGHT: u32 = 0xDCEEFF;
 
     // Status colors
+    /// Danger color, used for error messages and destructive actions.
     pub const DANGER: u32 = 0xDC2626; // Red, for error messages
 }

--- a/crates/nohrs-ui/src/window.rs
+++ b/crates/nohrs-ui/src/window.rs
@@ -1,3 +1,4 @@
+/// Platform traffic-light (window control button) configuration and hooks.
 pub mod traffic_lights;
 
 use gpui::{Bounds, Pixels, WindowBounds, WindowOptions};

--- a/crates/nohrs/src/main.rs
+++ b/crates/nohrs/src/main.rs
@@ -1,3 +1,6 @@
+//! The `nohrs` binary: parses CLI arguments, runs headless `config` subcommands
+//! when requested, and otherwise launches the gpui desktop application.
+
 mod app;
 mod cli;
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,13 +1,17 @@
 # cargo-deny configuration — licenses, advisories, dependency bans, sources.
 # Mirrors docs/testing.md §3. The CI `deny` job runs `cargo deny check`.
-# Detailed tuning of this file is tracked in #54.
 
 [advisories]
 # In CI, `bans`/`licenses`/`sources` are the required gate; `advisories` runs as
 # an informational (non-blocking) step — see .github/workflows/ci.yml. The gpui
 # async stack pulls several crates with open advisories that we cannot fix until
 # upstream bumps; surfacing them without blocking matches testing.md's
-# "informational early" stance. Tracked in #54.
+# "informational early" stance.
+#
+# testing.md §3 lists `vulnerability = "deny"`, but this cargo-deny version
+# removed the per-severity `vulnerability`/`notice` lint-level keys: advisories
+# of those kinds are always errors now, so the setting is implied (and would be
+# rejected as an unknown field if written out).
 db-urls = ["https://github.com/RustSec/advisory-db"]
 # Only flag unmaintained crates we depend on directly; transitive ones from the
 # gpui stack are out of our control.
@@ -43,10 +47,14 @@ deny = [
   # rustls unification — no OpenSSL in the tree.
   { name = "openssl-sys" },
   # NOTE: testing.md §3 also bans tokio outside the WASI plugin-execution layer
-  # (nohrs-plugin-host, P4+). It cannot be enforced yet: gpui pulls a full async
-  # reqwest stack (h2/hyper/tokio-util/...) that transitively depends on tokio,
-  # which the `wrappers` mechanism cannot express. App-core tokio removal (ADR
-  # 0004) and re-introducing this ban are tracked in #54.
+  # (nohrs-plugin-host, P4+). It cannot be enforced yet — two independent sources
+  # put tokio in the tree today:
+  #   1. nohrs-services depends on it directly (Cargo.toml), pending the app-core
+  #      tokio removal in ADR 0004 (P2).
+  #   2. gpui pulls a full async reqwest stack (zed-reqwest → hyper → h2 →
+  #      tokio-util → tokio) whose chain the `wrappers` allowlist cannot express.
+  # A hard `{ name = "tokio" }` deny would therefore fail CI immediately. Add it
+  # once (1) lands and (2) is shown to be expressible via `wrappers`.
 ]
 
 [sources]

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -1,7 +1,7 @@
 {
   "$defs": {
     "SortOrder": {
-      "description": "Column a directory listing is sorted by.",
+      "description": "The column a directory listing is ordered by.",
       "oneOf": [
         {
           "const": "name",

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -1,13 +1,29 @@
 {
   "$defs": {
     "SortOrder": {
-      "enum": [
-        "name",
-        "modified",
-        "size",
-        "kind"
-      ],
-      "type": "string"
+      "description": "Column a directory listing is sorted by.",
+      "oneOf": [
+        {
+          "const": "name",
+          "description": "Sort alphabetically by entry name.",
+          "type": "string"
+        },
+        {
+          "const": "modified",
+          "description": "Sort by last-modified time.",
+          "type": "string"
+        },
+        {
+          "const": "size",
+          "description": "Sort by file size.",
+          "type": "string"
+        },
+        {
+          "const": "kind",
+          "description": "Sort by entry kind (file/directory/...).",
+          "type": "string"
+        }
+      ]
     },
     "Theme": {
       "description": "Appearance settings.",
@@ -28,12 +44,24 @@
       "type": "object"
     },
     "ThemeMode": {
-      "enum": [
-        "system",
-        "light",
-        "dark"
-      ],
-      "type": "string"
+      "description": "Light/dark appearance selection.",
+      "oneOf": [
+        {
+          "const": "system",
+          "description": "Follow the operating system's light/dark preference.",
+          "type": "string"
+        },
+        {
+          "const": "light",
+          "description": "Always use the light appearance.",
+          "type": "string"
+        },
+        {
+          "const": "dark",
+          "description": "Always use the dark appearance.",
+          "type": "string"
+        }
+      ]
     },
     "Ui": {
       "description": "Explorer / view settings.",
@@ -68,10 +96,12 @@
       "type": "integer"
     },
     "theme": {
-      "$ref": "#/$defs/Theme"
+      "$ref": "#/$defs/Theme",
+      "description": "Appearance settings."
     },
     "ui": {
-      "$ref": "#/$defs/Ui"
+      "$ref": "#/$defs/Ui",
+      "description": "Explorer / view settings."
     }
   },
   "required": [

--- a/docs/plugin-templates.md
+++ b/docs/plugin-templates.md
@@ -227,7 +227,7 @@ poethepoet build
 |------|------|
 | plugin が load されない | `nohrs --log-level=debug` で `plugin host` 関連ログを確認 |
 | permission denied | nohrs UI の設定 → Plugins → 該当 plugin → permission 一覧で要確認 |
-| WIT 型エラー | `nohrs plugin check` で statically catch |
+| WIT 型エラー | `nohrs plugin check` で statically catches |
 | trap で crash | `auto_disabled_until` に記録、次回起動時に "Plugin X was disabled due to crash" 通知 |
 
 ---

--- a/docs/plugin-templates.md
+++ b/docs/plugin-templates.md
@@ -227,7 +227,7 @@ poethepoet build
 |------|------|
 | plugin が load されない | `nohrs --log-level=debug` で `plugin host` 関連ログを確認 |
 | permission denied | nohrs UI の設定 → Plugins → 該当 plugin → permission 一覧で要確認 |
-| WIT 型エラー | `nohrs plugin check` で staticly catch |
+| WIT 型エラー | `nohrs plugin check` で statically catch |
 | trap で crash | `auto_disabled_until` に記録、次回起動時に "Plugin X was disabled due to crash" 通知 |
 
 ---

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -144,31 +144,12 @@ reorder_imports = true
 
 ### `deny.toml`
 
-```toml
-[licenses]
-allow = ["MIT", "Apache-2.0", "Apache-2.0 WITH LLVM-exception", "BSD-2-Clause", "BSD-3-Clause", "Unicode-DFS-2016", "ISC", "Zlib"]
-confidence-threshold = 0.93
+実ファイル（リポジトリ root の [`deny.toml`](../deny.toml)）は当初案から次の点でずれている。理由はファイル内コメントに記載:
 
-[advisories]
-db-path = "~/.cargo/advisory-db"
-db-urls = ["https://github.com/RustSec/advisory-db"]
-vulnerability = "deny"
-unmaintained = "warn"
-yanked = "deny"
-
-[bans]
-multiple-versions = "warn"
-deny = [
-  # アプリコアでは禁止。WASI プラグイン実行層 (nohrs-plugin-host, P4 以降) のみ許可
-  { name = "tokio", wrappers = ["nohrs-plugin-host"] },
-  { name = "openssl-sys" },        # rustls 統一
-]
-
-[sources]
-unknown-registry = "deny"
-unknown-git = "deny"
-allow-git = []
-```
+- **`[licenses]`** — 実際の依存ツリーが要求するため許可リストを拡張（`0BSD` / `Unicode-3.0` / `MPL-2.0` / `CC0-1.0` / `NCSA`）。`Unicode-DFS-2016` は今の依存が `Unicode-3.0` を使うため不要。`confidence-threshold = 0.93` は同じ。
+- **`[advisories]`** — 現行 cargo-deny は per-severity の `vulnerability` / `notice` キーを廃止し、これらは常に error 扱い。よって `vulnerability = "deny"` は書かない（書くと unknown field で弾かれる）。`unmaintained = "workspace"`（直接依存のみ警告）、`yanked = "deny"`。CI では `advisories` のみ informational（`continue-on-error`）。
+- **`[bans]`** — `multiple-versions = "warn"` / `openssl-sys` を deny。`tokio` の ban は**まだ設置できない**: ① `nohrs-services` が直接依存（ADR 0004 / P2 で撤去予定）、② gpui が `zed-reqwest → hyper → h2 → tokio-util → tokio` を transitively 引き、`wrappers` で表現できない。両方が解消するまで hard ban は CI を即落とすため保留（deny.toml にコメントで明記）。
+- **`[sources]`** — `unknown-registry` / `unknown-git` を deny、`allow-git = []`。
 
 ---
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,11 @@
+# Formatting rules — mirrors docs/testing.md §3.
+#
+# `imports_granularity` and `group_imports` are nightly-only rustfmt options: the
+# stable toolchain (rust-toolchain.toml) parses but does not apply them, so
+# `cargo fmt --check` on stable enforces only `edition` / `reorder_imports`. They
+# are kept here so a nightly `cargo fmt` reorganizes imports consistently and so
+# the intended policy is documented in one place.
+edition = "2021"
+imports_granularity = "Crate"
+group_imports = "StdExternalCrate"
+reorder_imports = true

--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,26 @@
+# typos (https://github.com/crate-ci/typos) configuration — see docs/testing.md
+# §3. Project proper nouns and identifiers are allow-listed so the spell check
+# does not flag them. The CI `typos` job is a required gate.
+
+[files]
+# Generated or vendored content where typos must not gate.
+extend-exclude = [
+  "Cargo.lock",
+  # insta snapshots reproduce parsed input verbatim.
+  "*.snap",
+  # Generated JSON Schema.
+  "docs/config.schema.json",
+]
+
+[default]
+# Identifiers (code tokens) that are not misspellings. Matched against whole
+# identifiers as a regex.
+extend-ignore-identifiers-re = [
+  "noh.*rs",
+]
+
+[default.extend-words]
+# Proper nouns the dictionary would otherwise "correct".
+nohrs = "nohrs"
+gpui = "gpui"
+wasmtime = "wasmtime"


### PR DESCRIPTION
Closes #54 (partial — the tokio ban is deferred with a documented reason; see below).

Establishes the `docs/testing.md §3` static-analysis set (clippy.toml / rustfmt.toml / deny.toml / typos / cargo-machete) and wires it into CI, and turns on `missing_docs` across the workspace.

## What changed

**Static-analysis config**
- **`clippy.toml`** — `disallowed-methods` bans synchronous `std::fs::{read,write,read_to_string}` in app code (forces `nohrs-services::fs` or a background task; blocking I/O on the GPUI foreground thread stalls rendering). Legitimate exceptions carry a scoped `#[allow(clippy::disallowed_methods)]` with a reason: startup config I/O (`loader.rs`/`settings.rs`), the preview read already on `cx.background_spawn` (`preview.rs`), the search indexer on its own threads (`indexer.rs`), and test fixtures (per `mod tests`).
- **`rustfmt.toml`** — `edition` / `imports_granularity` / `group_imports` / `reorder_imports`. The two import-grouping options are nightly-only; the stable toolchain parses but ignores them (documented in the file), so `cargo fmt --check` stays green.
- **`typos.toml` + required `typos` CI job** — installs `typos` via the existing `taiki-e/install-action`; project proper nouns (nohrs / gpui / wasmtime) are allow-listed. Fixed one pre-existing typo (`staticly` → `statically`).
- **`machete.yml`** — `cargo-machete` on a **weekly** schedule (+ manual dispatch). Kept advisory/non-blocking, matching §3.
- **`deny.toml`** — `cargo deny check` was already required (`bans`/`licenses`/`sources`). Refreshed the comments to match the installed cargo-deny: the per-severity `vulnerability`/`notice` keys were removed upstream (those advisories are always errors now), so writing `vulnerability = "deny"` would be rejected.

**Workspace doc coverage**
- Enabled `missing_docs = "warn"` in `[workspace.lints.rust]` (promoted to an error in CI by `-D warnings`).
- Documented every public item flagged by the lint — ~285 across `nohrs-core`, `nohrs-models`, `nohrs-services`, `nohrs-ui`, `nohrs-pages`, and the `nohrs` binary.
- Regenerated `docs/config.schema.json`: the new doc comments on the config types flow into the schemars output as `description`s (and per-variant enum descriptions).

**Docs**
- `docs/testing.md §3` updated to describe the as-shipped `deny.toml` (expanded license allow-list, modern advisories format, deferred tokio ban) instead of the original pseudo-spec.

## Deferred: the tokio ban

The `[bans]` tokio entry from §3 **cannot be enabled yet** and would fail CI immediately, for two independent reasons (documented in `deny.toml`):
1. `nohrs-services` depends on `tokio` directly — removal is ADR 0004 / P2.
2. gpui pulls it transitively (`zed-reqwest → hyper → h2 → tokio-util → tokio`), a chain the `wrappers` allow-list cannot express.

Add the hard ban once (1) lands.

## Follow-up (not in this PR)

The new weekly `cargo-machete` run surfaces pre-existing unused deps left over from the workspace split (e.g. `nohrs-pages`: `anyhow`/`image`/`serde`/`serde_json`/`nohrs-models`; `nohrs`: `nohrs-models`; `nohrs-ui`: `nohrs-core`; `time` in core/services). Left for a dedicated cleanup PR so this one stays scoped to the tooling rollout.

## Verification

Not a user-visible change (config / CI / docs / doc-comments only), so no screenshots.

- `cargo fmt --all --check` ✓
- `cargo clippy --all-targets --locked -- -D warnings` ✓ (Linux/default-members tier)
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` ✓ (macOS-tier equivalent; confirms `missing_docs` is clean and the `disallowed_methods` allows are correct)
- `cargo test --locked` ✓ (44+ tests; `committed_schema_is_up_to_date` passes against the regenerated schema)
- `typos` ✓ clean
- `cargo-machete` runs (findings noted above)

## Suggested .rules additions

Two non-obvious traps hit while implementing this:

- Adding doc comments to the `Config`/`Theme`/`Ui` types (which `derive(JsonSchema)`) changes `docs/config.schema.json` — the `committed_schema_is_up_to_date` test then fails until the schema is regenerated (`nohrs config schema > docs/config.schema.json`, or `nohrs_core::config::json_schema_string()`).
- With `clippy::disallowed_methods` enabled for `std::fs`, test modules that write fixtures need a module-level `#[allow(clippy::disallowed_methods)]` (there is no `allow-*-in-tests` knob for it, unlike `unwrap_used`).

Release Notes:

- N/A

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add static analysis tooling and CI gates (`clippy`, `rustfmt`, `cargo deny`, `typos`, `cargo-machete`) to keep the workspace consistent. Enforce `missing_docs` across all crates and document public APIs, which updates the generated config schema. Also address review feedback in docs and regenerate the schema.

- **Refactors**
  - Enforce `missing_docs = "warn"` in `[workspace.lints.rust]`; add docs across the workspace. Regenerate `docs/config.schema.json` with `description`s from doc comments.
  - Ban sync filesystem calls in app code via `clippy::disallowed_methods` for `std::fs::{read, write, read_to_string}`; scoped `#[allow]` for startup config I/O, background tasks, search threads, and tests.
  - Add `rustfmt.toml` (edition/imports policy); nightly-only import grouping is parsed but ignored on stable.
  - Tidy doc wording: correct `FileEntryDto::kind` examples to `"symlink"` and reword `SortOrder` description; fix phrasing in `docs/plugin-templates.md`. Regenerate `docs/config.schema.json`.

- **Dependencies**
  - Add required `typos` CI job with `typos.toml` allow-list (checks code/comments; excludes generated docs). Fix one preexisting typo.
  - Add weekly `cargo-machete` workflow (advisory, manual dispatch supported).
  - Keep `cargo deny check` gates; refresh `deny.toml` comments for current `cargo-deny`. Defer a hard `tokio` ban due to a direct dep in services and a transitive chain via `gpui`.

<sup>Written for commit ef1d9d568a9e175b0e8b954c41a6c7675b09a891. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/noh-rs/nohrs/pull/150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search results now include the full matching line text alongside file path and line number.

* **Documentation**
  * Comprehensive documentation added across the codebase for clearer APIs, UI modules, and services.

* **Chores**
  * CI strengthened with a spell-check gate and a scheduled unused-dependency check.
  * Added spelling configuration, standardized formatting rules, and improved JSON schema descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->