### PR TITLE
Remove tokio from the application core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3987,7 +3987,6 @@ dependencies = [
  "nohrs-pages",
  "nohrs-services",
  "nohrs-ui",
- "tokio",
  "tracing",
 ]
 
@@ -4040,6 +4039,7 @@ name = "nohrs-services"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "async-channel 2.5.0",
  "dirs 5.0.1",
  "gpui",
  "grep",
@@ -4048,12 +4048,12 @@ dependencies = [
  "nohrs-models",
  "notify",
  "notify-debouncer-mini",
+ "postage",
  "serde",
  "syntect",
  "tantivy",
  "tempfile",
  "time",
- "tokio",
  "tracing",
 ]
 
@@ -6761,19 +6761,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
- "tokio-macros",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.111",
 ]
 
 [[package]]

--- a/crates/nohrs-services/Cargo.toml
+++ b/crates/nohrs-services/Cargo.toml
@@ -25,7 +25,8 @@ anyhow.workspace  = true
 serde.workspace   = true
 tracing.workspace = true
 time.workspace    = true
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time"] }
+async-channel = "2"
+postage = "0.5"
 tantivy = "0.26"
 ignore = "0.4"
 grep = "0.4"

--- a/crates/nohrs-services/src/search.rs
+++ b/crates/nohrs-services/src/search.rs
@@ -67,7 +67,7 @@ impl SearchService {
     }
 
     /// Returns a receiver for initial-indexing progress in the range `0.0..=1.0`.
-    pub fn progress_subscription(&self) -> tokio::sync::watch::Receiver<f32> {
+    pub fn progress_subscription(&self) -> postage::watch::Receiver<f32> {
         self.engine.progress_subscription()
     }
 }

--- a/crates/nohrs-services/src/search/engine.rs
+++ b/crates/nohrs-services/src/search/engine.rs
@@ -2,10 +2,7 @@ use super::indexer::IndexManager;
 use super::watcher::FileWatcher;
 use super::{SearchBackend, SearchResult, SearchScope};
 use anyhow::{Context, Result};
-use nohrs_core::telemetry::LogErr;
 use std::sync::{Arc, Mutex};
-use tokio::sync::mpsc;
-use tokio::task::JoinHandle;
 
 /// Deferred initial-indexing work handed to the caller so it can run on GPUI's
 /// background executor (`cx.background_spawn`) instead of a `tokio::task::
@@ -13,7 +10,7 @@ use tokio::task::JoinHandle;
 /// `Send` handles so the GUI can move it onto a worker thread.
 pub struct InitialIndexingJob {
     index_manager: Arc<IndexManager>,
-    progress_tx: tokio::sync::watch::Sender<f32>,
+    progress_tx: postage::watch::Sender<f32>,
 }
 
 impl InitialIndexingJob {
@@ -22,7 +19,7 @@ impl InitialIndexingJob {
     pub fn run(self) {
         let InitialIndexingJob {
             index_manager,
-            progress_tx,
+            mut progress_tx,
         } = self;
 
         // Check if schema has required fields (detects schema changes)
@@ -31,7 +28,7 @@ impl InitialIndexingJob {
 
         if !has_filename_field {
             tracing::info!("Schema outdated (missing filename field), forcing full indexing...");
-            progress_tx.send(0.0).log_err();
+            *progress_tx.borrow_mut() = 0.0;
             if let Err(e) = index_manager.index_home(Some(progress_tx)) {
                 tracing::error!("Initial indexing failed: {}", e);
             }
@@ -44,7 +41,7 @@ impl InitialIndexingJob {
                 let doc_count = reader.searcher().num_docs();
                 if doc_count == 0 {
                     tracing::info!("Index is empty, starting full indexing...");
-                    progress_tx.send(0.0).log_err(); // Reset to 0 for indexing
+                    *progress_tx.borrow_mut() = 0.0; // Reset to 0 for indexing
                     if let Err(e) = index_manager.index_home(Some(progress_tx)) {
                         tracing::error!("Initial indexing failed: {}", e);
                     }
@@ -58,7 +55,7 @@ impl InitialIndexingJob {
             }
             Err(e) => {
                 tracing::warn!("Failed to read index, running full indexing: {}", e);
-                progress_tx.send(0.0).log_err();
+                *progress_tx.borrow_mut() = 0.0;
                 if let Err(e) = index_manager.index_home(Some(progress_tx)) {
                     tracing::error!("Initial indexing failed: {}", e);
                 }
@@ -72,8 +69,10 @@ pub struct SearchEngine {
     index_manager: Arc<IndexManager>,
     root_backend: Arc<dyn SearchBackend>,
     _watcher: FileWatcher, // Keep alive
-    _watcher_task: JoinHandle<()>,
-    progress_rx: tokio::sync::watch::Receiver<f32>,
+    // The consumer thread exits on its own once `_watcher` drops and closes the
+    // channel; declared after `_watcher` so that drop order makes that happen.
+    _watcher_task: std::thread::JoinHandle<()>,
+    progress_rx: postage::watch::Receiver<f32>,
     // Taken once by `take_initial_indexing_job`; `None` afterwards.
     initial_indexing_job: Mutex<Option<InitialIndexingJob>>,
 }
@@ -92,21 +91,20 @@ impl SearchEngine {
             std::path::PathBuf::from("/"),
         ));
 
-        // Channel for watcher events.
-        // P2 (#56 follow-up): replace tokio::sync::mpsc with async-channel and
-        // the tokio::spawn consumer below with cx.background_spawn (async-runtime.md §2).
-        let (tx, mut rx) = mpsc::channel(100);
+        // Bounded channel for watcher events (async-channel; runtime-agnostic).
+        let (tx, rx) = async_channel::bounded(100);
 
         let home_dir = dirs::home_dir().context("Home directory not found")?;
         use std::time::Duration;
         let watcher = FileWatcher::new(home_dir, tx, Duration::from_secs(2))?;
 
-        // Spawn event handler task.
-        // P2: this tokio::spawn + rx.recv().await keeps the residual tokio runtime
-        // alive; move to cx.background_spawn over an async-channel receiver.
+        // The watcher consumer does blocking index updates, so it runs on a
+        // dedicated std::thread rather than an async task (async-runtime.md §4).
+        // `recv_blocking` returns `Err` once every sender drops (i.e. when the
+        // watcher above is dropped), which lets the thread exit cleanly.
         let manager_clone = index_manager.clone();
-        let watcher_task = tokio::spawn(async move {
-            while let Some(paths) = rx.recv().await {
+        let watcher_task = std::thread::spawn(move || {
+            while let Ok(paths) = rx.recv_blocking() {
                 if let Err(e) = manager_clone.process_changes(&paths) {
                     tracing::warn!("Failed to process batch changes: {}", e);
                 }
@@ -114,8 +112,7 @@ impl SearchEngine {
         });
 
         // Progress channel for initial indexing (starts at 1.0 == done).
-        // P2: replace tokio::sync::watch with postage::watch (async-runtime.md §2).
-        let (progress_tx, progress_rx) = tokio::sync::watch::channel(1.0);
+        let (progress_tx, progress_rx) = postage::watch::channel_with(1.0);
 
         // The actual indexing is deferred to the caller (the GUI) so it runs on
         // GPUI's background executor instead of a service-owned spawn_blocking.
@@ -135,7 +132,7 @@ impl SearchEngine {
     }
 
     /// Returns a receiver for initial-indexing progress in the range `0.0..=1.0`.
-    pub fn progress_subscription(&self) -> tokio::sync::watch::Receiver<f32> {
+    pub fn progress_subscription(&self) -> postage::watch::Receiver<f32> {
         self.progress_rx.clone()
     }
 

--- a/crates/nohrs-services/src/search/indexer.rs
+++ b/crates/nohrs-services/src/search/indexer.rs
@@ -1,5 +1,4 @@
 use anyhow::{Context, Result};
-use nohrs_core::telemetry::LogErr;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
@@ -96,7 +95,7 @@ impl IndexManager {
     // writer() helper removed as we use shared writer
 
     /// Indexes the content root from scratch, reporting progress through `progress_tx` if given.
-    pub fn index_home(&self, progress_tx: Option<tokio::sync::watch::Sender<f32>>) -> Result<()> {
+    pub fn index_home(&self, mut progress_tx: Option<postage::watch::Sender<f32>>) -> Result<()> {
         let mut writer_guard = self
             .writer
             .lock()
@@ -117,8 +116,8 @@ impl IndexManager {
 
         // 1. Count files if progress tracking is enabled
         let mut total_files = 0;
-        if let Some(tx) = &progress_tx {
-            tx.send(0.0).log_err();
+        if let Some(tx) = &mut progress_tx {
+            *tx.borrow_mut() = 0.0;
             let walker = ignore::WalkBuilder::new(&self.content_root)
                 .hidden(false)
                 .git_ignore(true)
@@ -168,9 +167,9 @@ impl IndexManager {
 
                     // Update progress
                     processed += 1;
-                    if let Some(tx) = &progress_tx {
+                    if let Some(tx) = &mut progress_tx {
                         if total_files > 0 && processed % 100 == 0 {
-                            tx.send(processed as f32 / total_files as f32).log_err();
+                            *tx.borrow_mut() = processed as f32 / total_files as f32;
                         }
                     }
                 }
@@ -178,8 +177,8 @@ impl IndexManager {
             }
         }
 
-        if let Some(tx) = &progress_tx {
-            tx.send(1.0).log_err(); // Done
+        if let Some(tx) = &mut progress_tx {
+            *tx.borrow_mut() = 1.0; // Done
         }
 
         writer_guard.commit()?;

--- a/crates/nohrs-services/src/search/watcher.rs
+++ b/crates/nohrs-services/src/search/watcher.rs
@@ -4,10 +4,10 @@ use notify_debouncer_mini::{new_debouncer, DebounceEventResult, Debouncer};
 use std::path::PathBuf;
 use std::time::Duration;
 // `notify` / `notify-debouncer-mini` are runtime-agnostic (they drive their own
-// std::thread), so the watcher itself needs no change for the tokio removal.
-// P2 (#56 follow-up): swap this tokio::sync::mpsc sender for an async-channel
-// sender once the consumer task moves off tokio (async-runtime.md §2).
-use tokio::sync::mpsc;
+// std::thread). The debounce callback runs on that thread, so it forwards
+// batches over an `async-channel` sender with the blocking `send_blocking`
+// (async-runtime.md §2/§4).
+use async_channel::Sender;
 
 /// Watches a directory tree and forwards debounced batches of changed paths.
 pub struct FileWatcher {
@@ -18,15 +18,14 @@ pub struct FileWatcher {
 impl FileWatcher {
     /// Starts watching `root` recursively, sending debounced change batches on `tx`
     /// with the given debounce `timeout`.
-    pub fn new(root: PathBuf, tx: mpsc::Sender<Vec<PathBuf>>, timeout: Duration) -> Result<Self> {
+    pub fn new(root: PathBuf, tx: Sender<Vec<PathBuf>>, timeout: Duration) -> Result<Self> {
         // Create debouncer with specified timeout
         let mut debouncer = new_debouncer(timeout, move |res: DebounceEventResult| {
             match res {
                 Ok(events) => {
                     let paths: Vec<PathBuf> = events.into_iter().map(|e| e.path).collect();
-                    // Blocking send is fine here as we are in a separate thread managed by notify
-                    // But wait, tx is tokio sender. We need blocking_send inside this sync closure.
-                    if let Err(e) = tx.blocking_send(paths) {
+                    // We run on notify's own thread, so a blocking send is correct here.
+                    if let Err(e) = tx.send_blocking(paths) {
                         tracing::warn!("Failed to send watcher events: {}", e);
                         // Receiver dropped, we can't do much.
                     }

--- a/crates/nohrs/Cargo.toml
+++ b/crates/nohrs/Cargo.toml
@@ -24,7 +24,6 @@ nohrs-ui       = { path = "../nohrs-ui" }
 nohrs-pages    = { path = "../nohrs-pages" }
 gpui = "0.2"
 gpui-component = "0.3"
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tracing.workspace = true
 clap = { version = "4", features = ["derive"] }
 

--- a/crates/nohrs/src/app.rs
+++ b/crates/nohrs/src/app.rs
@@ -41,22 +41,9 @@ impl NohrsApp {
         let config_error = config::report_diagnostics(&diagnostics);
 
         // GPUI drives the app (replacing `#[tokio::main]`; ADR 0004, async-runtime.md
-        // §7 P1). A small residual tokio runtime is kept and entered on this thread
-        // only so the watcher task (`tokio::spawn`) and channels (`tokio::sync::*`)
-        // inside `SearchService::new` still resolve a runtime. P2 removes those last
-        // tokio users and this runtime with them.
-        let runtime = match tokio::runtime::Builder::new_multi_thread()
-            .enable_all()
-            .build()
-        {
-            Ok(runtime) => runtime,
-            Err(error) => {
-                tracing::error!("failed to start async runtime: {error}");
-                return;
-            }
-        };
-        let _runtime_guard = runtime.enter();
-
+        // §7). The search service is now tokio-free — its file watcher and progress
+        // channels run on std threads and runtime-agnostic channels — so no async
+        // runtime needs to be entered here.
         Application::new().with_assets(Assets).run(move |app: &mut App| {
             gpui_component::init(app);
             let resizable = ResizableState::new(app);

--- a/deny.toml
+++ b/deny.toml
@@ -48,10 +48,12 @@ deny = [
   { name = "openssl-sys" },
   # NOTE: testing.md §3 also bans tokio outside the WASI plugin-execution layer
   # (nohrs-plugin-host, P4+). The app-core tokio removal (ADR 0004 / #64, P2) is
-  # done — no nohrs-* crate depends on tokio, and `cargo tree | grep '^tokio'` is
-  # empty. A hard `{ name = "tokio" }` deny still cannot be enforced because gpui
-  # itself pulls a full async reqwest stack as a non-optional dependency
-  # (gpui → gpui_http_client → zed-reqwest → hyper → h2 → tokio). tokio's direct
+  # done: no first-party (nohrs-*) crate depends on tokio directly any more.
+  # tokio is still present transitively, however, because gpui pulls a full async
+  # reqwest stack as a non-optional dependency
+  # (gpui → gpui_http_client → zed-reqwest → hyper → h2 → tokio) — `cargo tree -i
+  # tokio` roots only in that chain, never in a first-party crate. A hard
+  # `{ name = "tokio" }` deny therefore still cannot be enforced: tokio's direct
   # parents in that chain (h2, hyper, hyper-util, tokio-rustls, tokio-socks, …)
   # cannot be cleanly expressed via the `wrappers` allowlist. Add the hard deny
   # once gpui's HTTP stack can be feature-gated off (or a tokio-free gpui ships).

--- a/deny.toml
+++ b/deny.toml
@@ -47,14 +47,14 @@ deny = [
   # rustls unification — no OpenSSL in the tree.
   { name = "openssl-sys" },
   # NOTE: testing.md §3 also bans tokio outside the WASI plugin-execution layer
-  # (nohrs-plugin-host, P4+). It cannot be enforced yet — two independent sources
-  # put tokio in the tree today:
-  #   1. nohrs-services depends on it directly (Cargo.toml), pending the app-core
-  #      tokio removal in ADR 0004 (P2).
-  #   2. gpui pulls a full async reqwest stack (zed-reqwest → hyper → h2 →
-  #      tokio-util → tokio) whose chain the `wrappers` allowlist cannot express.
-  # A hard `{ name = "tokio" }` deny would therefore fail CI immediately. Add it
-  # once (1) lands and (2) is shown to be expressible via `wrappers`.
+  # (nohrs-plugin-host, P4+). The app-core tokio removal (ADR 0004 / #64, P2) is
+  # done — no nohrs-* crate depends on tokio, and `cargo tree | grep '^tokio'` is
+  # empty. A hard `{ name = "tokio" }` deny still cannot be enforced because gpui
+  # itself pulls a full async reqwest stack as a non-optional dependency
+  # (gpui → gpui_http_client → zed-reqwest → hyper → h2 → tokio). tokio's direct
+  # parents in that chain (h2, hyper, hyper-util, tokio-rustls, tokio-socks, …)
+  # cannot be cleanly expressed via the `wrappers` allowlist. Add the hard deny
+  # once gpui's HTTP stack can be feature-gated off (or a tokio-free gpui ships).
 ]
 
 [sources]


### PR DESCRIPTION
Completes the app-core scope of the tokio removal (ADR 0004, `docs/async-runtime.md` §2/§4). The last tokio users lived in the search service; they are replaced with runtime-agnostic primitives so no `nohrs-*` crate depends on tokio.

## What changed

- `tokio::sync::watch` → **`postage::watch`** for indexing progress (`channel_with` / `borrow_mut` producer / `borrow` consumer).
- `tokio::sync::mpsc` → **`async-channel`** (bounded) for file-watcher events, using `send_blocking` from notify's thread.
- The `tokio::spawn` watcher consumer → a dedicated **`std::thread`** that drains the channel with `recv_blocking` and exits cleanly when the watcher drops (field drop order guarantees the channel closes first).
- Removed the residual multi-thread **tokio runtime** from app startup — GPUI drives the app, and the service no longer needs an ambient runtime.
- Dropped `tokio` from `nohrs-services` and `nohrs` `Cargo.toml`.

`tokio::time::*`, `oneshot`, async `Mutex`, and an HTTP client (ureq) had no occurrences in the app core, so those mapping rows are N/A for now.

## Result

`cargo tree | grep -E '^tokio'` is now **empty** — tokio is no longer a dependency of any first-party crate.

A hard `{ name = "tokio" }` ban in `deny.toml` still cannot be enabled: `gpui` pulls tokio transitively through its **non-optional** HTTP client (`gpui_http_client → zed-reqwest → hyper → h2 → tokio`), and that chain's direct parents can't be cleanly expressed via the cargo-deny `wrappers` allowlist. The `[bans]` comment is updated to record this; the ban can land once gpui's HTTP stack is feature-gatable or a tokio-free gpui ships. For that reason this is **Toward #64** rather than a full close.

## Verification

Internal async refactor with no user-visible change. Verified via the local gate — `cargo fmt --check`, `cargo clippy --all-features -- -D warnings -W clippy::unwrap_used -W clippy::expect_used`, and `cargo test` (full workspace with gpui linked: 50 passed / 0 failed) — plus a headless GUI smoke test (Xvfb + llvmpipe) to confirm the runtime change does not break the running app:

- **App boots with no startup panic** — the removed residual tokio runtime is no longer needed.
- **Initial indexing runs** on `cx.background_spawn` (confirmed by tantivy logs), and **file browsing / preview** render.
- **Full-text search works end-to-end** — `fn main` returns "16 matches in content", exercising `SearchService::search` on the background executor with results delivered over the new `async-channel` / `postage` plumbing (no tokio runtime).

![demo](https://raw.githubusercontent.com/noh-rs/nohrs/pr-assets/screenshots/pr153-tokio-removal/2982771-28238/demo.gif)

Browse + preview, and search results:

![browse and preview](https://raw.githubusercontent.com/noh-rs/nohrs/pr-assets/screenshots/pr153-tokio-removal/2982771-28238/browse-and-preview.png)
![search results](https://raw.githubusercontent.com/noh-rs/nohrs/pr-assets/screenshots/pr153-tokio-removal/2982771-28238/search-results.png)

Full clip (mp4): https://raw.githubusercontent.com/noh-rs/nohrs/pr-assets/screenshots/pr153-tokio-removal/2982771-28238/demo.mp4

Release Notes:

- N/A

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed `tokio` from the app core by refactoring the search service to runtime-agnostic primitives. Startup no longer creates a Tokio runtime; all first-party crates are `tokio`-free, with `tokio` only present transitively via `gpui`.

- **Refactors**
  - Progress: `tokio::sync::watch` → `postage::watch`.
  - Watcher events: `tokio::sync::mpsc` → `async-channel` (bounded) with `send_blocking` on the notify thread.
  - Replaced `tokio::spawn` with a `std::thread` that drains via `recv_blocking` and exits when the watcher drops.
  - Removed the residual multi-thread runtime from app startup; GPUI drives the app.

- **Dependencies**
  - Added `async-channel` and `postage`; removed `tokio` from `nohrs-services` and `nohrs`.
  - Updated `deny.toml` to clarify that no first-party crates depend on `tokio` directly; a hard ban remains blocked by `gpui`’s non-optional HTTP chain (`gpui_http_client` → `zed-reqwest` → `hyper` → `h2` → `tokio`).

<sup>Written for commit e748f90d42ef1cba9087297cd1a35c445ab8b5d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/noh-rs/nohrs/pull/153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Search service made runtime-agnostic: startup no longer initializes a dedicated async runtime, reducing resource usage.
  * Progress reporting for indexing made lighter and more reliable across threads/runtimes.
  * File-watching and event dispatching streamlined for more efficient, predictable change handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
