### PR TITLE
nohrs-store: Add SQLite + redb persistence crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,7 +229,7 @@ jobs:
         id: rate
         shell: bash
         run: |
-          rate=$(grep -o 'line-rate="[0-9.]*"' cobertura-core.xml | head -1 | grep -o '[0-9.]*' | head -1)
+          rate=$(grep -o -m1 'line-rate="[0-9.]*"' cobertura-core.xml | grep -o -m1 '[0-9.]*')
           pct=$(awk "BEGIN { printf \"%.2f\", ${rate:-0} * 100 }")
           echo "rate=${pct}" >> "$GITHUB_OUTPUT"
       # GitHub native code coverage (PR diff inline). Skipped for PRs from forks,
@@ -292,7 +292,7 @@ jobs:
         id: rate
         shell: bash
         run: |
-          rate=$(grep -o 'line-rate="[0-9.]*"' cobertura-overall.xml | head -1 | grep -o '[0-9.]*' | head -1)
+          rate=$(grep -o -m1 'line-rate="[0-9.]*"' cobertura-overall.xml | grep -o -m1 '[0-9.]*')
           pct=$(awk "BEGIN { printf \"%.2f\", ${rate:-0} * 100 }")
           echo "rate=${pct}" >> "$GITHUB_OUTPUT"
       - name: Upload coverage to GitHub

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1856,6 +1856,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fancy-regex"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2845,6 +2857,9 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -2864,6 +2879,15 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -3568,6 +3592,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "libz-sys"
 version = "1.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4054,6 +4089,17 @@ dependencies = [
  "tantivy",
  "tempfile",
  "time",
+ "tracing",
+]
+
+[[package]]
+name = "nohrs-store"
+version = "0.2.0"
+dependencies = [
+ "redb",
+ "rusqlite",
+ "tempfile",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
@@ -5211,6 +5257,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redb"
+version = "2.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eca1e9d98d5a7e9002d0013e18d5a9b000aee942eb134883a82f06ebffb6c01"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5339,6 +5394,20 @@ name = "roxmltree"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+
+[[package]]
+name = "rusqlite"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+dependencies = [
+ "bitflags 2.10.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
 
 [[package]]
 name = "rust-embed"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,11 +5,11 @@ members = [
   "crates/nohrs-core",
   "crates/nohrs-models",
   "crates/nohrs-services",
+  "crates/nohrs-store",
   "crates/nohrs-ui",
   "crates/nohrs-pages",
 ]
 # P2 以降に追加:
-#   "crates/nohrs-store",
 #   "crates/nohrs-launcher",
 #   "crates/nohrs-plugin-host",
 #   "crates/plugins/*"
@@ -24,6 +24,7 @@ default-members = [
   "crates/nohrs-core",
   "crates/nohrs-models",
   "crates/nohrs-services",
+  "crates/nohrs-store",
 ]
 
 [workspace.package]

--- a/crates/nohrs-core/src/config.rs
+++ b/crates/nohrs-core/src/config.rs
@@ -19,7 +19,8 @@ pub mod watcher;
 pub use loader::{backup, ensure_exists, needs_migration, reset, write_default};
 pub use settings::{
     json_schema_string, load_from_path, report_diagnostics, Config, ConfigOverride, Diagnostic,
-    DiagnosticLevel, SortOrder, Theme, ThemeMode, Ui, CURRENT_SCHEMA_VERSION, SCHEMA_URL,
+    DiagnosticLevel, Diagnostics, DiagnosticsStore, SortOrder, Theme, ThemeMode, Ui,
+    CURRENT_SCHEMA_VERSION, SCHEMA_URL,
 };
 pub use watcher::ConfigWatcher;
 

--- a/crates/nohrs-core/src/config/settings.rs
+++ b/crates/nohrs-core/src/config/settings.rs
@@ -22,10 +22,10 @@ pub const SCHEMA_URL: &str = "https://nohrs.app/schema/config.schema.json";
 
 /// The fully merged, validated configuration.
 ///
-/// Only the P1 surface (`theme` / `ui`) is modelled here. `[keybindings]` and
-/// `[plugins]` are recognised as reserved sections (see [`is_reserved_section`])
-/// but intentionally not deserialized yet, so their future shapes can be added
-/// without breaking older files.
+/// Models the P1 surface (`theme` / `ui`) plus the P2 `[diagnostics]` section.
+/// `[keybindings]` and `[plugins]` are recognised as reserved sections (see
+/// [`is_reserved_section`]) but intentionally not deserialized yet, so their
+/// future shapes can be added without breaking older files.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct Config {
     /// On-disk schema version. Must be [`CURRENT_SCHEMA_VERSION`] for this build.
@@ -34,6 +34,8 @@ pub struct Config {
     pub theme: Theme,
     /// Explorer / view settings.
     pub ui: Ui,
+    /// Diagnostics / performance-logging settings.
+    pub diagnostics: Diagnostics,
 }
 
 impl Default for Config {
@@ -42,6 +44,7 @@ impl Default for Config {
             schema_version: CURRENT_SCHEMA_VERSION,
             theme: Theme::default(),
             ui: Ui::default(),
+            diagnostics: Diagnostics::default(),
         }
     }
 }
@@ -84,6 +87,27 @@ impl Default for Ui {
             icon_pack: "default".to_string(),
         }
     }
+}
+
+/// Diagnostics / performance-logging settings (see `docs/persistence.md` §5).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct Diagnostics {
+    /// Performance logging for the persistence layer (`nohrs-store`).
+    pub store: DiagnosticsStore,
+}
+
+/// Performance logging for the SQLite / redb store. All off by default, so a
+/// default config adds no overhead. Output goes through `tracing` (targets
+/// `nohrs_store::sql` / `nohrs_store::redb`) and is filterable with `RUST_LOG`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct DiagnosticsStore {
+    /// Log every SQL query at `debug` (verbose).
+    pub log_all_queries: bool,
+    /// Log SQL queries slower than this many milliseconds at `warn`. Zero (the
+    /// default) disables slow-query logging.
+    pub slow_query_ms: u64,
+    /// Log redb `get`/`put`/`delete`/`batch` operations and their durations.
+    pub log_redb_ops: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
@@ -309,10 +333,25 @@ impl Config {
                 None => diagnostics.push(Diagnostic::warn("[ui] is not a table; ignoring")),
             }
         }
+        if let Some(value) = table.get("diagnostics") {
+            match value.as_table() {
+                Some(diag) => read_diagnostics(diag, &mut config.diagnostics, &mut diagnostics),
+                None => {
+                    diagnostics.push(Diagnostic::warn("[diagnostics] is not a table; ignoring"))
+                }
+            }
+        }
 
         warn_unknown_keys(
             table,
-            &["schema_version", "theme", "ui", "keybindings", "plugins"],
+            &[
+                "schema_version",
+                "theme",
+                "ui",
+                "diagnostics",
+                "keybindings",
+                "plugins",
+            ],
             "",
             &mut diagnostics,
         );
@@ -340,6 +379,13 @@ impl Config {
              default_sort = \"name\"   # \"name\" | \"modified\" | \"size\" | \"kind\"\n\
              show_hidden = false\n\
              icon_pack = \"default\"\n\
+             \n\
+             # Store performance logging for analysis; all off by default.\n\
+             # Output via tracing (RUST_LOG), see docs/persistence.md §5.\n\
+             [diagnostics.store]\n\
+             log_all_queries = false   # log every SQL query at debug\n\
+             slow_query_ms = 0         # warn on SQL slower than this (0 = off)\n\
+             log_redb_ops = false      # log redb get/put/delete/batch timings\n\
              \n\
              # Reserved for future use; left empty in P1.\n\
              [keybindings]\n\
@@ -409,6 +455,62 @@ fn read_ui(table: &toml::Table, ui: &mut Ui, diagnostics: &mut Vec<Diagnostic>) 
         table,
         &["default_sort", "show_hidden", "icon_pack"],
         "ui.",
+        diagnostics,
+    );
+}
+
+fn read_diagnostics(
+    table: &toml::Table,
+    diag: &mut Diagnostics,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    if let Some(value) = table.get("store") {
+        match value.as_table() {
+            Some(store) => read_diagnostics_store(store, &mut diag.store, diagnostics),
+            None => diagnostics.push(Diagnostic::warn(
+                "[diagnostics.store] is not a table; ignoring",
+            )),
+        }
+    }
+    warn_unknown_keys(table, &["store"], "diagnostics.", diagnostics);
+}
+
+fn read_diagnostics_store(
+    table: &toml::Table,
+    store: &mut DiagnosticsStore,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    if let Some(value) = table.get("log_all_queries") {
+        match value.as_bool() {
+            Some(flag) => store.log_all_queries = flag,
+            None => diagnostics.push(Diagnostic::warn(format!(
+                "invalid diagnostics.store.log_all_queries {value}; using {}",
+                store.log_all_queries
+            ))),
+        }
+    }
+    if let Some(value) = table.get("slow_query_ms") {
+        match value.as_integer() {
+            Some(ms) if ms >= 0 => store.slow_query_ms = ms as u64,
+            _ => diagnostics.push(Diagnostic::warn(format!(
+                "invalid diagnostics.store.slow_query_ms {value}; using {}",
+                store.slow_query_ms
+            ))),
+        }
+    }
+    if let Some(value) = table.get("log_redb_ops") {
+        match value.as_bool() {
+            Some(flag) => store.log_redb_ops = flag,
+            None => diagnostics.push(Diagnostic::warn(format!(
+                "invalid diagnostics.store.log_redb_ops {value}; using {}",
+                store.log_redb_ops
+            ))),
+        }
+    }
+    warn_unknown_keys(
+        table,
+        &["log_all_queries", "slow_query_ms", "log_redb_ops"],
+        "diagnostics.store.",
         diagnostics,
     );
 }
@@ -566,6 +668,36 @@ mod tests {
         assert_eq!(config.ui.default_sort, SortOrder::Modified);
         assert!(config.ui.show_hidden);
         assert_eq!(config.ui.icon_pack, "nerd");
+    }
+
+    #[test]
+    fn parses_diagnostics_store() {
+        let toml = r#"
+            [diagnostics.store]
+            log_all_queries = true
+            slow_query_ms = 50
+            log_redb_ops = true
+        "#;
+        let (config, diagnostics) = Config::from_toml_str(toml);
+        assert!(diagnostics.is_empty(), "{diagnostics:?}");
+        assert!(config.diagnostics.store.log_all_queries);
+        assert_eq!(config.diagnostics.store.slow_query_ms, 50);
+        assert!(config.diagnostics.store.log_redb_ops);
+    }
+
+    #[test]
+    fn diagnostics_store_rejects_bad_values_leniently() {
+        let toml = r#"
+            [diagnostics.store]
+            slow_query_ms = -5
+            log_all_queries = "yes"
+        "#;
+        let (config, diagnostics) = Config::from_toml_str(toml);
+        assert!(errors(&diagnostics).is_empty());
+        // Bad values fall back to defaults.
+        assert_eq!(config.diagnostics.store.slow_query_ms, 0);
+        assert!(!config.diagnostics.store.log_all_queries);
+        assert_eq!(diagnostics.len(), 2);
     }
 
     #[test]

--- a/crates/nohrs-core/src/config/snapshots/nohrs_core__config__settings__tests__from_toml_str_output_snapshot.snap
+++ b/crates/nohrs-core/src/config/snapshots/nohrs_core__config__settings__tests__from_toml_str_output_snapshot.snap
@@ -14,6 +14,13 @@ expression: parsed
             show_hidden: true,
             icon_pack: "default",
         },
+        diagnostics: Diagnostics {
+            store: DiagnosticsStore {
+                log_all_queries: false,
+                slow_query_ms: 0,
+                log_redb_ops: false,
+            },
+        },
     },
     [
         Diagnostic {

--- a/crates/nohrs-store/Cargo.toml
+++ b/crates/nohrs-store/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "nohrs-store"
+description = "Persistence layer: SQLite (metadata/history) and redb (host KV) behind interface-segregated traits."
+version.workspace      = true
+edition.workspace      = true
+rust-version.workspace = true
+license.workspace      = true
+repository.workspace   = true
+homepage.workspace     = true
+authors.workspace      = true
+
+[lib]
+name = "nohrs_store"
+path = "src/nohrs_store.rs"
+
+[dependencies]
+thiserror.workspace = true
+tracing.workspace   = true
+# `bundled` vendors SQLite (no OS dependency, stable docker/nix). `blob` enables
+# incremental BLOB I/O (reserved for P3 content hashing). `trace` exposes the
+# `profile` hook used by the diagnostics query logger. No tokio is pulled in.
+rusqlite = { version = "0.31", features = ["bundled", "blob", "trace"] }
+redb     = "2"
+
+[dev-dependencies]
+tempfile = "3"
+
+[lints]
+workspace = true

--- a/crates/nohrs-store/migrations/001_init.sql
+++ b/crates/nohrs-store/migrations/001_init.sql
@@ -1,0 +1,25 @@
+-- Initial schema for the nohrs metadata/history store (docs/persistence.md §2).
+-- Forward-only; the `_migrations` bookkeeping table is created by the runner.
+-- Host KV (window position, tab/session restore) lives in redb, not here.
+
+CREATE TABLE files (
+    id            INTEGER PRIMARY KEY,
+    path          TEXT NOT NULL UNIQUE,
+    parent_path   TEXT NOT NULL,
+    inode         INTEGER NOT NULL,
+    size          INTEGER NOT NULL,
+    mtime_ns      INTEGER NOT NULL,
+    content_hash  BLOB,                   -- blake3 first-N-KB hash (P3)
+    indexed_at    INTEGER,                -- Tantivy indexing time (P3)
+    deleted_at    INTEGER                 -- logical delete (P3 watcher)
+);
+CREATE INDEX idx_files_parent ON files(parent_path);
+CREATE INDEX idx_files_inode  ON files(inode);
+
+CREATE TABLE history (
+    id          INTEGER PRIMARY KEY,
+    kind        TEXT NOT NULL,            -- "open" | "search" | "command"
+    payload     TEXT NOT NULL,
+    occurred_at INTEGER NOT NULL
+);
+CREATE INDEX idx_history_kind_time ON history(kind, occurred_at DESC);

--- a/crates/nohrs-store/migrations/001_init.sql
+++ b/crates/nohrs-store/migrations/001_init.sql
@@ -18,7 +18,7 @@ CREATE INDEX idx_files_inode  ON files(inode);
 
 CREATE TABLE history (
     id          INTEGER PRIMARY KEY,
-    kind        TEXT NOT NULL,            -- "open" | "search" | "command"
+    kind        TEXT NOT NULL CHECK (kind IN ('open', 'search', 'command')),
     payload     TEXT NOT NULL,
     occurred_at INTEGER NOT NULL
 );

--- a/crates/nohrs-store/src/nohrs_store.rs
+++ b/crates/nohrs-store/src/nohrs_store.rs
@@ -1,0 +1,320 @@
+//! Persistence layer for nohrs (see `docs/persistence.md`).
+//!
+//! Two backends sit behind interface-segregated traits, split by a single
+//! question: *does the data ever need to be queried by anything other than an
+//! exact key?*
+//!
+//! * **SQLite** ([`SqliteStore`]) — file metadata and history, which need
+//!   range/diff/ordered queries. Implements [`MetadataQuery`], [`MetadataStore`],
+//!   and [`HistoryStore`]. Uses bundled SQLite in WAL mode.
+//! * **redb** ([`RedbKvStore`]) — host key/value state (window position,
+//!   tab/session restore, dynamic settings): pure `key -> blob`. Implements
+//!   [`KvStore`].
+//!
+//! Both backends are synchronous and tokio-free; the UI layer is expected to
+//! call them from `cx.background_spawn`. Per-operation performance logging is
+//! controlled by [`StoreLogConfig`] (see `docs/persistence.md` §5).
+
+use std::path::PathBuf;
+
+mod redb_kv;
+mod sqlite;
+
+pub use redb_kv::RedbKvStore;
+pub use sqlite::SqliteStore;
+
+/// Errors returned by the store backends.
+#[derive(Debug, thiserror::Error)]
+pub enum StoreError {
+    /// A SQLite operation failed.
+    #[error("sqlite error: {0}")]
+    Sqlite(#[from] rusqlite::Error),
+    /// A redb operation failed. Boxed because `redb::Error` is large and would
+    /// otherwise bloat every `Result` in this crate (`clippy::result_large_err`).
+    #[error("redb error: {0}")]
+    Redb(Box<redb::Error>),
+}
+
+// redb surfaces a family of error types from its different stages. Funnel each
+// through `redb::Error` so `?` converts directly to [`StoreError`].
+macro_rules! redb_error_from {
+    ($($error:ty),+ $(,)?) => {$(
+        impl From<$error> for StoreError {
+            fn from(error: $error) -> Self {
+                StoreError::Redb(Box::new(redb::Error::from(error)))
+            }
+        }
+    )+};
+}
+redb_error_from!(
+    redb::Error,
+    redb::DatabaseError,
+    redb::TransactionError,
+    redb::TableError,
+    redb::StorageError,
+    redb::CommitError,
+);
+
+/// Result type used throughout the store crate.
+pub type Result<T> = std::result::Result<T, StoreError>;
+
+/// Controls per-operation performance logging for the store backends. All
+/// fields default to off, so a default config adds zero overhead (the SQLite
+/// profile hook is not even installed). Output is emitted via `tracing` and can
+/// be filtered with `RUST_LOG`; see `docs/persistence.md` §5.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct StoreLogConfig {
+    /// Log every SQL statement at `debug` (target `nohrs_store::sql`).
+    pub log_all_queries: bool,
+    /// Log SQL statements slower than this many milliseconds at `warn`
+    /// (target `nohrs_store::sql`). Zero disables slow-query logging.
+    pub slow_query_ms: u64,
+    /// Log redb `get`/`put`/`delete`/`batch` operations and their durations at
+    /// `debug` (target `nohrs_store::redb`).
+    pub log_redb_ops: bool,
+}
+
+/// Primary key of a row in the `files` table.
+pub type FileId = i64;
+
+/// A row read back from the `files` table.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FileRecord {
+    /// Stable row identifier.
+    pub id: FileId,
+    /// Absolute path to the entry (unique).
+    pub path: PathBuf,
+    /// Path of the containing directory.
+    pub parent_path: PathBuf,
+    /// Filesystem inode number.
+    pub inode: u64,
+    /// Size in bytes.
+    pub size: u64,
+    /// Last-modified time in nanoseconds since the Unix epoch.
+    pub mtime_ns: i64,
+    /// Content hash (blake3 first-N-KB), populated in P3.
+    pub content_hash: Option<Vec<u8>>,
+    /// Time the entry was last indexed (nanoseconds since epoch), or `None`.
+    pub indexed_at: Option<i64>,
+    /// Logical-deletion time (nanoseconds since epoch), or `None` if live.
+    pub deleted_at: Option<i64>,
+}
+
+/// The data needed to insert or update a `files` row. `indexed_at` and
+/// `deleted_at` are managed separately via [`MetadataStore::mark_indexed`] and
+/// [`MetadataStore::delete_file`], so they are not part of an upsert.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FileUpsert {
+    /// Absolute path to the entry (the upsert conflict key).
+    pub path: PathBuf,
+    /// Path of the containing directory.
+    pub parent_path: PathBuf,
+    /// Filesystem inode number.
+    pub inode: u64,
+    /// Size in bytes.
+    pub size: u64,
+    /// Last-modified time in nanoseconds since the Unix epoch.
+    pub mtime_ns: i64,
+    /// Content hash, if already computed (otherwise `None`).
+    pub content_hash: Option<Vec<u8>>,
+}
+
+/// The category of a [`HistoryEntry`], stored as the `kind` text column.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HistoryKind {
+    /// A file or directory was opened.
+    Open,
+    /// A search was run.
+    Search,
+    /// A command was invoked.
+    Command,
+}
+
+impl HistoryKind {
+    /// The lowercase string stored in the `kind` column.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            HistoryKind::Open => "open",
+            HistoryKind::Search => "search",
+            HistoryKind::Command => "command",
+        }
+    }
+
+    /// Parse the `kind` column spelling back into a [`HistoryKind`].
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "open" => Some(HistoryKind::Open),
+            "search" => Some(HistoryKind::Search),
+            "command" => Some(HistoryKind::Command),
+            _ => None,
+        }
+    }
+}
+
+/// A single history record (recent files, searches, command usage).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HistoryEntry {
+    /// What kind of event this is.
+    pub kind: HistoryKind,
+    /// Opaque, caller-defined payload (e.g. a path or query string).
+    pub payload: String,
+    /// When the event occurred, in nanoseconds since the Unix epoch.
+    pub occurred_at: i64,
+}
+
+/// A single operation in a [`KvStore::batch`] call, applied atomically.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KvOp {
+    /// Insert or overwrite `key` with `value`.
+    Put {
+        /// The key to write.
+        key: String,
+        /// The value to store.
+        value: Vec<u8>,
+    },
+    /// Remove `key` if present.
+    Delete {
+        /// The key to remove.
+        key: String,
+    },
+}
+
+/// Read-only access to file metadata. Kept separate from [`MetadataStore`] so
+/// callers that only read (e.g. plugins with `read_paths` permission) cannot
+/// mutate the table.
+pub trait MetadataQuery: Send + Sync {
+    /// Fetch the record for `path`, or `None` if it is not tracked.
+    fn get_file(&self, path: &std::path::Path) -> Result<Option<FileRecord>>;
+    /// List the direct children of directory `parent`.
+    fn list_children(&self, parent: &std::path::Path) -> Result<Vec<FileRecord>>;
+    /// List records changed after `ts_ns` (modified or logically deleted since),
+    /// for incremental re-indexing.
+    fn list_changed_since(&self, ts_ns: i64) -> Result<Vec<FileRecord>>;
+    /// Find a record by its filesystem inode, or `None` if untracked.
+    fn find_by_inode(&self, inode: u64) -> Result<Option<FileRecord>>;
+}
+
+/// Read/write access to file metadata.
+pub trait MetadataStore: MetadataQuery {
+    /// Insert `entry`, or update the existing row with the same path. Returns
+    /// the row id.
+    fn upsert_file(&self, entry: &FileUpsert) -> Result<FileId>;
+    /// Remove the row for `path` (hard delete in P2).
+    fn delete_file(&self, path: &std::path::Path) -> Result<()>;
+    /// Record that the file `id` was indexed at `indexed_at_ns`.
+    fn mark_indexed(&self, id: FileId, indexed_at_ns: i64) -> Result<()>;
+}
+
+/// A simple key/value blob store (host KV, backed by redb).
+pub trait KvStore: Send + Sync {
+    /// Fetch the value for `key`, or `None` if absent.
+    fn get(&self, key: &str) -> Result<Option<Vec<u8>>>;
+    /// Insert or overwrite `key` with `value`.
+    fn put(&self, key: &str, value: &[u8]) -> Result<()>;
+    /// Remove `key` if present.
+    fn delete(&self, key: &str) -> Result<()>;
+    /// Return every `(key, value)` whose key begins with `prefix`.
+    fn list_prefix(&self, prefix: &str) -> Result<Vec<(String, Vec<u8>)>>;
+    /// Apply `ops` atomically in a single transaction.
+    fn batch(&self, ops: Vec<KvOp>) -> Result<()>;
+}
+
+/// Append-only history of recent files, searches and commands.
+pub trait HistoryStore: Send + Sync {
+    /// Append `entry` to the history.
+    fn record(&self, entry: HistoryEntry) -> Result<()>;
+    /// Return up to `limit` entries of `kind`, most recent first.
+    fn list(&self, kind: HistoryKind, limit: usize) -> Result<Vec<HistoryEntry>>;
+}
+
+/// Current time in nanoseconds since the Unix epoch, saturating to 0 if the
+/// clock is set before the epoch.
+pub(crate) fn now_ns() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|elapsed| i64::try_from(elapsed.as_nanos()).unwrap_or(i64::MAX))
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    // A consumer that only needs to read metadata depends on the narrow
+    // `MetadataQuery` trait, so it can be exercised against a hand-written mock
+    // without a real database — the point of the interface segregation.
+    fn newest_child(query: &dyn MetadataQuery, parent: &Path) -> Result<Option<FileRecord>> {
+        Ok(query
+            .list_children(parent)?
+            .into_iter()
+            .max_by_key(|record| record.mtime_ns))
+    }
+
+    #[derive(Default)]
+    struct MockMetadataQuery {
+        children: Vec<FileRecord>,
+    }
+
+    impl MetadataQuery for MockMetadataQuery {
+        fn get_file(&self, path: &Path) -> Result<Option<FileRecord>> {
+            Ok(self
+                .children
+                .iter()
+                .find(|record| record.path == path)
+                .cloned())
+        }
+        fn list_children(&self, _parent: &Path) -> Result<Vec<FileRecord>> {
+            Ok(self.children.clone())
+        }
+        fn list_changed_since(&self, _ts_ns: i64) -> Result<Vec<FileRecord>> {
+            Ok(self.children.clone())
+        }
+        fn find_by_inode(&self, inode: u64) -> Result<Option<FileRecord>> {
+            Ok(self
+                .children
+                .iter()
+                .find(|record| record.inode == inode)
+                .cloned())
+        }
+    }
+
+    fn record(path: &str, inode: u64, mtime_ns: i64) -> FileRecord {
+        FileRecord {
+            id: inode as FileId,
+            path: PathBuf::from(path),
+            parent_path: PathBuf::from("/home/user"),
+            inode,
+            size: 0,
+            mtime_ns,
+            content_hash: None,
+            indexed_at: None,
+            deleted_at: None,
+        }
+    }
+
+    #[test]
+    fn consumer_works_against_metadata_query_mock() {
+        let mock = MockMetadataQuery {
+            children: vec![
+                record("/home/user/a.txt", 1, 100),
+                record("/home/user/b.txt", 2, 300),
+                record("/home/user/c.txt", 3, 200),
+            ],
+        };
+        let newest = newest_child(&mock, Path::new("/home/user"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(newest.path, PathBuf::from("/home/user/b.txt"));
+    }
+
+    #[test]
+    fn history_kind_round_trips_through_text() {
+        for kind in [HistoryKind::Open, HistoryKind::Search, HistoryKind::Command] {
+            assert_eq!(HistoryKind::parse(kind.as_str()), Some(kind));
+        }
+        assert_eq!(HistoryKind::parse("unknown"), None);
+    }
+}

--- a/crates/nohrs-store/src/redb_kv.rs
+++ b/crates/nohrs-store/src/redb_kv.rs
@@ -1,0 +1,228 @@
+//! redb backend: host key/value state (`docs/persistence.md` §3).
+
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Instant;
+
+use redb::{Database, TableDefinition, TableError};
+
+use crate::{KvOp, KvStore, Result, StoreLogConfig};
+
+/// The single host KV table. Keys are namespaced strings (e.g.
+/// `"window.position"`, `"session.tabs"`); values are opaque blobs the caller
+/// serializes (JSON / MessagePack / …).
+const HOST_KV: TableDefinition<'static, &str, &[u8]> = TableDefinition::new("kv");
+
+/// redb-backed host [`KvStore`] (`state.redb`).
+pub struct RedbKvStore {
+    database: Arc<Database>,
+    log_ops: bool,
+}
+
+impl RedbKvStore {
+    /// Open (creating if needed) the database at `path`.
+    pub fn open(path: &Path, log: &StoreLogConfig) -> Result<Self> {
+        Ok(Self {
+            database: Arc::new(Database::create(path)?),
+            log_ops: log.log_redb_ops,
+        })
+    }
+
+    /// Open an in-memory database (for tests).
+    pub fn open_in_memory(log: &StoreLogConfig) -> Result<Self> {
+        let database =
+            Database::builder().create_with_backend(redb::backends::InMemoryBackend::new())?;
+        Ok(Self {
+            database: Arc::new(database),
+            log_ops: log.log_redb_ops,
+        })
+    }
+
+    fn trace(&self, op: &str, started: Instant) {
+        if self.log_ops {
+            let elapsed_us = u64::try_from(started.elapsed().as_micros()).unwrap_or(u64::MAX);
+            tracing::debug!(target: "nohrs_store::redb", op, elapsed_us, "kv op");
+        }
+    }
+}
+
+impl KvStore for RedbKvStore {
+    fn get(&self, key: &str) -> Result<Option<Vec<u8>>> {
+        let started = Instant::now();
+        let read_txn = self.database.begin_read()?;
+        let value = match read_txn.open_table(HOST_KV) {
+            Ok(table) => table.get(key)?.map(|guard| guard.value().to_vec()),
+            // No writes have happened yet: an absent table means an absent key.
+            Err(TableError::TableDoesNotExist(_)) => None,
+            Err(error) => return Err(error.into()),
+        };
+        self.trace("get", started);
+        Ok(value)
+    }
+
+    fn put(&self, key: &str, value: &[u8]) -> Result<()> {
+        let started = Instant::now();
+        let write_txn = self.database.begin_write()?;
+        {
+            let mut table = write_txn.open_table(HOST_KV)?;
+            table.insert(key, value)?;
+        }
+        write_txn.commit()?;
+        self.trace("put", started);
+        Ok(())
+    }
+
+    fn delete(&self, key: &str) -> Result<()> {
+        let started = Instant::now();
+        let write_txn = self.database.begin_write()?;
+        {
+            let mut table = write_txn.open_table(HOST_KV)?;
+            table.remove(key)?;
+        }
+        write_txn.commit()?;
+        self.trace("delete", started);
+        Ok(())
+    }
+
+    fn list_prefix(&self, prefix: &str) -> Result<Vec<(String, Vec<u8>)>> {
+        let started = Instant::now();
+        let read_txn = self.database.begin_read()?;
+        let table = match read_txn.open_table(HOST_KV) {
+            Ok(table) => table,
+            Err(TableError::TableDoesNotExist(_)) => return Ok(Vec::new()),
+            Err(error) => return Err(error.into()),
+        };
+        let mut matches = Vec::new();
+        // Keys are ordered, so once one stops matching the prefix none after it can.
+        for entry in table.range(prefix..)? {
+            let (key, value) = entry?;
+            let key = key.value();
+            if !key.starts_with(prefix) {
+                break;
+            }
+            matches.push((key.to_string(), value.value().to_vec()));
+        }
+        self.trace("list_prefix", started);
+        Ok(matches)
+    }
+
+    fn batch(&self, ops: Vec<KvOp>) -> Result<()> {
+        let started = Instant::now();
+        let write_txn = self.database.begin_write()?;
+        {
+            let mut table = write_txn.open_table(HOST_KV)?;
+            for op in &ops {
+                match op {
+                    KvOp::Put { key, value } => {
+                        table.insert(key.as_str(), value.as_slice())?;
+                    }
+                    KvOp::Delete { key } => {
+                        table.remove(key.as_str())?;
+                    }
+                }
+            }
+        }
+        write_txn.commit()?;
+        self.trace("batch", started);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn store() -> RedbKvStore {
+        RedbKvStore::open_in_memory(&StoreLogConfig::default()).unwrap()
+    }
+
+    #[test]
+    fn get_missing_key_before_any_write() {
+        let store = store();
+        assert_eq!(store.get("absent").unwrap(), None);
+        assert!(store.list_prefix("any").unwrap().is_empty());
+    }
+
+    #[test]
+    fn put_get_delete_round_trip() {
+        let store = store();
+        store.put("window.position", b"1,2,3,4").unwrap();
+        assert_eq!(
+            store.get("window.position").unwrap().as_deref(),
+            Some(&b"1,2,3,4"[..])
+        );
+        store.delete("window.position").unwrap();
+        assert_eq!(store.get("window.position").unwrap(), None);
+    }
+
+    #[test]
+    fn list_prefix_returns_only_matching_keys() {
+        let store = store();
+        store.put("session.tabs", b"a").unwrap();
+        store.put("session.active", b"b").unwrap();
+        store.put("window.position", b"c").unwrap();
+        let mut session = store.list_prefix("session.").unwrap();
+        session.sort();
+        assert_eq!(session.len(), 2);
+        assert_eq!(session[0].0, "session.active");
+        assert_eq!(session[1].0, "session.tabs");
+    }
+
+    #[test]
+    fn batch_is_applied_atomically() {
+        let store = store();
+        store.put("keep", b"x").unwrap();
+        store
+            .batch(vec![
+                KvOp::Put {
+                    key: "a".to_string(),
+                    value: b"1".to_vec(),
+                },
+                KvOp::Put {
+                    key: "b".to_string(),
+                    value: b"2".to_vec(),
+                },
+                KvOp::Delete {
+                    key: "keep".to_string(),
+                },
+            ])
+            .unwrap();
+        assert_eq!(store.get("a").unwrap().as_deref(), Some(&b"1"[..]));
+        assert_eq!(store.get("b").unwrap().as_deref(), Some(&b"2"[..]));
+        assert_eq!(store.get("keep").unwrap(), None);
+    }
+
+    #[test]
+    fn opening_with_op_logging_enabled_still_works() {
+        let log = StoreLogConfig {
+            log_redb_ops: true,
+            ..Default::default()
+        };
+        let store = RedbKvStore::open_in_memory(&log).unwrap();
+        store.put("k", b"v").unwrap();
+        store
+            .batch(vec![KvOp::Put {
+                key: "x".to_string(),
+                value: b"y".to_vec(),
+            }])
+            .unwrap();
+        assert_eq!(store.get("k").unwrap().as_deref(), Some(&b"v"[..]));
+        assert_eq!(store.list_prefix("").unwrap().len(), 2);
+    }
+
+    #[test]
+    fn data_persists_across_reopen() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.redb");
+        {
+            let store = RedbKvStore::open(&path, &StoreLogConfig::default()).unwrap();
+            store.put("session.tabs", b"restored").unwrap();
+        }
+        let reopened = RedbKvStore::open(&path, &StoreLogConfig::default()).unwrap();
+        assert_eq!(
+            reopened.get("session.tabs").unwrap().as_deref(),
+            Some(&b"restored"[..])
+        );
+    }
+}

--- a/crates/nohrs-store/src/sqlite.rs
+++ b/crates/nohrs-store/src/sqlite.rs
@@ -1,0 +1,423 @@
+//! SQLite backend: file metadata and history (`docs/persistence.md` §2).
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
+use std::time::Duration;
+
+use rusqlite::{params, Connection, OptionalExtension, Row};
+
+use crate::{
+    now_ns, FileId, FileRecord, FileUpsert, HistoryEntry, HistoryKind, HistoryStore, MetadataQuery,
+    MetadataStore, Result, StoreLogConfig,
+};
+
+/// Forward-only migrations, applied in order and recorded in `_migrations`.
+const MIGRATIONS: &[(i64, &str)] = &[(1, include_str!("../migrations/001_init.sql"))];
+
+// rusqlite's `profile` hook takes a bare `fn` pointer (not a closure), so the
+// query-logging thresholds are kept in process-global atomics that the callback
+// reads. A nohrs process opens a single metadata store, so this global state is
+// effectively per-store; the last `open` wins if several are created.
+static LOG_ALL_QUERIES: AtomicBool = AtomicBool::new(false);
+static SLOW_QUERY_MS: AtomicU64 = AtomicU64::new(0);
+
+/// SQLite-backed metadata and history store.
+///
+/// The connection is wrapped in a `Mutex` (SQLite WAL allows one writer plus
+/// many readers, but a single `Connection` is not `Sync`), so callers should
+/// keep operations short and run them off the UI thread.
+pub struct SqliteStore {
+    connection: Arc<Mutex<Connection>>,
+}
+
+impl SqliteStore {
+    /// Open (creating if needed) the database at `path`, run pending migrations,
+    /// and install query logging per `log`.
+    pub fn open(path: &Path, log: &StoreLogConfig) -> Result<Self> {
+        Self::from_connection(Connection::open(path)?, log)
+    }
+
+    /// Open an in-memory database (for tests). Each call is an isolated database.
+    pub fn open_in_memory(log: &StoreLogConfig) -> Result<Self> {
+        Self::from_connection(Connection::open_in_memory()?, log)
+    }
+
+    fn from_connection(mut connection: Connection, log: &StoreLogConfig) -> Result<Self> {
+        // WAL gives single-writer / many-reader concurrency. `query_row` (not
+        // `pragma_update`) because the statement returns the resulting mode.
+        connection.query_row("PRAGMA journal_mode=WAL;", [], |row| {
+            row.get::<_, String>(0)
+        })?;
+        configure_query_logging(&mut connection, log);
+        migrate(&connection)?;
+        Ok(Self {
+            connection: Arc::new(Mutex::new(connection)),
+        })
+    }
+
+    /// Lock the connection, recovering from a poisoned mutex (a panic in another
+    /// thread while holding the lock) rather than propagating the panic — the
+    /// connection itself remains usable.
+    fn connection(&self) -> MutexGuard<'_, Connection> {
+        self.connection
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+    }
+}
+
+/// Install (or not) the rusqlite profile hook based on `log`. When both
+/// thresholds are off the hook is left uninstalled so logging adds no overhead.
+fn configure_query_logging(connection: &mut Connection, log: &StoreLogConfig) {
+    LOG_ALL_QUERIES.store(log.log_all_queries, Ordering::Relaxed);
+    SLOW_QUERY_MS.store(log.slow_query_ms, Ordering::Relaxed);
+    if log.log_all_queries || log.slow_query_ms > 0 {
+        connection.profile(Some(profile_callback));
+    } else {
+        connection.profile(None);
+    }
+}
+
+fn profile_callback(sql: &str, duration: Duration) {
+    let elapsed_ms = u64::try_from(duration.as_millis()).unwrap_or(u64::MAX);
+    let slow_threshold = SLOW_QUERY_MS.load(Ordering::Relaxed);
+    if slow_threshold > 0 && elapsed_ms >= slow_threshold {
+        tracing::warn!(target: "nohrs_store::sql", elapsed_ms, sql, "slow query");
+    } else if LOG_ALL_QUERIES.load(Ordering::Relaxed) {
+        tracing::debug!(target: "nohrs_store::sql", elapsed_ms, sql, "query");
+    }
+}
+
+fn migrate(connection: &Connection) -> Result<()> {
+    connection.execute_batch(
+        "CREATE TABLE IF NOT EXISTS _migrations (\
+             version INTEGER PRIMARY KEY, \
+             applied_at INTEGER NOT NULL\
+         );",
+    )?;
+    for (version, sql) in MIGRATIONS {
+        let already_applied: bool = connection.query_row(
+            "SELECT EXISTS(SELECT 1 FROM _migrations WHERE version = ?1)",
+            [version],
+            |row| row.get(0),
+        )?;
+        if !already_applied {
+            connection.execute_batch(sql)?;
+            connection.execute(
+                "INSERT INTO _migrations (version, applied_at) VALUES (?1, ?2)",
+                params![version, now_ns()],
+            )?;
+        }
+    }
+    Ok(())
+}
+
+/// Columns selected by every `files` query, in the order [`row_to_file`] reads.
+const FILE_COLUMNS: &str =
+    "id, path, parent_path, inode, size, mtime_ns, content_hash, indexed_at, deleted_at";
+
+fn row_to_file(row: &Row<'_>) -> rusqlite::Result<FileRecord> {
+    let path: String = row.get(1)?;
+    let parent_path: String = row.get(2)?;
+    let inode: i64 = row.get(3)?;
+    let size: i64 = row.get(4)?;
+    Ok(FileRecord {
+        id: row.get(0)?,
+        path: PathBuf::from(path),
+        parent_path: PathBuf::from(parent_path),
+        inode: inode as u64,
+        size: size as u64,
+        mtime_ns: row.get(5)?,
+        content_hash: row.get(6)?,
+        indexed_at: row.get(7)?,
+        deleted_at: row.get(8)?,
+    })
+}
+
+fn path_str(path: &Path) -> String {
+    path.to_string_lossy().into_owned()
+}
+
+impl MetadataQuery for SqliteStore {
+    fn get_file(&self, path: &Path) -> Result<Option<FileRecord>> {
+        let connection = self.connection();
+        let record = connection
+            .query_row(
+                &format!("SELECT {FILE_COLUMNS} FROM files WHERE path = ?1"),
+                [path_str(path)],
+                row_to_file,
+            )
+            .optional()?;
+        Ok(record)
+    }
+
+    fn list_children(&self, parent: &Path) -> Result<Vec<FileRecord>> {
+        let connection = self.connection();
+        let mut statement = connection.prepare(&format!(
+            "SELECT {FILE_COLUMNS} FROM files WHERE parent_path = ?1 ORDER BY path"
+        ))?;
+        let rows = statement.query_map([path_str(parent)], row_to_file)?;
+        Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+    }
+
+    fn list_changed_since(&self, ts_ns: i64) -> Result<Vec<FileRecord>> {
+        let connection = self.connection();
+        let mut statement = connection.prepare(&format!(
+            "SELECT {FILE_COLUMNS} FROM files \
+             WHERE mtime_ns > ?1 OR (deleted_at IS NOT NULL AND deleted_at > ?1) \
+             ORDER BY mtime_ns"
+        ))?;
+        let rows = statement.query_map([ts_ns], row_to_file)?;
+        Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+    }
+
+    fn find_by_inode(&self, inode: u64) -> Result<Option<FileRecord>> {
+        let connection = self.connection();
+        let record = connection
+            .query_row(
+                &format!("SELECT {FILE_COLUMNS} FROM files WHERE inode = ?1 LIMIT 1"),
+                [inode as i64],
+                row_to_file,
+            )
+            .optional()?;
+        Ok(record)
+    }
+}
+
+impl MetadataStore for SqliteStore {
+    fn upsert_file(&self, entry: &FileUpsert) -> Result<FileId> {
+        let connection = self.connection();
+        // `excluded` refers to the row that would have been inserted; on a path
+        // conflict we refresh the changeable columns but leave indexed_at /
+        // deleted_at to the dedicated methods.
+        let id = connection.query_row(
+            "INSERT INTO files (path, parent_path, inode, size, mtime_ns, content_hash) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6) \
+             ON CONFLICT(path) DO UPDATE SET \
+                 parent_path = excluded.parent_path, \
+                 inode = excluded.inode, \
+                 size = excluded.size, \
+                 mtime_ns = excluded.mtime_ns, \
+                 content_hash = excluded.content_hash \
+             RETURNING id",
+            params![
+                path_str(&entry.path),
+                path_str(&entry.parent_path),
+                entry.inode as i64,
+                entry.size as i64,
+                entry.mtime_ns,
+                entry.content_hash,
+            ],
+            |row| row.get(0),
+        )?;
+        Ok(id)
+    }
+
+    fn delete_file(&self, path: &Path) -> Result<()> {
+        let connection = self.connection();
+        connection.execute("DELETE FROM files WHERE path = ?1", [path_str(path)])?;
+        Ok(())
+    }
+
+    fn mark_indexed(&self, id: FileId, indexed_at_ns: i64) -> Result<()> {
+        let connection = self.connection();
+        connection.execute(
+            "UPDATE files SET indexed_at = ?2 WHERE id = ?1",
+            params![id, indexed_at_ns],
+        )?;
+        Ok(())
+    }
+}
+
+impl HistoryStore for SqliteStore {
+    fn record(&self, entry: HistoryEntry) -> Result<()> {
+        let connection = self.connection();
+        connection.execute(
+            "INSERT INTO history (kind, payload, occurred_at) VALUES (?1, ?2, ?3)",
+            params![entry.kind.as_str(), entry.payload, entry.occurred_at],
+        )?;
+        Ok(())
+    }
+
+    fn list(&self, kind: HistoryKind, limit: usize) -> Result<Vec<HistoryEntry>> {
+        let connection = self.connection();
+        let mut statement = connection.prepare(
+            "SELECT kind, payload, occurred_at FROM history \
+             WHERE kind = ?1 ORDER BY occurred_at DESC LIMIT ?2",
+        )?;
+        let rows = statement.query_map(params![kind.as_str(), limit as i64], |row| {
+            let kind_text: String = row.get(0)?;
+            Ok(HistoryEntry {
+                // The kind came straight from our own enum, so it always parses.
+                kind: HistoryKind::parse(&kind_text).unwrap_or(kind),
+                payload: row.get(1)?,
+                occurred_at: row.get(2)?,
+            })
+        })?;
+        Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn store() -> SqliteStore {
+        SqliteStore::open_in_memory(&StoreLogConfig::default()).unwrap()
+    }
+
+    fn sample(path: &str, inode: u64, mtime_ns: i64) -> FileUpsert {
+        FileUpsert {
+            path: PathBuf::from(path),
+            parent_path: PathBuf::from("/home/user"),
+            inode,
+            size: 10,
+            mtime_ns,
+            content_hash: None,
+        }
+    }
+
+    #[test]
+    fn upsert_then_get_round_trips() {
+        let store = store();
+        let id = store
+            .upsert_file(&sample("/home/user/a.txt", 1, 100))
+            .unwrap();
+        let record = store
+            .get_file(Path::new("/home/user/a.txt"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(record.id, id);
+        assert_eq!(record.inode, 1);
+        assert_eq!(record.mtime_ns, 100);
+        assert_eq!(record.indexed_at, None);
+    }
+
+    #[test]
+    fn upsert_updates_existing_row_in_place() {
+        let store = store();
+        let first = store
+            .upsert_file(&sample("/home/user/a.txt", 1, 100))
+            .unwrap();
+        let second = store
+            .upsert_file(&sample("/home/user/a.txt", 1, 200))
+            .unwrap();
+        assert_eq!(first, second, "same path keeps the same row id");
+        let record = store
+            .get_file(Path::new("/home/user/a.txt"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(record.mtime_ns, 200);
+    }
+
+    #[test]
+    fn list_children_and_find_by_inode() {
+        let store = store();
+        store
+            .upsert_file(&sample("/home/user/a.txt", 11, 100))
+            .unwrap();
+        store
+            .upsert_file(&sample("/home/user/b.txt", 12, 100))
+            .unwrap();
+        let children = store.list_children(Path::new("/home/user")).unwrap();
+        assert_eq!(children.len(), 2);
+        let found = store.find_by_inode(12).unwrap().unwrap();
+        assert_eq!(found.path, PathBuf::from("/home/user/b.txt"));
+    }
+
+    #[test]
+    fn list_changed_since_filters_by_mtime() {
+        let store = store();
+        store
+            .upsert_file(&sample("/home/user/old.txt", 1, 100))
+            .unwrap();
+        store
+            .upsert_file(&sample("/home/user/new.txt", 2, 300))
+            .unwrap();
+        let changed = store.list_changed_since(200).unwrap();
+        assert_eq!(changed.len(), 1);
+        assert_eq!(changed[0].path, PathBuf::from("/home/user/new.txt"));
+    }
+
+    #[test]
+    fn mark_indexed_and_delete() {
+        let store = store();
+        let id = store
+            .upsert_file(&sample("/home/user/a.txt", 1, 100))
+            .unwrap();
+        store.mark_indexed(id, 500).unwrap();
+        let record = store
+            .get_file(Path::new("/home/user/a.txt"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(record.indexed_at, Some(500));
+        store.delete_file(Path::new("/home/user/a.txt")).unwrap();
+        assert!(store
+            .get_file(Path::new("/home/user/a.txt"))
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn history_records_and_lists_most_recent_first() {
+        let store = store();
+        for (payload, at) in [("first", 100), ("second", 200), ("third", 300)] {
+            store
+                .record(HistoryEntry {
+                    kind: HistoryKind::Open,
+                    payload: payload.to_string(),
+                    occurred_at: at,
+                })
+                .unwrap();
+        }
+        store
+            .record(HistoryEntry {
+                kind: HistoryKind::Search,
+                payload: "query".to_string(),
+                occurred_at: 250,
+            })
+            .unwrap();
+        let opens = store.list(HistoryKind::Open, 2).unwrap();
+        assert_eq!(opens.len(), 2);
+        assert_eq!(opens[0].payload, "third");
+        assert_eq!(opens[1].payload, "second");
+        let searches = store.list(HistoryKind::Search, 10).unwrap();
+        assert_eq!(searches.len(), 1);
+    }
+
+    #[test]
+    fn opening_with_query_logging_enabled_still_works() {
+        let log = StoreLogConfig {
+            log_all_queries: true,
+            slow_query_ms: 1,
+            log_redb_ops: false,
+        };
+        let store = SqliteStore::open_in_memory(&log).unwrap();
+        let id = store
+            .upsert_file(&sample("/home/user/a.txt", 1, 100))
+            .unwrap();
+        assert!(store
+            .get_file(Path::new("/home/user/a.txt"))
+            .unwrap()
+            .is_some());
+        store.mark_indexed(id, 1).unwrap();
+    }
+
+    #[test]
+    fn data_persists_across_reopen() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("db.sqlite");
+        {
+            let store = SqliteStore::open(&path, &StoreLogConfig::default()).unwrap();
+            store
+                .upsert_file(&sample("/home/user/a.txt", 1, 100))
+                .unwrap();
+        }
+        let reopened = SqliteStore::open(&path, &StoreLogConfig::default()).unwrap();
+        assert!(reopened
+            .get_file(Path::new("/home/user/a.txt"))
+            .unwrap()
+            .is_some());
+    }
+}

--- a/crates/nohrs-store/src/sqlite.rs
+++ b/crates/nohrs-store/src/sqlite.rs
@@ -50,7 +50,7 @@ impl SqliteStore {
             row.get::<_, String>(0)
         })?;
         configure_query_logging(&mut connection, log);
-        migrate(&connection)?;
+        migrate(&mut connection)?;
         Ok(Self {
             connection: Arc::new(Mutex::new(connection)),
         })
@@ -88,7 +88,7 @@ fn profile_callback(sql: &str, duration: Duration) {
     }
 }
 
-fn migrate(connection: &Connection) -> Result<()> {
+fn migrate(connection: &mut Connection) -> Result<()> {
     connection.execute_batch(
         "CREATE TABLE IF NOT EXISTS _migrations (\
              version INTEGER PRIMARY KEY, \
@@ -102,11 +102,17 @@ fn migrate(connection: &Connection) -> Result<()> {
             |row| row.get(0),
         )?;
         if !already_applied {
-            connection.execute_batch(sql)?;
-            connection.execute(
+            // Apply the migration and record its version in one transaction:
+            // SQLite DDL is transactional, so a crash mid-migration rolls back
+            // cleanly. Otherwise a half-applied migration with no bookkeeping
+            // would re-run the (non-idempotent) DDL on next startup and fail.
+            let transaction = connection.transaction()?;
+            transaction.execute_batch(sql)?;
+            transaction.execute(
                 "INSERT INTO _migrations (version, applied_at) VALUES (?1, ?2)",
                 params![version, now_ns()],
             )?;
+            transaction.commit()?;
         }
     }
     Ok(())

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -57,7 +57,7 @@ ROADMAP 本体には判断の要点のみを記し、詳細は次の設計ドキ
 | [`docs/testing.md`](./testing.md) | P1 | GPUI `TestAppContext`・llvm-cov→R2/GitHub native パイプライン・静的解析 |
 | [`docs/dev-environment.md`](./dev-environment.md) | P1 | docker dev/ci 二系統・nix devshell |
 | [`docs/config.md`](./config.md) | P1→P2 | `~/.config/nohrs/config.toml` スキーマ・hot reload タイミング・JSON Schema |
-| [`docs/persistence.md`](./persistence.md) | P2 | rusqlite + WAL・redb (plugin KV)・`MetadataStore`/`KvStore` trait・マイグレーション |
+| [`docs/persistence.md`](./persistence.md) | P2 | rusqlite + WAL (メタデータ/履歴)・redb (ホスト KV, plugin KV は P4)・使い分け基準・`MetadataStore`/`KvStore` trait・マイグレーション・診断ログ |
 | [`docs/async-runtime.md`](./async-runtime.md) | P2 | GPUI executor 統一・`postage`/`async-channel`/`ureq` への置換 |
 | [`docs/explorer-essentials.md`](./explorer-essentials.md) | P1骨子→P2 | DnD・ファイル操作・スプリットビュー・タブ |
 | [`docs/launcher.md`](./launcher.md) | P3 | フローティング window・グローバルホットキー・アクションフレームワーク |
@@ -126,11 +126,11 @@ ROADMAP 本体には判断の要点のみを記し、詳細は次の設計ドキ
 - **DnD**: 内部 pane 間・外部アプリ間 (drop in / drop out)・複数選択ドラッグ。Cmd で copy / 通常は move (cross-volume は自動で copy)。詳細は [`docs/explorer-essentials.md`](./explorer-essentials.md)
 - **ファイル操作**: copy / cut / paste / rename / delete (trash デフォルト・Shift で permanent) / new folder / undo (window 単位 stack)。conflict は Rename/Overwrite/Skip + "Apply to all"
 - **スプリットビュー**: 2-way (水平/垂直)、ペイン独立ナビゲーション、ペイン単位 tab
-- **タブ**: 復元 (再起動時)、close、reorder。ピン留めは P3
+- **タブ**: 復元 (再起動時)、close、reorder。ピン留めは P3。復元状態の永続化先は redb (`state.redb`)、詳細は [`docs/persistence.md`](./persistence.md)
 - **OS 統合 (Finder 代替)**: `public.folder` 登録・`NSFileViewer`・Apple Event (`odoc`/`GURL`)・LaunchServices (`lsregister`)・Quick Look を実装し、Finder を起動せず完結できる状態にする。Linux は XDG MIME / `.desktop` 等価。アプリバンドル (`.app`) を前提とするため最小バンドル生成を本フェーズに前倒し (本格パッケージング/`dmg` は P6)。詳細は [`docs/os-integration.md`](./os-integration.md)
-- **SQLite + MetadataStore trait**: `nohrs-store` crate 新設、rusqlite + bundled + WAL モード。`MetadataStore` / `KvStore` / `HistoryStore` 等の interface segregated trait。詳細は [`docs/persistence.md`](./persistence.md)
+- **nohrs-store crate (SQLite + redb)**: `nohrs-store` crate 新設。SQLite (rusqlite + bundled + WAL) がメタデータ・履歴、redb がホスト KV (タブ/セッション復元・window 位置)。「キー完全一致以外で問い合わせるか」で使い分け。`MetadataStore` / `KvStore` / `HistoryStore` 等の interface segregated trait。詳細は [`docs/persistence.md`](./persistence.md)
 - **アプリコアの tokio 撤去**: `tokio::sync::*` を `postage` / `async-channel` / `futures::channel::oneshot` に、`tokio::spawn` を `cx.background_spawn` に、`tokio::time::*` を GPUI timer に置換。HTTP は `ureq` 採用。`cargo-deny` でアプリコアの tokio を ban (プラグイン実行層は P4 で `wrappers` 許可)。詳細は [`docs/async-runtime.md`](./async-runtime.md)
-- **config 拡張**: keybindings セクション草案 (P3 で本格化)、`schemars` で JSON Schema 自動生成
+- **config 拡張**: keybindings セクション草案 (P3 で本格化)、パフォーマンス解析用のストアログ設定 (`[diagnostics.store]`)、`schemars` で JSON Schema 自動生成
 
 ### Web
 
@@ -159,7 +159,7 @@ ROADMAP 本体には判断の要点のみを記し、詳細は次の設計ドキ
 ### Core
 
 - **Launcher 本体** (`crates/nohrs-launcher`):
-  - 別 window、フローティング、画面中央寄り上、マウスドラッグで移動可能 (位置記憶は SQLite `key_value`)、リサイズ不可
+  - 別 window、フローティング、画面中央寄り上、マウスドラッグで移動可能 (位置記憶は redb `state.redb`)、リサイズ不可
   - グローバルホットキー `Cmd+Shift+Space` (`global-hotkey` crate)、アプリ内 `Cmd+K`
   - 入力前は空欄 + placeholder ヒント
   - 結果リスト: icon / title / subtitle / kind badge / shortcut accessory

--- a/docs/config.md
+++ b/docs/config.md
@@ -12,12 +12,13 @@
 | データ種別 | 場所 |
 |-----------|------|
 | **config** | `$XDG_CONFIG_HOME/nohrs/config.toml` (Linux/macOS: `~/.config/nohrs/config.toml`) |
-| **SQLite DB** | `$XDG_DATA_HOME/nohrs/db.sqlite` |
+| **SQLite DB** (メタデータ・履歴) | `$XDG_DATA_HOME/nohrs/db.sqlite` |
+| **redb (ホスト KV, P2)** | `$XDG_DATA_HOME/nohrs/state.redb` |
 | **Tantivy index** | `$XDG_DATA_HOME/nohrs/index/` |
-| **redb (plugin KV)** | `$XDG_DATA_HOME/nohrs/plugin-kv.redb` |
+| **redb (plugin KV, P4)** | `$XDG_DATA_HOME/nohrs/plugin-kv.redb` |
 | **ログ / キャッシュ** | `$XDG_CACHE_HOME/nohrs/` |
 | **plugin インストール先** | `$XDG_DATA_HOME/nohrs/plugins/<plugin-id>/` |
-| **window position など高頻度更新** | SQLite `key_value` テーブル (config.toml ではない) |
+| **window position・タブ/セッション復元など高頻度更新** | redb `state.redb` (config.toml ではない、詳細は [`docs/persistence.md`](./persistence.md)) |
 
 XDG 環境変数 `$XDG_CONFIG_HOME` / `$XDG_DATA_HOME` / `$XDG_CACHE_HOME` を直接解決し、未設定時は `~/.config` / `~/.local/share` / `~/.cache` にフォールバックして上記を組み立てる。`dirs::config_dir()` / `data_dir()` / `cache_dir()` は **使わない**: macOS では `~/Library/Application Support` 等の OS ネイティブパスを返してしまい、本プロジェクトが全プラットフォームで意図する XDG スタイルの dotfile パス (`~/.config` など) と矛盾するため。
 
@@ -62,6 +63,14 @@ backend = "auto"  # "sqlite-fts" | "tantivy" | "ripgrep" | "auto"
 [launcher]
 hotkey = "Cmd+Shift+Space"
 position_remember = true
+
+[diagnostics.store]
+# パフォーマンス解析用のストア操作ログ。デフォルト全 off (本番では無音)。
+# 出力は tracing 経由 (target = "nohrs_store::sql" / "nohrs_store::redb")、RUST_LOG で絞り込み可。
+# 詳細は docs/persistence.md §5。
+log_all_queries = false   # 全 SQL クエリを debug で記録 (verbose)
+slow_query_ms   = 0       # >0 のとき、この閾値(ms)超過の SQL クエリを warn で記録 (0 = 無効)
+log_redb_ops    = false   # redb の get/put/delete/batch 操作と所要時間を記録
 ```
 
 ---
@@ -119,6 +128,7 @@ config.toml の冒頭に:
 | `ui.default_sort` | ✅ Yes | **P1** | 開いているビューに伝播 |
 | `ui.show_hidden` | ✅ Yes | **P1** | 開いているビューに伝播 |
 | `ui.icon_pack` | ✅ Yes | **P1** | アイコンキャッシュをクリア |
+| `diagnostics.store.*` | ❌ No (再起動) | P3 で hot reload に格上げ検討 | ストア接続 open 時に profile フックの登録可否を決めるため (off 時はフック未登録でオーバーヘッド 0) |
 | `keybindings.*` | ❌ No (再起動) | P3 で hot reload に格上げ検討 | キーマップは入力ハンドラに焼き込まれているため |
 | `plugins.enabled` | ❌ No (再起動) | P5 で動的 enable/disable に格上げ検討 | wasm host のライフサイクル安定化が前提 |
 | `schema_version` | ❌ No (再起動、マイグレーション処理走る) | 永続 | 変更は版アップに伴う |

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -1,5 +1,42 @@
 {
   "$defs": {
+    "Diagnostics": {
+      "description": "Diagnostics / performance-logging settings (see `docs/persistence.md` §5).",
+      "properties": {
+        "store": {
+          "$ref": "#/$defs/DiagnosticsStore",
+          "description": "Performance logging for the persistence layer (`nohrs-store`)."
+        }
+      },
+      "required": [
+        "store"
+      ],
+      "type": "object"
+    },
+    "DiagnosticsStore": {
+      "description": "Performance logging for the SQLite / redb store. All off by default, so a\ndefault config adds no overhead. Output goes through `tracing` (targets\n`nohrs_store::sql` / `nohrs_store::redb`) and is filterable with `RUST_LOG`.",
+      "properties": {
+        "log_all_queries": {
+          "description": "Log every SQL query at `debug` (verbose).",
+          "type": "boolean"
+        },
+        "log_redb_ops": {
+          "description": "Log redb `get`/`put`/`delete`/`batch` operations and their durations.",
+          "type": "boolean"
+        },
+        "slow_query_ms": {
+          "description": "Log SQL queries slower than this many milliseconds at `warn`. Zero (the\ndefault) disables slow-query logging.",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "log_all_queries",
+        "slow_query_ms",
+        "log_redb_ops"
+      ],
+      "type": "object"
+    },
     "SortOrder": {
       "description": "The column a directory listing is ordered by.",
       "oneOf": [
@@ -88,8 +125,12 @@
     }
   },
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "description": "The fully merged, validated configuration.\n\nOnly the P1 surface (`theme` / `ui`) is modelled here. `[keybindings]` and\n`[plugins]` are recognised as reserved sections (see [`is_reserved_section`])\nbut intentionally not deserialized yet, so their future shapes can be added\nwithout breaking older files.",
+  "description": "The fully merged, validated configuration.\n\nModels the P1 surface (`theme` / `ui`) plus the P2 `[diagnostics]` section.\n`[keybindings]` and `[plugins]` are recognised as reserved sections (see\n[`is_reserved_section`]) but intentionally not deserialized yet, so their\nfuture shapes can be added without breaking older files.",
   "properties": {
+    "diagnostics": {
+      "$ref": "#/$defs/Diagnostics",
+      "description": "Diagnostics / performance-logging settings."
+    },
     "schema_version": {
       "description": "On-disk schema version. Must be [`CURRENT_SCHEMA_VERSION`] for this build.",
       "minimum": 0,
@@ -107,7 +148,8 @@
   "required": [
     "schema_version",
     "theme",
-    "ui"
+    "ui",
+    "diagnostics"
   ],
   "title": "Config",
   "type": "object"

--- a/docs/launcher.md
+++ b/docs/launcher.md
@@ -14,7 +14,7 @@
 | **モデル** | 別ウィンドウ (フローティング)。explorer とは独立した window |
 | **表示位置 (初回)** | 画面中央寄り上 (画面上端から 25%) |
 | **表示位置 (2 回目以降)** | 最後にユーザーが置いた位置を記憶し、その位置で起動 |
-| **位置の記憶** | SQLite `key_value` テーブル (`launcher.window_position`) に保存。高頻度更新のため config.toml ではない |
+| **位置の記憶** | redb ホスト KV (`state.redb`、key `launcher.window_position`) に保存。高頻度更新のため config.toml ではない (詳細は [`persistence.md`](./persistence.md)) |
 | **移動** | 検索バー上部の数十 px (drag handle) をマウスでドラッグして移動可能 |
 | **位置リセット** | `Cmd+0` でデフォルト位置に戻す |
 | **マルチディスプレイ** | ドラッグで別ディスプレイへ移動可、移動先で位置記憶 |
@@ -219,7 +219,7 @@ struct Action {
 - window: GPUI で borderless + blur 化、`window.set_window_level(.floating)`
 - global hotkey: `global-hotkey` crate
 - ranking: `nucleo`
-- 位置記憶: `nohrs-store::KvStore` (SQLite `key_value`) 経由
+- 位置記憶: `nohrs-store::KvStore` (redb `state.redb`) 経由
 
 ---
 

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -1,6 +1,6 @@
 # Persistence — SQLite + redb
 
-> Status: Draft (P2 で実装、P4 で plugin KV 拡張)
+> Status: Draft (P2 で SQLite + redb ホスト KV を実装、P4 で plugin KV 拡張)
 > Related: [`ROADMAP.md`](./ROADMAP.md), [`docs/async-runtime.md`](./async-runtime.md), [`docs/plugin-api.md`](./plugin-api.md)
 
 本書はメタデータ・履歴・プラグイン状態の永続化レイヤを定めます。
@@ -9,16 +9,29 @@
 
 ## 1. 全体方針
 
-| データ種別 | ストア | 理由 |
-|-----------|--------|------|
-| **ファイルメタデータ・履歴・KV (ホスト)** | **SQLite (rusqlite)** | SQL 表現力 (差分 query / 結合 query) が必要 |
-| **プラグイン専用 KV** | **redb** | 高速 R/W、plugin_id でテーブル隔離、host data と分離 |
-| **設定ファイル** | TOML (`config.toml`) | 詳細は [`docs/config.md`](./config.md) |
+| データ種別 | ストア | ファイル | 理由 |
+|-----------|--------|---------|------|
+| **ファイルメタデータ・履歴** | **SQLite (rusqlite)** | `db.sqlite` | SQL 表現力 (差分 query / 結合 query / 順序付き query) が必要 |
+| **ホスト KV** (window 位置・タブ/セッション復元・動的設定) | **redb** | `state.redb` | 純粋な key→blob の高頻度・小サイズ書き込み。SQL 不要、メタデータ書き込みと隔離 |
+| **プラグイン専用 KV** (P4) | **redb** | `plugin-kv.redb` | 高速 R/W、plugin_id でテーブル隔離、host data と分離 |
+| **設定ファイル** | TOML (`config.toml`) | — | 詳細は [`docs/config.md`](./config.md) |
 
 理由:
-- ホストデータは SQL 表現力 (検索メタデータの差分検出など) が必要
-- プラグイン KV はシンプル かつ高速性が要求 (Raycast / VSCode 流の plugin state)
-- 2 つの DB を持つが、それぞれ単一ファイルで backup 単純、`MetadataStore` / `KvStore` の trait は別物なので混乱無し
+- 検索メタデータ (差分検出など) と履歴 (kind+時刻順) は SQL 表現力が必要 → SQLite
+- ホスト KV (タブ復元・window 位置等) は純 KV で SQL 不要。高頻度・小サイズの書き込みを、P3 のメタデータインデクサがハンマーする SQLite 単一ライター WAL から隔離するため redb に置く
+- プラグイン KV (P4) はシンプルかつ高速性が要求され (Raycast / VSCode 流の plugin state)、host KV と同じ redb 実装 (`RedbKvStore`) を再利用する
+- 複数の DB を持つが、それぞれ単一ファイルで backup 単純、`MetadataStore` / `KvStore` の trait は別物なので混乱無し
+
+### 1.1 SQLite と redb の使い分け基準
+
+> **判断基準: 「キー完全一致以外で問い合わせる必要があるか？」**
+
+| 答え | 例 | ストア |
+|------|----|--------|
+| **Yes** — 範囲 / 差分 / 順序 / 二次インデックスでクエリする | `list_children` / `list_changed_since` / `find_by_inode` / kind+時刻順の履歴 | **SQLite** |
+| **No** — 純粋な key→blob の get / put / prefix だけ | タブ/セッション復元、window 位置、ホスト動的 KV、plugin KV | **redb** |
+
+新しい永続データを追加するときは必ずこの基準で配置先を決める。判断に迷う「とりあえず DB」を避け、SQL 表現力を実際に使うものだけを SQLite に集約する。
 
 ---
 
@@ -54,12 +67,7 @@ CREATE TABLE files (
 CREATE INDEX idx_files_parent ON files(parent_path);
 CREATE INDEX idx_files_inode  ON files(inode);
 
--- ホスト KV (動的設定、launcher window position 等)
-CREATE TABLE key_value (
-    key        TEXT PRIMARY KEY,
-    value      BLOB NOT NULL,    -- JSON or MessagePack
-    updated_at INTEGER NOT NULL
-);
+-- (ホスト KV は redb `state.redb` に置く。§3 参照。SQLite には持たない)
 
 -- 履歴 (recent files, search history, command usage)
 CREATE TABLE history (
@@ -128,7 +136,7 @@ fn migrate(conn: &Connection) -> Result<()> {
 
 ---
 
-## 3. redb (plugin KV)
+## 3. redb (ホスト KV + plugin KV)
 
 ### 設定
 
@@ -137,12 +145,32 @@ fn migrate(conn: &Connection) -> Result<()> {
 redb = "2"
 ```
 
-### ファイル配置
-
-- `$XDG_DATA_HOME/nohrs/plugin-kv.redb` (単一ファイル)
 - ACID + MVCC、SQLite と同じく WAL 風 crash recovery
+- ホスト KV (P2) と plugin KV (P4) は **別ファイル** に分ける
 
-### テーブル設計
+| ファイル | 用途 | フェーズ |
+|---------|------|---------|
+| `$XDG_DATA_HOME/nohrs/state.redb` | ホスト KV (window 位置・タブ/セッション復元・動的設定) | **P2** |
+| `$XDG_DATA_HOME/nohrs/plugin-kv.redb` | プラグイン専用 KV / cache | P4 |
+
+### ホスト KV テーブル設計 (P2)
+
+```rust
+// crates/nohrs-store/src/nohrs_store.rs (擬似コード)
+use redb::TableDefinition;
+
+// 単一テーブル。key は "window.position" / "session.tabs" 等の名前空間付き文字列。
+const HOST_KV: TableDefinition<'static, &str, &[u8]> = TableDefinition::new("kv");
+```
+
+- `KvStore::get` / `put` / `delete` は `HOST_KV` への単純な点アクセス
+- `KvStore::list_prefix(prefix)` は `range(prefix..)` を走査し prefix 不一致で打ち切る
+- `KvStore::batch(ops)` は 1 つの write transaction にまとめて atomic commit
+- value は JSON or MessagePack で serialize した blob (タブ群のスナップショット等)
+
+### プラグイン KV テーブル設計 (P4)
+
+`plugin-kv.redb` に plugin_id ごとの隔離テーブルを置く (本 Issue #63 では対象外、P4 で実装)。
 
 ```rust
 // 擬似コード
@@ -232,9 +260,13 @@ pub trait PluginStore: Send + Sync {
 pub struct SqliteStore { conn: Arc<Mutex<Connection>> }
 impl MetadataQuery  for SqliteStore { ... }
 impl MetadataStore  for SqliteStore { ... }
-impl KvStore        for SqliteStore { ... }   // ホスト KV
 impl HistoryStore   for SqliteStore { ... }
 
+// ホスト KV は redb backend (P2)。`state.redb` の単一 "kv" テーブルを使う。
+pub struct RedbKvStore { db: Arc<redb::Database> }
+impl KvStore  for RedbKvStore { ... }
+
+// (P4) プラグイン専用 KV / cache。`plugin-kv.redb` を plugin_id で隔離。
 pub struct RedbPluginKv { db: Arc<redb::Database>, plugin_id: String }
 impl KvStore  for RedbPluginKv { ... }
 impl Cache    for RedbPluginCache { ... }
@@ -247,7 +279,29 @@ impl Cache    for RedbPluginCache { ... }
 
 ---
 
-## 5. プラグインへの公開範囲
+## 5. 診断 / パフォーマンスログ
+
+ストア操作の所要時間を計測してパフォーマンス解析に使うためのログ機構。デフォルトは全 off (本番は無音) で、`config.toml` の `[diagnostics.store]` で有効化する (スキーマは [`docs/config.md`](./config.md) §2)。出力は既存の `tracing` + `EnvFilter` (`RUST_LOG`) 経路 ([`crates/nohrs-core/src/telemetry/logging.rs`](../crates/nohrs-core/src/telemetry/logging.rs)) にそのまま乗る。
+
+### SQLite
+
+rusqlite の組み込みフックを使う:
+
+- `Connection::profile(Some(callback))` — 各ステートメント完了後に実行 SQL と所要時間を受け取る。`slow_query_ms` 超過なら `warn`、`log_all_queries` 有効時は全件を `debug` で `tracing` へ emit (target = `nohrs_store::sql`)。
+- `Connection::trace(Some(callback))` — 必要なら展開後 SQL を `trace` レベルで出力 (より詳細)。
+
+### redb
+
+redb には同等の組み込みフックが無いため、`RedbKvStore` の各操作 (`get` / `put` / `delete` / `batch`) を計測ラッパで囲み、`log_redb_ops` 有効時に操作名と所要時間を `tracing` へ emit (target = `nohrs_store::redb`)。
+
+### 方針
+
+- フックの登録はストア接続の open 時に config を見て決定する (config off ならフック自体を登録せず、無効時のオーバーヘッドをゼロにする)。
+- 閾値・フラグの解釈は `config.toml` のレニエントなバリデーション方針 (config.md §6) に従う。
+
+---
+
+## 6. プラグインへの公開範囲
 
 | 機能 | コミュニティ plugin の権限 |
 |------|--------------------------|
@@ -262,8 +316,11 @@ impl Cache    for RedbPluginCache { ... }
 
 ---
 
-## 6. バックアップ・移行
+## 7. バックアップ・移行
 
-- SQLite は単一ファイル → `cp ~/.local/share/nohrs/db.sqlite ./backup-$(date +%Y%m%d).sqlite`
-- redb も単一ファイル
+- いずれも単一ファイル。P2 では `db.sqlite` (メタデータ・履歴) と `state.redb` (ホスト KV) の 2 ファイル、P4 で `plugin-kv.redb` が加わる
+  ```sh
+  cp ~/.local/share/nohrs/db.sqlite   ./backup-$(date +%Y%m%d).sqlite
+  cp ~/.local/share/nohrs/state.redb  ./backup-$(date +%Y%m%d).redb
+  ```
 - ユーザー向けの export/import 機能は P5 以降で検討

--- a/docs/plugin-permissions.md
+++ b/docs/plugin-permissions.md
@@ -194,7 +194,7 @@ manifest が要求してもブロックされる操作:
 | **process: shell injection** | `sh`, `bash`, `zsh`, `cmd.exe`, `powershell` をコマンド名で要求 | 引数フィルタが効かなくなる |
 | **process: 引数の shell expansion** | `process.spawn` は **必ず list、shell なし** | `sh -c` 直渡し禁止、host 側で reject |
 | **fs.write: システムパス** | `/etc/`, `/usr/`, `/bin/`, `/sbin/`, `~/Library/Preferences/`, `~/Library/Application Support/` (nohrs 自身を除く) | manifest で要求しても install 時に hard reject |
-| **fs.write: nohrs データ** | `$XDG_DATA_HOME/nohrs/db.sqlite`, `$XDG_DATA_HOME/nohrs/plugin-kv.redb` | 他 plugin のデータや host state の破壊を防ぐ |
+| **fs.write: nohrs データ** | `$XDG_DATA_HOME/nohrs/db.sqlite`, `$XDG_DATA_HOME/nohrs/state.redb`, `$XDG_DATA_HOME/nohrs/plugin-kv.redb` | 他 plugin のデータや host state の破壊を防ぐ |
 | **network: localhost** | `localhost`, `127.0.0.1`, `0.0.0.0`, `::1` | manifest で許可しても reject (内部サービスへの攻撃を防ぐ) |
 | **network: link-local / private IP** | `169.254.0.0/16`, `192.168.0.0/16`, `10.0.0.0/8`, `172.16.0.0/12` | SSRF 防御 |
 


### PR DESCRIPTION
Implements #63 — the P2 persistence foundation as a new `nohrs-store` crate.

## What

- **`crates/nohrs-store/`** — new crate (`[lib] path = "src/nohrs_store.rs"`), tokio-free, added to workspace `members` / `default-members`.
  - **SQLite** (`rusqlite`, `bundled`+`blob`+`trace`) in WAL mode for `files` metadata and `history`, with self-written forward-only migrations (`migrations/001_init.sql`, recorded in `_migrations`).
  - **redb** for host key/value state (`state.redb`) — window position, tab/session restore, dynamic settings.
  - Interface-segregated traits: `MetadataQuery` / `MetadataStore` / `KvStore` / `HistoryStore`. SQLite implements metadata + history; redb implements `KvStore`.
  - In-memory backends (`:memory:` for SQLite, redb `InMemoryBackend`) plus a single-trait `MockMetadataQuery` for tests. 16 unit tests (round-trip, persistence-across-reopen, prefix scan, atomic batch).

## Design decision: SQLite vs redb

Per the issue's addendum, redb is introduced now and the split is documented (`docs/persistence.md` §1.1):

> **Need to query by anything other than the exact key?** Yes (range / diff / ordered / secondary index) → SQLite. No (pure `key -> blob`) → redb.

This moves the host `key_value` table out of SQLite into redb (`state.redb`); `001_init.sql` no longer creates it. Docs (`persistence.md`, `config.md`, `ROADMAP.md`, `launcher.md`, `plugin-permissions.md`) and `config.schema.json` are updated to match.

## Performance logging

`StoreLogConfig` drives opt-in, default-off logging via `tracing`/`RUST_LOG`:
- SQL: rusqlite `profile` hook — slow queries → `warn`, all queries → `debug` (target `nohrs_store::sql`).
- redb: per-op timing wrapper (target `nohrs_store::redb`).

Exposed to users as a typed `[diagnostics.store]` section in `nohrs-core` (`log_all_queries` / `slow_query_ms` / `log_redb_ops`), with lenient validation and JSON-schema regeneration.

## Out of scope (follow-up)

Opening the store at app startup and threading `config.diagnostics.store` → `StoreLogConfig` into app state is left for the P2 integration work that introduces the first consumers (tab restore, metadata indexer); no consumer exists yet.

## Verification

Backend/config change, no UI. Local gate green: `cargo fmt --all`, `cargo clippy --all-targets -- -D warnings`, `cargo build`, `cargo test` (46 + 16 + 6 tests pass). `cargo check -p nohrs` compiles. New deps (`rusqlite`, `redb`, `libsqlite3-sys`, …) are all MIT/Apache-2.0; `cargo tree -i tokio` confirms no tokio in the crate.

Release Notes:

- N/A

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `nohrs-store`: a new persistence crate that uses SQLite for metadata/history and `redb` for host key/value state, with opt-in performance logging and config integration. Implements #63 to land the P2 storage foundation without pulling in tokio.

- **New Features**
  - New `crates/nohrs-store` crate. SQLite (`rusqlite` bundled, WAL) handles `files` and `history` (now with a CHECK on `history.kind`); `redb` manages host KV in `state.redb`.
  - Clear split: range/diff/ordered → SQLite; exact key→blob → `redb`. Traits: `MetadataQuery`, `MetadataStore`, `HistoryStore`, `KvStore`.
  - Forward-only migrations applied atomically (DDL + `_migrations` insert in one transaction). In-memory backends and a minimal mock for tests. No tokio.
  - Store performance logs via `StoreLogConfig`: rusqlite profile hook (slow→warn, all→debug) and `redb` op timings, exposed under `[diagnostics.store]` (JSON Schema/docs updated).

- **Migration**
  - Host `key_value` table moved out of SQLite; host state now lives in `state.redb`. `db.sqlite` contains only `files` and `history`.
  - Docs updated across persistence, config, roadmap, launcher, and plugin permissions. Integration at app startup will follow with P2 consumers.

<sup>Written for commit daebded58943d74731988eb5fea0d1ed77df181d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/noh-rs/nohrs/pull/158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a top-level diagnostics config ([diagnostics.store]) with toggles for query logging, redb operation logging, and slow-query threshold.
  * Introduced a unified persistence layer: SQLite for metadata/history and redb for host key/value state; launcher window position now persists to the redb state store.

* **Documentation**
  * Updated storage, config, persistence, launcher, roadmap, and plugin-permissions docs and the default config/template to reflect the new persistence layout and diagnostics options.

* **Tests**
  * Added parsing and persistence tests for diagnostics and storage behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->