### PR TITLE
nohrs-store: Harden SQLite write/read performance

### DIFF
--- a/crates/nohrs-store/src/sqlite.rs
+++ b/crates/nohrs-store/src/sqlite.rs
@@ -49,6 +49,12 @@ impl SqliteStore {
         connection.query_row("PRAGMA journal_mode=WAL;", [], |row| {
             row.get::<_, String>(0)
         })?;
+        // `synchronous=NORMAL` is the recommended pairing with WAL: it fsyncs at
+        // checkpoints rather than every commit, so a power loss may drop the last
+        // few transactions but never corrupts the database. Our data (metadata /
+        // history) is a rebuildable cache, so trading that durability for far
+        // fewer fsyncs is the right call.
+        connection.pragma_update(None, "synchronous", "NORMAL")?;
         configure_query_logging(&mut connection, log);
         migrate(&mut connection)?;
         Ok(Self {
@@ -147,19 +153,19 @@ fn path_str(path: &Path) -> String {
 impl MetadataQuery for SqliteStore {
     fn get_file(&self, path: &Path) -> Result<Option<FileRecord>> {
         let connection = self.connection();
-        let record = connection
-            .query_row(
-                &format!("SELECT {FILE_COLUMNS} FROM files WHERE path = ?1"),
-                [path_str(path)],
-                row_to_file,
-            )
+        // `prepare_cached` reuses the compiled statement across calls (these are
+        // hot paths once the P3 indexer runs); the SQL text is the cache key.
+        let mut statement = connection
+            .prepare_cached(&format!("SELECT {FILE_COLUMNS} FROM files WHERE path = ?1"))?;
+        let record = statement
+            .query_row([path_str(path)], row_to_file)
             .optional()?;
         Ok(record)
     }
 
     fn list_children(&self, parent: &Path) -> Result<Vec<FileRecord>> {
         let connection = self.connection();
-        let mut statement = connection.prepare(&format!(
+        let mut statement = connection.prepare_cached(&format!(
             "SELECT {FILE_COLUMNS} FROM files WHERE parent_path = ?1 ORDER BY path"
         ))?;
         let rows = statement.query_map([path_str(parent)], row_to_file)?;
@@ -168,7 +174,7 @@ impl MetadataQuery for SqliteStore {
 
     fn list_changed_since(&self, ts_ns: i64) -> Result<Vec<FileRecord>> {
         let connection = self.connection();
-        let mut statement = connection.prepare(&format!(
+        let mut statement = connection.prepare_cached(&format!(
             "SELECT {FILE_COLUMNS} FROM files \
              WHERE mtime_ns > ?1 OR (deleted_at IS NOT NULL AND deleted_at > ?1) \
              ORDER BY mtime_ns"
@@ -179,12 +185,11 @@ impl MetadataQuery for SqliteStore {
 
     fn find_by_inode(&self, inode: u64) -> Result<Option<FileRecord>> {
         let connection = self.connection();
-        let record = connection
-            .query_row(
-                &format!("SELECT {FILE_COLUMNS} FROM files WHERE inode = ?1 LIMIT 1"),
-                [inode as i64],
-                row_to_file,
-            )
+        let mut statement = connection.prepare_cached(&format!(
+            "SELECT {FILE_COLUMNS} FROM files WHERE inode = ?1 LIMIT 1"
+        ))?;
+        let record = statement
+            .query_row([inode as i64], row_to_file)
             .optional()?;
         Ok(record)
     }
@@ -196,7 +201,7 @@ impl MetadataStore for SqliteStore {
         // `excluded` refers to the row that would have been inserted; on a path
         // conflict we refresh the changeable columns but leave indexed_at /
         // deleted_at to the dedicated methods.
-        let id = connection.query_row(
+        let mut statement = connection.prepare_cached(
             "INSERT INTO files (path, parent_path, inode, size, mtime_ns, content_hash) \
              VALUES (?1, ?2, ?3, ?4, ?5, ?6) \
              ON CONFLICT(path) DO UPDATE SET \
@@ -206,6 +211,8 @@ impl MetadataStore for SqliteStore {
                  mtime_ns = excluded.mtime_ns, \
                  content_hash = excluded.content_hash \
              RETURNING id",
+        )?;
+        let id = statement.query_row(
             params![
                 path_str(&entry.path),
                 path_str(&entry.parent_path),
@@ -221,16 +228,17 @@ impl MetadataStore for SqliteStore {
 
     fn delete_file(&self, path: &Path) -> Result<()> {
         let connection = self.connection();
-        connection.execute("DELETE FROM files WHERE path = ?1", [path_str(path)])?;
+        connection
+            .prepare_cached("DELETE FROM files WHERE path = ?1")?
+            .execute([path_str(path)])?;
         Ok(())
     }
 
     fn mark_indexed(&self, id: FileId, indexed_at_ns: i64) -> Result<()> {
         let connection = self.connection();
-        connection.execute(
-            "UPDATE files SET indexed_at = ?2 WHERE id = ?1",
-            params![id, indexed_at_ns],
-        )?;
+        connection
+            .prepare_cached("UPDATE files SET indexed_at = ?2 WHERE id = ?1")?
+            .execute(params![id, indexed_at_ns])?;
         Ok(())
     }
 }
@@ -238,20 +246,26 @@ impl MetadataStore for SqliteStore {
 impl HistoryStore for SqliteStore {
     fn record(&self, entry: HistoryEntry) -> Result<()> {
         let connection = self.connection();
-        connection.execute(
-            "INSERT INTO history (kind, payload, occurred_at) VALUES (?1, ?2, ?3)",
-            params![entry.kind.as_str(), entry.payload, entry.occurred_at],
-        )?;
+        connection
+            .prepare_cached("INSERT INTO history (kind, payload, occurred_at) VALUES (?1, ?2, ?3)")?
+            .execute(params![
+                entry.kind.as_str(),
+                entry.payload,
+                entry.occurred_at
+            ])?;
         Ok(())
     }
 
     fn list(&self, kind: HistoryKind, limit: usize) -> Result<Vec<HistoryEntry>> {
         let connection = self.connection();
-        let mut statement = connection.prepare(
+        let mut statement = connection.prepare_cached(
             "SELECT kind, payload, occurred_at FROM history \
              WHERE kind = ?1 ORDER BY occurred_at DESC LIMIT ?2",
         )?;
-        let rows = statement.query_map(params![kind.as_str(), limit as i64], |row| {
+        // Saturate rather than wrap: a `usize` past `i64::MAX` would otherwise
+        // become a negative LIMIT, which SQLite treats as "no limit".
+        let limit = i64::try_from(limit).unwrap_or(i64::MAX);
+        let rows = statement.query_map(params![kind.as_str(), limit], |row| {
             let kind_text: String = row.get(0)?;
             Ok(HistoryEntry {
                 // The kind came straight from our own enum, so it always parses.

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -168,6 +168,8 @@ const HOST_KV: TableDefinition<'static, &str, &[u8]> = TableDefinition::new("kv"
 - `KvStore::batch(ops)` は 1 つの write transaction にまとめて atomic commit
 - value は JSON or MessagePack で serialize した blob (タブ群のスナップショット等)
 
+> **書き込み頻度に関する注意**: redb の commit はデフォルトで durable (fsync) なので、window ドラッグ等の高頻度更新を 1 操作ずつ `put` すると fsync が多発する。呼び出し側 (UI 層) で **debounce してから書く**、複数キーは `batch` でまとめる、を原則とする。
+
 ### プラグイン KV テーブル設計 (P4)
 
 `plugin-kv.redb` に plugin_id ごとの隔離テーブルを置く (本 Issue #63 では対象外、P4 で実装)。


### PR DESCRIPTION
Self-review follow-ups on the `nohrs-store` crate (#158).

## Performance

- **`PRAGMA synchronous=NORMAL`** paired with WAL. Metadata/history is a rebuildable cache, so fsyncing at checkpoints rather than every commit trades a few transactions on power loss (never corruption) for far fewer fsyncs.
- **`prepare_cached`** for the repeated metadata/history statements, so the compiled plan is reused on hot paths (notably the P3 indexer's `list_children` / `get_file`).
- **Saturate the history `LIMIT`** instead of letting a huge `usize` wrap to a negative `i64` (which SQLite would read as "no limit").
- **Doc note**: high-frequency host KV writes (e.g. window drag) must be debounced and batched, since redb commits fsync by default (`docs/persistence.md` §3).

## Security review notes

Full self-review found no exploitable issues: all SQL uses parameter binding (the only interpolation is the compile-time `FILE_COLUMNS` const), no `unsafe`, no network I/O, host-only trust boundary.

One **known limitation** (intentionally not changed here): paths are stored via `to_string_lossy()`, so on Linux two distinct non-UTF-8 paths could collide in the `path UNIQUE` column. This matches the rest of the codebase (`nohrs-models::FileEntryDto` is `path: String`); switching the store to byte-preserving paths should be a project-wide decision, not a unilateral divergence in one crate.

## Verification

Backend-only, no UI. Local gate green: `cargo fmt --all`, `cargo clippy --all-targets -- -D warnings`, `cargo build`, `cargo test`. Changes are behavior-preserving; existing store tests cover correctness.

Release Notes:

- N/A