### PR TITLE
Add CodeRabbit review configuration

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,64 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+#
+# CodeRabbit configuration for nohrs.
+#
+# Philosophy: this file does NOT restate the project's coding rules. Instead it
+# points CodeRabbit at the authoritative documents (.rules, docs/, ADRs) via the
+# knowledge base and lets the reviewer read them and judge for itself. Keeping the
+# rules in one place avoids the config drifting out of sync with the docs.
+
+language: "en-US"
+
+tone_instructions: >
+  Be concise and direct. Follow the repo's .rules and design docs (ADRs, ROADMAP).
+  Flag performance, security, and spec mismatches against the docs first. Small
+  syntax nits are welcome. Don't re-flag fmt/clippy/cargo-deny already gated by CI.
+
+reviews:
+  profile: assertive
+  # Pre-alpha: surface issues but don't hard-block merges via GitHub's
+  # request-changes mechanism.
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+
+  auto_review:
+    enabled: true
+    auto_incremental_review: true
+    # nohrs develops off `develop`; review PRs targeting it (and release branches).
+    base_branches:
+      - "develop"
+      - "release/.*"
+
+  # Skip generated, vendored, and non-source artifacts.
+  path_filters:
+    - "!target/**"
+    - "!**/*.lock"
+    - "!**/node_modules/**"
+    - "!web/**/dist/**"
+    - "!web/**/.output/**"
+
+  # Minimal pointer only — the substance lives in the knowledge base below.
+  path_instructions:
+    - path: "crates/**/*.rs"
+      instructions: >
+        Review against the repo's .rules and the relevant docs/ and docs/adr files
+        rather than generic Rust style. Prioritize performance, security
+        (untrusted input, filesystem/symlink handling, plugin permissions), and
+        any mismatch with the design docs (ADRs, ROADMAP, spec docs).
+
+knowledge_base:
+  # Let CodeRabbit read the project's own guidelines and specs so it can apply
+  # nohrs-specific conventions and catch divergence from the design.
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - ".rules"
+      - "CLAUDE.md"
+      - "CONTRIBUTING.md"
+      - "docs/**/*.md"
+      - "docs/adr/**/*.md"
+      - "deny.toml"
+      - "clippy.toml"
+  learnings:
+    scope: "local"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -57,7 +57,6 @@ knowledge_base:
       - "CLAUDE.md"
       - "CONTRIBUTING.md"
       - "docs/**/*.md"
-      - "docs/adr/**/*.md"
       - "deny.toml"
       - "clippy.toml"
   learnings:


### PR DESCRIPTION
Adds a `.coderabbit.yaml` so CodeRabbit reviews PRs with nohrs-specific context instead of generic Rust style.

## What and why

The repo had no CodeRabbit config, yet `coderabbitai[bot]` is a required review gate in the `/pull-request` flow. The project also carries non-obvious, doc-encoded constraints (tokio-free app core per ADR 0004, no sync `std::fs` on the UI thread per `clippy.toml`, GPUI test conventions, plugin permission/sandbox rules, ROADMAP/ADR alignment) that generic review misses.

Rather than copy those rules into the config — which would drift out of sync — this points CodeRabbit at the authoritative sources via the knowledge base and lets the reviewer read and apply them:

- `knowledge_base.code_guidelines.filePatterns` ingests `.rules`, `CLAUDE.md`, `CONTRIBUTING.md`, `docs/**`, `docs/adr/**`, `deny.toml`, `clippy.toml`.
- `tone_instructions` prioritizes performance, security, and spec mismatches, and avoids re-flagging fmt/clippy/cargo-deny already gated by CI.
- `reviews.profile: assertive` with English (`en-US`) comments; syntax/small nits welcome.
- `request_changes_workflow: false` (pre-alpha), incremental review on, `develop`/`release/*` base branches, generated artifacts excluded via `path_filters`.
- `path_instructions` is intentionally minimal — a single pointer telling the reviewer to consult `.rules` and the relevant docs, not a per-glob rule dump.

## Verification

Config-only change (no Rust/UI). YAML validated locally (parses; `tone_instructions` 240/250 chars). End-to-end behavior will be confirmed on this PR: that CodeRabbit accepts the config without parse errors and reviews in the expected categories.

Release Notes:

- N/A

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `.coderabbit.yaml` to review PRs against the repo’s rules and design docs, not generic Rust style. Focuses feedback on performance, security, and spec mismatches; fmt/clippy/cargo-deny remain CI-gated.

- **New Features**
  - Knowledge base loads `.rules`, `CLAUDE.md`, `CONTRIBUTING.md`, `docs/**/*.md` (covers ADRs), `deny.toml`, `clippy.toml`.
  - Auto incremental reviews on `develop` and `release/*`; assertive `en-US` comments; change-requests disabled.
  - Filters generated/vendor paths: `target/**`, `**/*.lock`, `**/node_modules/**`, `web/**/dist/**`, `web/**/.output/**`.
  - Minimal path instructions that defer to docs; high-level summaries enabled.

<sup>Written for commit b6d32024e81a1509bc185063d46d89b830e4508c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/noh-rs/nohrs/pull/160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a CodeRabbit configuration to enable automated, incremental code reviews for develop and release branches.
  * Configured review behavior to produce high-level summaries, respect local guidelines/docs, and skip generated/vendor artifacts to reduce noise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->