### PR TITLE
Expand config schema with P2 sections and CI schema sync

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"061678c2-2f26-4c4b-a1d4-b47bd4810821","pid":3426773,"procStart":"155592013","acquiredAt":1780464782633}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,32 @@ jobs:
       - name: Spell check
         run: typos
 
+  # Keeps `docs/config.schema.json` in lock-step with the `Config` structs. The
+  # schema is generated from the Rust types (schemars) via a `nohrs-core` example
+  # so it builds on Linux without the gpui-backed binary. Regenerating into the
+  # committed path and diffing makes a stale schema a hard failure with a visible
+  # diff; `nohrs config schema` emits the same bytes. Regenerate locally with
+  # `cargo run -p nohrs-core --example schema > docs/config.schema.json`.
+  schema:
+    name: config schema
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
+      - name: Regenerate JSON Schema
+        run: cargo run -p nohrs-core --example schema --locked > docs/config.schema.json
+
+      - name: Fail if the committed schema is stale
+        run: git diff --exit-code -- docs/config.schema.json
+
   # gpui renders with Metal/Blade and the GUI stack is only exercised on macOS.
   # Linux therefore lints/tests/builds the headless `default-members` subset
   # (nohrs-core / nohrs-models / nohrs-services without its `gui` feature), while

--- a/crates/nohrs-core/examples/schema.rs
+++ b/crates/nohrs-core/examples/schema.rs
@@ -1,0 +1,15 @@
+//! Print the `config.toml` JSON Schema to stdout.
+//!
+//! This emits the exact bytes committed to `docs/config.schema.json` (and the
+//! same output as `nohrs config schema`), but builds only `nohrs-core`, so it
+//! runs on Linux where the gpui-backed `nohrs` binary does not link. CI uses it
+//! to keep the committed schema in sync:
+//!
+//! ```bash
+//! cargo run -p nohrs-core --example schema > docs/config.schema.json
+//! ```
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("{}", nohrs_core::config::json_schema_string()?);
+    Ok(())
+}

--- a/crates/nohrs-core/src/config.rs
+++ b/crates/nohrs-core/src/config.rs
@@ -19,7 +19,8 @@ pub mod watcher;
 pub use loader::{backup, ensure_exists, needs_migration, reset, write_default};
 pub use settings::{
     json_schema_string, load_from_path, report_diagnostics, Config, ConfigOverride, Diagnostic,
-    DiagnosticLevel, Diagnostics, DiagnosticsStore, SortOrder, Theme, ThemeMode, Ui,
+    DiagnosticLevel, Diagnostics, DiagnosticsStore, Indexing, IndexingExclude, IndexingMode,
+    Keybindings, Launcher, Plugins, Search, SearchBackend, SortOrder, Theme, ThemeMode, Ui,
     CURRENT_SCHEMA_VERSION, SCHEMA_URL,
 };
 pub use watcher::ConfigWatcher;

--- a/crates/nohrs-core/src/config/settings.rs
+++ b/crates/nohrs-core/src/config/settings.rs
@@ -660,7 +660,9 @@ fn read_keybindings(
     for (action, value) in table {
         match value.as_str() {
             Some(chord) => {
-                keybindings.bindings.insert(action.clone(), chord.to_string());
+                keybindings
+                    .bindings
+                    .insert(action.clone(), chord.to_string());
             }
             None => diagnostics.push(Diagnostic::warn(format!(
                 "invalid keybindings.{action} {value}; expected a string, ignoring"
@@ -1051,7 +1053,11 @@ mod tests {
             Some("ctrl-q")
         );
         assert_eq!(
-            config.keybindings.bindings.get("search").map(String::as_str),
+            config
+                .keybindings
+                .bindings
+                .get("search")
+                .map(String::as_str),
             Some("ctrl-f")
         );
     }

--- a/crates/nohrs-core/src/config/settings.rs
+++ b/crates/nohrs-core/src/config/settings.rs
@@ -29,7 +29,20 @@ pub const SCHEMA_URL: &str = "https://nohrs.app/schema/config.schema.json";
 /// defined and parsed leniently so files can adopt them now, but the values do
 /// not drive behaviour yet (keybindings land in P3, plugins in P4; see
 /// `docs/config.md` §2/§5).
+///
+/// Only `theme`, `ui`, and `diagnostics` are consumed at runtime today. The
+/// remaining sections (`keybindings`, `plugins`, `indexing`, `search`,
+/// `launcher`) are accepted and validated now so files and editor completion can
+/// adopt them, but editing them has no effect until the matching subsystem is
+/// wired in a later phase — see the per-section notes and `docs/config.md` §5.
+///
+/// Every field is `#[serde(default)]`: the loader starts from
+/// [`Config::default`] and overlays only the keys present in the file, so a
+/// missing section is filled with its default rather than rejected. The
+/// generated schema therefore has no `required` properties, matching the
+/// loader (an empty `config.toml` is valid).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(default)]
 pub struct Config {
     /// On-disk schema version. Must be [`CURRENT_SCHEMA_VERSION`] for this build.
     pub schema_version: u64,
@@ -70,6 +83,7 @@ impl Default for Config {
 
 /// Appearance settings.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(default)]
 pub struct Theme {
     /// Light/dark selection, or following the OS.
     pub mode: ThemeMode,
@@ -89,6 +103,7 @@ impl Default for Theme {
 
 /// Explorer / view settings.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(default)]
 pub struct Ui {
     /// Column the listing is sorted by on load.
     pub default_sort: SortOrder,
@@ -117,6 +132,7 @@ impl Default for Ui {
 /// restart, config.md §5), so arbitrary action names are accepted without
 /// warning to keep forward compatibility.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(default)]
 pub struct Keybindings {
     /// Action identifier → key chord. Empty means "use the built-in keymap".
     #[serde(flatten)]
@@ -128,6 +144,7 @@ pub struct Keybindings {
 /// Type definition / reservation only: the lists are parsed and stored, but no
 /// plugin host loads them yet (that lands in P4).
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(default)]
 pub struct Plugins {
     /// Built-in (first-party) plugins to enable, by id (e.g. `"git"`).
     pub core: Vec<String>,
@@ -137,6 +154,7 @@ pub struct Plugins {
 
 /// Filesystem indexing settings.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(default)]
 pub struct Indexing {
     /// When the background index is built and maintained.
     pub mode: IndexingMode,
@@ -171,6 +189,7 @@ impl IndexingMode {
 
 /// Paths and globs excluded from indexing.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(default)]
 pub struct IndexingExclude {
     /// Literal paths (absolute or relative to the indexed root) to skip.
     pub paths: Vec<String>,
@@ -180,6 +199,7 @@ pub struct IndexingExclude {
 
 /// Search backend selection.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(default)]
 pub struct Search {
     /// Which engine answers content searches.
     pub backend: SearchBackend,
@@ -216,6 +236,7 @@ impl SearchBackend {
 
 /// Launcher window settings.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(default)]
 pub struct Launcher {
     /// Global hotkey that summons the launcher.
     pub hotkey: String,
@@ -234,6 +255,7 @@ impl Default for Launcher {
 
 /// Diagnostics / performance-logging settings (see `docs/persistence.md` §5).
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(default)]
 pub struct Diagnostics {
     /// Performance logging for the persistence layer (`nohrs-store`).
     pub store: DiagnosticsStore,
@@ -243,6 +265,7 @@ pub struct Diagnostics {
 /// default config adds no overhead. Output goes through `tracing` (targets
 /// `nohrs_store::sql` / `nohrs_store::redb`) and is filterable with `RUST_LOG`.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(default)]
 pub struct DiagnosticsStore {
     /// Log every SQL query at `debug` (verbose).
     pub log_all_queries: bool,
@@ -559,6 +582,10 @@ impl Config {
              show_hidden = false\n\
              icon_pack = \"default\"\n\
              \n\
+             # The sections below are parsed and validated, but not yet applied at\n\
+             # runtime — they take effect when their subsystem is wired in a later\n\
+             # phase (docs/config.md §5). They are here so files and editor\n\
+             # completion can adopt the shape early.\n\
              [indexing]\n\
              mode = \"auto\"   # \"auto\" | \"always-on\" | \"manual\"\n\
              \n\
@@ -881,7 +908,9 @@ fn warn_unknown_keys(
 ///   they are not standard JSON Schema draft 2020-12 formats, and `type` +
 ///   `minimum` already capture the constraint. Standard string formats are kept.
 ///
-/// Array element order (enum variants, `required`) is left untouched.
+/// There are no `required` arrays: every field is `#[serde(default)]`, so the
+/// loader (and a conforming editor) accepts a file that omits any section.
+/// Array element order (enum variants) is left untouched.
 pub fn json_schema_string() -> serde_json::Result<String> {
     let schema = schemars::schema_for!(Config);
     let value = serde_json::to_value(&schema)?;
@@ -1209,6 +1238,21 @@ mod tests {
         let schema = json_schema_string().unwrap();
         assert!(schema.contains("schema_version"));
         assert!(schema.contains("default_sort"));
+    }
+
+    #[test]
+    fn schema_has_no_required_so_partial_configs_validate() {
+        // The loader defaults every field (it overlays a parsed table onto
+        // `Config::default`), so no section is required. The schema must agree,
+        // otherwise editors reject files the app accepts.
+        let schema = json_schema_string().unwrap();
+        assert!(
+            !schema.contains("\"required\""),
+            "schema must not mark any field required"
+        );
+        let (config, diagnostics) = Config::from_toml_str("");
+        assert_eq!(config, Config::default());
+        assert!(diagnostics.is_empty(), "{diagnostics:?}");
     }
 
     #[test]

--- a/crates/nohrs-core/src/config/settings.rs
+++ b/crates/nohrs-core/src/config/settings.rs
@@ -10,6 +10,7 @@
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use std::path::Path;
 
 /// Schema version understood by this build. Bumped only when the on-disk
@@ -22,10 +23,12 @@ pub const SCHEMA_URL: &str = "https://nohrs.app/schema/config.schema.json";
 
 /// The fully merged, validated configuration.
 ///
-/// Models the P1 surface (`theme` / `ui`) plus the P2 `[diagnostics]` section.
-/// `[keybindings]` and `[plugins]` are recognised as reserved sections (see
-/// [`is_reserved_section`]) but intentionally not deserialized yet, so their
-/// future shapes can be added without breaking older files.
+/// Models the P1 surface (`theme` / `ui`) plus the P2 sections: `[indexing]`,
+/// `[search]`, `[launcher]`, and `[diagnostics]`. `[keybindings]` and
+/// `[plugins]` are reserved here as forward-compatible drafts — their types are
+/// defined and parsed leniently so files can adopt them now, but the values do
+/// not drive behaviour yet (keybindings land in P3, plugins in P4; see
+/// `docs/config.md` §2/§5).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct Config {
     /// On-disk schema version. Must be [`CURRENT_SCHEMA_VERSION`] for this build.
@@ -34,6 +37,17 @@ pub struct Config {
     pub theme: Theme,
     /// Explorer / view settings.
     pub ui: Ui,
+    /// Keybinding overrides (draft; full support in P3). Empty means the
+    /// built-in keymap is used.
+    pub keybindings: Keybindings,
+    /// Plugin selection (reserved; full support in P4).
+    pub plugins: Plugins,
+    /// Filesystem indexing strategy and exclusions.
+    pub indexing: Indexing,
+    /// Search backend selection.
+    pub search: Search,
+    /// Launcher window settings.
+    pub launcher: Launcher,
     /// Diagnostics / performance-logging settings.
     pub diagnostics: Diagnostics,
 }
@@ -44,6 +58,11 @@ impl Default for Config {
             schema_version: CURRENT_SCHEMA_VERSION,
             theme: Theme::default(),
             ui: Ui::default(),
+            keybindings: Keybindings::default(),
+            plugins: Plugins::default(),
+            indexing: Indexing::default(),
+            search: Search::default(),
+            launcher: Launcher::default(),
             diagnostics: Diagnostics::default(),
         }
     }
@@ -85,6 +104,130 @@ impl Default for Ui {
             default_sort: SortOrder::Name,
             show_hidden: false,
             icon_pack: "default".to_string(),
+        }
+    }
+}
+
+/// Keybinding overrides (config.md §2, draft for P3).
+///
+/// A draft surface: a map of action identifier to key chord (e.g.
+/// `"quit" = "ctrl-q"`). An empty map — the default — means the built-in keymap
+/// is used. The action vocabulary and live re-binding are defined in P3; until
+/// then values are stored and validated but not applied (hot reload is a
+/// restart, config.md §5), so arbitrary action names are accepted without
+/// warning to keep forward compatibility.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct Keybindings {
+    /// Action identifier → key chord. Empty means "use the built-in keymap".
+    #[serde(flatten)]
+    pub bindings: BTreeMap<String, String>,
+}
+
+/// Plugin selection (config.md §2, reserved for P4).
+///
+/// Type definition / reservation only: the lists are parsed and stored, but no
+/// plugin host loads them yet (that lands in P4).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct Plugins {
+    /// Built-in (first-party) plugins to enable, by id (e.g. `"git"`).
+    pub core: Vec<String>,
+    /// Community plugins to enable, as `user/repo` or a URL.
+    pub community: Vec<String>,
+}
+
+/// Filesystem indexing settings.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct Indexing {
+    /// When the background index is built and maintained.
+    pub mode: IndexingMode,
+    /// Paths and globs excluded from indexing.
+    pub exclude: IndexingExclude,
+}
+
+/// When the filesystem index is built and kept up to date.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum IndexingMode {
+    /// Index on demand and keep warm while the app is in use (the default).
+    #[default]
+    Auto,
+    /// Continuously index in the background, even while idle.
+    AlwaysOn,
+    /// Only index when explicitly requested.
+    Manual,
+}
+
+impl IndexingMode {
+    /// Parse the `config.toml` spelling (`auto`/`always-on`/`manual`).
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "auto" => Some(Self::Auto),
+            "always-on" => Some(Self::AlwaysOn),
+            "manual" => Some(Self::Manual),
+            _ => None,
+        }
+    }
+}
+
+/// Paths and globs excluded from indexing.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct IndexingExclude {
+    /// Literal paths (absolute or relative to the indexed root) to skip.
+    pub paths: Vec<String>,
+    /// Glob patterns (e.g. `**/target/**`) to skip.
+    pub globs: Vec<String>,
+}
+
+/// Search backend selection.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct Search {
+    /// Which engine answers content searches.
+    pub backend: SearchBackend,
+}
+
+/// The engine used to answer content searches.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum SearchBackend {
+    /// Pick the best available backend at runtime (the default).
+    #[default]
+    Auto,
+    /// SQLite full-text search (FTS5).
+    SqliteFts,
+    /// The Tantivy index.
+    Tantivy,
+    /// External `ripgrep`.
+    Ripgrep,
+}
+
+impl SearchBackend {
+    /// Parse the `config.toml` spelling
+    /// (`sqlite-fts`/`tantivy`/`ripgrep`/`auto`).
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "sqlite-fts" => Some(Self::SqliteFts),
+            "tantivy" => Some(Self::Tantivy),
+            "ripgrep" => Some(Self::Ripgrep),
+            "auto" => Some(Self::Auto),
+            _ => None,
+        }
+    }
+}
+
+/// Launcher window settings.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct Launcher {
+    /// Global hotkey that summons the launcher.
+    pub hotkey: String,
+    /// Whether the launcher reopens at its last on-screen position.
+    pub position_remember: bool,
+}
+
+impl Default for Launcher {
+    fn default() -> Self {
+        Self {
+            hotkey: "Cmd+Shift+Space".to_string(),
+            position_remember: true,
         }
     }
 }
@@ -333,6 +476,38 @@ impl Config {
                 None => diagnostics.push(Diagnostic::warn("[ui] is not a table; ignoring")),
             }
         }
+        if let Some(value) = table.get("keybindings") {
+            match value.as_table() {
+                Some(keys) => read_keybindings(keys, &mut config.keybindings, &mut diagnostics),
+                None => {
+                    diagnostics.push(Diagnostic::warn("[keybindings] is not a table; ignoring"))
+                }
+            }
+        }
+        if let Some(value) = table.get("plugins") {
+            match value.as_table() {
+                Some(plugins) => read_plugins(plugins, &mut config.plugins, &mut diagnostics),
+                None => diagnostics.push(Diagnostic::warn("[plugins] is not a table; ignoring")),
+            }
+        }
+        if let Some(value) = table.get("indexing") {
+            match value.as_table() {
+                Some(indexing) => read_indexing(indexing, &mut config.indexing, &mut diagnostics),
+                None => diagnostics.push(Diagnostic::warn("[indexing] is not a table; ignoring")),
+            }
+        }
+        if let Some(value) = table.get("search") {
+            match value.as_table() {
+                Some(search) => read_search(search, &mut config.search, &mut diagnostics),
+                None => diagnostics.push(Diagnostic::warn("[search] is not a table; ignoring")),
+            }
+        }
+        if let Some(value) = table.get("launcher") {
+            match value.as_table() {
+                Some(launcher) => read_launcher(launcher, &mut config.launcher, &mut diagnostics),
+                None => diagnostics.push(Diagnostic::warn("[launcher] is not a table; ignoring")),
+            }
+        }
         if let Some(value) = table.get("diagnostics") {
             match value.as_table() {
                 Some(diag) => read_diagnostics(diag, &mut config.diagnostics, &mut diagnostics),
@@ -348,9 +523,12 @@ impl Config {
                 "schema_version",
                 "theme",
                 "ui",
-                "diagnostics",
                 "keybindings",
                 "plugins",
+                "indexing",
+                "search",
+                "launcher",
+                "diagnostics",
             ],
             "",
             &mut diagnostics,
@@ -365,7 +543,8 @@ impl Config {
     }
 
     /// The default `config.toml` written on first run or `reset`, including the
-    /// `#:schema` header and empty reserved sections.
+    /// `#:schema` header. Every value matches [`Config::default`], so a freshly
+    /// written file round-trips to defaults with no diagnostics.
     pub fn default_toml_template() -> String {
         format!(
             "#:schema {SCHEMA_URL}\n\
@@ -380,6 +559,20 @@ impl Config {
              show_hidden = false\n\
              icon_pack = \"default\"\n\
              \n\
+             [indexing]\n\
+             mode = \"auto\"   # \"auto\" | \"always-on\" | \"manual\"\n\
+             \n\
+             [indexing.exclude]\n\
+             paths = []\n\
+             globs = []\n\
+             \n\
+             [search]\n\
+             backend = \"auto\"   # \"sqlite-fts\" | \"tantivy\" | \"ripgrep\" | \"auto\"\n\
+             \n\
+             [launcher]\n\
+             hotkey = \"Cmd+Shift+Space\"\n\
+             position_remember = true\n\
+             \n\
              # Store performance logging for analysis; all off by default.\n\
              # Output via tracing (RUST_LOG), see docs/persistence.md §5.\n\
              [diagnostics.store]\n\
@@ -387,18 +580,16 @@ impl Config {
              slow_query_ms = 0         # warn on SQL slower than this (0 = off)\n\
              log_redb_ops = false      # log redb get/put/delete/batch timings\n\
              \n\
-             # Reserved for future use; left empty in P1.\n\
+             # Draft sections; defaults are built-in, so these stay empty until\n\
+             # keybindings (P3) and plugins (P4) are wired up.\n\
              [keybindings]\n\
+             # quit = \"ctrl-q\"\n\
              \n\
-             [plugins]\n"
+             [plugins]\n\
+             # core = [\"git\"]\n\
+             # community = [\"user/repo\"]\n"
         )
     }
-}
-
-/// Whether `name` is a reserved top-level section that P1 recognises but does
-/// not yet read (so its presence is not flagged as an unknown key).
-pub fn is_reserved_section(name: &str) -> bool {
-    matches!(name, "keybindings" | "plugins")
 }
 
 fn read_theme(table: &toml::Table, theme: &mut Theme, diagnostics: &mut Vec<Diagnostic>) {
@@ -459,6 +650,148 @@ fn read_ui(table: &toml::Table, ui: &mut Ui, diagnostics: &mut Vec<Diagnostic>) 
     );
 }
 
+fn read_keybindings(
+    table: &toml::Table,
+    keybindings: &mut Keybindings,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    // Draft: accept any action name → chord. Unknown actions are not warned
+    // about (the action vocabulary is defined in P3); only non-string values are.
+    for (action, value) in table {
+        match value.as_str() {
+            Some(chord) => {
+                keybindings.bindings.insert(action.clone(), chord.to_string());
+            }
+            None => diagnostics.push(Diagnostic::warn(format!(
+                "invalid keybindings.{action} {value}; expected a string, ignoring"
+            ))),
+        }
+    }
+}
+
+fn read_plugins(table: &toml::Table, plugins: &mut Plugins, diagnostics: &mut Vec<Diagnostic>) {
+    if let Some(value) = table.get("core") {
+        if let Some(core) = read_string_array(value, "plugins.core", diagnostics) {
+            plugins.core = core;
+        }
+    }
+    if let Some(value) = table.get("community") {
+        if let Some(community) = read_string_array(value, "plugins.community", diagnostics) {
+            plugins.community = community;
+        }
+    }
+    warn_unknown_keys(table, &["core", "community"], "plugins.", diagnostics);
+}
+
+fn read_indexing(table: &toml::Table, indexing: &mut Indexing, diagnostics: &mut Vec<Diagnostic>) {
+    if let Some(value) = table.get("mode") {
+        match value.as_str().and_then(IndexingMode::parse) {
+            Some(mode) => indexing.mode = mode,
+            None => diagnostics.push(Diagnostic::warn(format!(
+                "invalid indexing.mode {value}; using {:?}",
+                indexing.mode
+            ))),
+        }
+    }
+    if let Some(value) = table.get("exclude") {
+        match value.as_table() {
+            Some(exclude) => read_indexing_exclude(exclude, &mut indexing.exclude, diagnostics),
+            None => diagnostics.push(Diagnostic::warn(
+                "[indexing.exclude] is not a table; ignoring",
+            )),
+        }
+    }
+    warn_unknown_keys(table, &["mode", "exclude"], "indexing.", diagnostics);
+}
+
+fn read_indexing_exclude(
+    table: &toml::Table,
+    exclude: &mut IndexingExclude,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    if let Some(value) = table.get("paths") {
+        if let Some(paths) = read_string_array(value, "indexing.exclude.paths", diagnostics) {
+            exclude.paths = paths;
+        }
+    }
+    if let Some(value) = table.get("globs") {
+        if let Some(globs) = read_string_array(value, "indexing.exclude.globs", diagnostics) {
+            exclude.globs = globs;
+        }
+    }
+    warn_unknown_keys(table, &["paths", "globs"], "indexing.exclude.", diagnostics);
+}
+
+fn read_search(table: &toml::Table, search: &mut Search, diagnostics: &mut Vec<Diagnostic>) {
+    if let Some(value) = table.get("backend") {
+        match value.as_str().and_then(SearchBackend::parse) {
+            Some(backend) => search.backend = backend,
+            None => diagnostics.push(Diagnostic::warn(format!(
+                "invalid search.backend {value}; using {:?}",
+                search.backend
+            ))),
+        }
+    }
+    warn_unknown_keys(table, &["backend"], "search.", diagnostics);
+}
+
+fn read_launcher(table: &toml::Table, launcher: &mut Launcher, diagnostics: &mut Vec<Diagnostic>) {
+    if let Some(value) = table.get("hotkey") {
+        match value.as_str() {
+            Some(hotkey) if !hotkey.trim().is_empty() => launcher.hotkey = hotkey.to_string(),
+            _ => diagnostics.push(Diagnostic::warn(format!(
+                "invalid launcher.hotkey {value}; using {:?}",
+                launcher.hotkey
+            ))),
+        }
+    }
+    if let Some(value) = table.get("position_remember") {
+        match value.as_bool() {
+            Some(flag) => launcher.position_remember = flag,
+            None => diagnostics.push(Diagnostic::warn(format!(
+                "invalid launcher.position_remember {value}; using {}",
+                launcher.position_remember
+            ))),
+        }
+    }
+    warn_unknown_keys(
+        table,
+        &["hotkey", "position_remember"],
+        "launcher.",
+        diagnostics,
+    );
+}
+
+/// Read a TOML array of strings, warning about (and skipping) any non-string
+/// element. Returns `None` — with a warning — when the value is not an array,
+/// so the caller keeps its current value.
+fn read_string_array(
+    value: &toml::Value,
+    field: &str,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> Option<Vec<String>> {
+    match value.as_array() {
+        Some(items) => {
+            let mut out = Vec::with_capacity(items.len());
+            for item in items {
+                match item.as_str() {
+                    Some(entry) => out.push(entry.to_string()),
+                    None => diagnostics.push(Diagnostic::warn(format!(
+                        "ignoring non-string entry {item} in {field}"
+                    ))),
+                }
+            }
+            Some(out)
+        }
+        None => {
+            diagnostics.push(Diagnostic::warn(format!(
+                "{field} is not an array; ignoring"
+            )));
+            None
+        }
+    }
+}
+
 fn read_diagnostics(
     table: &toml::Table,
     diag: &mut Diagnostics,
@@ -515,9 +848,9 @@ fn read_diagnostics_store(
     );
 }
 
-/// Emit a warning for every key in `table` that is neither a known key nor a
-/// reserved top-level section. `prefix` is prepended for nested tables (e.g.
-/// `"theme."`) so messages point at the offending path.
+/// Emit a warning for every key in `table` that is not a known key. `prefix` is
+/// prepended for nested tables (e.g. `"theme."`) so messages point at the
+/// offending path.
 fn warn_unknown_keys(
     table: &toml::Table,
     known: &[&str],
@@ -525,9 +858,7 @@ fn warn_unknown_keys(
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     for key in table.keys() {
-        let is_known = known.contains(&key.as_str());
-        let is_reserved = prefix.is_empty() && is_reserved_section(key);
-        if !is_known && !is_reserved {
+        if !known.contains(&key.as_str()) {
             diagnostics.push(Diagnostic::warn(format!(
                 "unknown config key {prefix}{key}; ignoring"
             )));
@@ -683,6 +1014,81 @@ mod tests {
         assert!(config.diagnostics.store.log_all_queries);
         assert_eq!(config.diagnostics.store.slow_query_ms, 50);
         assert!(config.diagnostics.store.log_redb_ops);
+    }
+
+    #[test]
+    fn parses_p2_sections() {
+        let toml = r#"
+            [indexing]
+            mode = "always-on"
+            [indexing.exclude]
+            paths = ["/tmp", "node_modules"]
+            globs = ["**/target/**"]
+            [search]
+            backend = "tantivy"
+            [launcher]
+            hotkey = "Ctrl+Space"
+            position_remember = false
+            [plugins]
+            core = ["git", "calculator"]
+            community = ["user/repo"]
+            [keybindings]
+            quit = "ctrl-q"
+            search = "ctrl-f"
+        "#;
+        let (config, diagnostics) = Config::from_toml_str(toml);
+        assert!(diagnostics.is_empty(), "{diagnostics:?}");
+        assert_eq!(config.indexing.mode, IndexingMode::AlwaysOn);
+        assert_eq!(config.indexing.exclude.paths, ["/tmp", "node_modules"]);
+        assert_eq!(config.indexing.exclude.globs, ["**/target/**"]);
+        assert_eq!(config.search.backend, SearchBackend::Tantivy);
+        assert_eq!(config.launcher.hotkey, "Ctrl+Space");
+        assert!(!config.launcher.position_remember);
+        assert_eq!(config.plugins.core, ["git", "calculator"]);
+        assert_eq!(config.plugins.community, ["user/repo"]);
+        assert_eq!(
+            config.keybindings.bindings.get("quit").map(String::as_str),
+            Some("ctrl-q")
+        );
+        assert_eq!(
+            config.keybindings.bindings.get("search").map(String::as_str),
+            Some("ctrl-f")
+        );
+    }
+
+    #[test]
+    fn p2_sections_reject_bad_values_leniently() {
+        let toml = r#"
+            [indexing]
+            mode = "turbo"
+            [indexing.exclude]
+            paths = "not-an-array"
+            globs = [1, "ok"]
+            [search]
+            backend = "grep"
+            [launcher]
+            hotkey = ""
+            position_remember = "yes"
+            [plugins]
+            core = "git"
+            [keybindings]
+            quit = 7
+        "#;
+        let (config, diagnostics) = Config::from_toml_str(toml);
+        // No fatal errors: bad fields fall back to defaults.
+        assert!(errors(&diagnostics).is_empty());
+        assert_eq!(config.indexing.mode, IndexingMode::Auto);
+        assert!(config.indexing.exclude.paths.is_empty());
+        // The non-string array entry is skipped; the valid one is kept.
+        assert_eq!(config.indexing.exclude.globs, ["ok"]);
+        assert_eq!(config.search.backend, SearchBackend::Auto);
+        assert_eq!(config.launcher.hotkey, Config::default().launcher.hotkey);
+        assert!(config.launcher.position_remember);
+        assert!(config.plugins.core.is_empty());
+        assert!(config.keybindings.bindings.is_empty());
+        // mode, paths(not array), globs(one bad entry), backend, hotkey,
+        // position_remember, plugins.core(not array), keybindings.quit.
+        assert_eq!(diagnostics.len(), 8);
     }
 
     #[test]

--- a/crates/nohrs-core/src/config/snapshots/nohrs_core__config__settings__tests__from_toml_str_output_snapshot.snap
+++ b/crates/nohrs-core/src/config/snapshots/nohrs_core__config__settings__tests__from_toml_str_output_snapshot.snap
@@ -14,6 +14,27 @@ expression: parsed
             show_hidden: true,
             icon_pack: "default",
         },
+        keybindings: Keybindings {
+            bindings: {},
+        },
+        plugins: Plugins {
+            core: [],
+            community: [],
+        },
+        indexing: Indexing {
+            mode: Auto,
+            exclude: IndexingExclude {
+                paths: [],
+                globs: [],
+            },
+        },
+        search: Search {
+            backend: Auto,
+        },
+        launcher: Launcher {
+            hotkey: "Cmd+Shift+Space",
+            position_remember: true,
+        },
         diagnostics: Diagnostics {
             store: DiagnosticsStore {
                 log_all_queries: false,

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,6 +1,6 @@
 # Configuration
 
-> Status: Draft (P1 で最小実装、P2 で拡張)
+> Status: P1 最小実装 + P2 拡張 (indexing / search / launcher 実装、keybindings / plugins 予約)
 > Related: [`ROADMAP.md`](./ROADMAP.md), [`docs/persistence.md`](./persistence.md)
 
 本書はユーザー設定ファイル `config.toml` の配置・スキーマ・ロード戦略・hot reload を定めます。
@@ -39,15 +39,19 @@ show_hidden = false
 icon_pack = "default"
 
 [keybindings]
-# P3 で本格化。P1 では空、デフォルトは built-in。
+# 草案 (P3 で本格化)。`action = "chord"` の自由マップ。空ならデフォルトは built-in。
+# 任意のアクション名を forward-compat のため warn なしで受理 (値は string のみ)。
+# quit = "ctrl-q"
 
 [plugins]
-# P4 で本格運用。P1 では空。
+# 型予約のみ (P4 で本格運用)。リストは parse/格納されるが host はまだロードしない。
 # core = ["git", "calculator"]
 # community = ["user/repo", "https://..."]
 ```
 
-### P2 以降の拡張
+`[keybindings]` と `[plugins]` は型として定義済みだが、値はまだ挙動に反映されない (hot reload は再起動扱い、§5)。スキーマには予約済みで、P3/P4 で形を拡張しても古いファイルは壊れない。
+
+### P2 拡張 (実装済み)
 
 ```toml
 [indexing]
@@ -103,11 +107,17 @@ let merged = defaults
 
 ## 4. JSON Schema 生成
 
-`schemars` crate で Rust 構造体から JSON Schema を自動生成し、`docs/config.schema.json` を生成。
+`schemars` crate で Rust 構造体 (`Config` 以下) から JSON Schema を自動生成し、`docs/config.schema.json` にコミットする。出力は安定化済み (キーソート + Rust 固有の integer `format` を除去) なので byte-for-byte で再現できる。
 
 ```bash
+# GUI バイナリ経由 (macOS):
 cargo run --bin nohrs -- config schema > docs/config.schema.json
+
+# GUI 非依存 (Linux/CI、上と同一バイト列を出力):
+cargo run -p nohrs-core --example schema > docs/config.schema.json
 ```
+
+**CI で常に最新を保証**: `config schema` ジョブが上記 example でスキーマを再生成し、コミット済みファイルと `git diff --exit-code` する。構造体を変更してスキーマ再生成を忘れると、diff 付きで CI が落ちる。加えて `nohrs-core` のユニットテスト (`committed_schema_is_up_to_date`) が同じ検証をローカル/`cargo test` でも行う。
 
 config.toml の冒頭に:
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -52,7 +52,7 @@ icon_pack = "default"
 `[keybindings]` と `[plugins]` は型として定義済みだが、値はまだ挙動に反映されない (hot reload は再起動扱い、§5)。スキーマには予約済みで、P3/P4 で形を拡張しても古いファイルは壊れない。
 
 > **ランタイム反映状況**: 現状でランタイムに反映されるのは `theme` / `ui` / `diagnostics` のみ。`indexing` / `search` / `launcher` / `keybindings` / `plugins` は **parse + validate されるが、まだ挙動には反映されない** (各サブシステムが配線される後続フェーズで有効化)。schema / template に先行して載せているのは、ファイルとエディタ補完が形を先取りできるようにするため。編集しても今は効果がない点に注意。
-
+>
 > **`required` なし**: 全フィールドが `#[serde(default)]`。ローダは `Config::default()` から開始して存在するキーだけ上書きするため、どのセクションを省略しても (空の `config.toml` でも) 受理される。生成スキーマも `required` を持たず、エディタ検証とローダ挙動が一致する。
 
 ### P2 拡張 (schema 定義済み / ランタイムは後続フェーズ)

--- a/docs/config.md
+++ b/docs/config.md
@@ -51,7 +51,11 @@ icon_pack = "default"
 
 `[keybindings]` と `[plugins]` は型として定義済みだが、値はまだ挙動に反映されない (hot reload は再起動扱い、§5)。スキーマには予約済みで、P3/P4 で形を拡張しても古いファイルは壊れない。
 
-### P2 拡張 (実装済み)
+> **ランタイム反映状況**: 現状でランタイムに反映されるのは `theme` / `ui` / `diagnostics` のみ。`indexing` / `search` / `launcher` / `keybindings` / `plugins` は **parse + validate されるが、まだ挙動には反映されない** (各サブシステムが配線される後続フェーズで有効化)。schema / template に先行して載せているのは、ファイルとエディタ補完が形を先取りできるようにするため。編集しても今は効果がない点に注意。
+
+> **`required` なし**: 全フィールドが `#[serde(default)]`。ローダは `Config::default()` から開始して存在するキーだけ上書きするため、どのセクションを省略しても (空の `config.toml` でも) 受理される。生成スキーマも `required` を持たず、エディタ検証とローダ挙動が一致する。
+
+### P2 拡張 (schema 定義済み / ランタイムは後続フェーズ)
 
 ```toml
 [indexing]

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -5,36 +5,36 @@
       "properties": {
         "store": {
           "$ref": "#/$defs/DiagnosticsStore",
+          "default": {
+            "log_all_queries": false,
+            "log_redb_ops": false,
+            "slow_query_ms": 0
+          },
           "description": "Performance logging for the persistence layer (`nohrs-store`)."
         }
       },
-      "required": [
-        "store"
-      ],
       "type": "object"
     },
     "DiagnosticsStore": {
       "description": "Performance logging for the SQLite / redb store. All off by default, so a\ndefault config adds no overhead. Output goes through `tracing` (targets\n`nohrs_store::sql` / `nohrs_store::redb`) and is filterable with `RUST_LOG`.",
       "properties": {
         "log_all_queries": {
+          "default": false,
           "description": "Log every SQL query at `debug` (verbose).",
           "type": "boolean"
         },
         "log_redb_ops": {
+          "default": false,
           "description": "Log redb `get`/`put`/`delete`/`batch` operations and their durations.",
           "type": "boolean"
         },
         "slow_query_ms": {
+          "default": 0,
           "description": "Log SQL queries slower than this many milliseconds at `warn`. Zero (the\ndefault) disables slow-query logging.",
           "minimum": 0,
           "type": "integer"
         }
       },
-      "required": [
-        "log_all_queries",
-        "slow_query_ms",
-        "log_redb_ops"
-      ],
       "type": "object"
     },
     "Indexing": {
@@ -42,23 +42,25 @@
       "properties": {
         "exclude": {
           "$ref": "#/$defs/IndexingExclude",
+          "default": {
+            "globs": [],
+            "paths": []
+          },
           "description": "Paths and globs excluded from indexing."
         },
         "mode": {
           "$ref": "#/$defs/IndexingMode",
+          "default": "auto",
           "description": "When the background index is built and maintained."
         }
       },
-      "required": [
-        "mode",
-        "exclude"
-      ],
       "type": "object"
     },
     "IndexingExclude": {
       "description": "Paths and globs excluded from indexing.",
       "properties": {
         "globs": {
+          "default": [],
           "description": "Glob patterns (e.g. `**/target/**`) to skip.",
           "items": {
             "type": "string"
@@ -66,6 +68,7 @@
           "type": "array"
         },
         "paths": {
+          "default": [],
           "description": "Literal paths (absolute or relative to the indexed root) to skip.",
           "items": {
             "type": "string"
@@ -73,10 +76,6 @@
           "type": "array"
         }
       },
-      "required": [
-        "paths",
-        "globs"
-      ],
       "type": "object"
     },
     "IndexingMode": {
@@ -110,24 +109,23 @@
       "description": "Launcher window settings.",
       "properties": {
         "hotkey": {
+          "default": "Cmd+Shift+Space",
           "description": "Global hotkey that summons the launcher.",
           "type": "string"
         },
         "position_remember": {
+          "default": true,
           "description": "Whether the launcher reopens at its last on-screen position.",
           "type": "boolean"
         }
       },
-      "required": [
-        "hotkey",
-        "position_remember"
-      ],
       "type": "object"
     },
     "Plugins": {
       "description": "Plugin selection (config.md §2, reserved for P4).\n\nType definition / reservation only: the lists are parsed and stored, but no\nplugin host loads them yet (that lands in P4).",
       "properties": {
         "community": {
+          "default": [],
           "description": "Community plugins to enable, as `user/repo` or a URL.",
           "items": {
             "type": "string"
@@ -135,6 +133,7 @@
           "type": "array"
         },
         "core": {
+          "default": [],
           "description": "Built-in (first-party) plugins to enable, by id (e.g. `\"git\"`).",
           "items": {
             "type": "string"
@@ -142,10 +141,6 @@
           "type": "array"
         }
       },
-      "required": [
-        "core",
-        "community"
-      ],
       "type": "object"
     },
     "Search": {
@@ -153,12 +148,10 @@
       "properties": {
         "backend": {
           "$ref": "#/$defs/SearchBackend",
+          "default": "auto",
           "description": "Which engine answers content searches."
         }
       },
-      "required": [
-        "backend"
-      ],
       "type": "object"
     },
     "SearchBackend": {
@@ -215,18 +208,16 @@
       "description": "Appearance settings.",
       "properties": {
         "accent": {
+          "default": "blue",
           "description": "Accent colour, given as a named colour or a hex string. Full\ncustomization lands in P5; P1 stores the value and applies the mode.",
           "type": "string"
         },
         "mode": {
           "$ref": "#/$defs/ThemeMode",
+          "default": "system",
           "description": "Light/dark selection, or following the OS."
         }
       },
-      "required": [
-        "mode",
-        "accent"
-      ],
       "type": "object"
     },
     "ThemeMode": {
@@ -254,77 +245,100 @@
       "properties": {
         "default_sort": {
           "$ref": "#/$defs/SortOrder",
+          "default": "name",
           "description": "Column the listing is sorted by on load."
         },
         "icon_pack": {
+          "default": "default",
           "description": "Identifier of the icon pack used to render entries.",
           "type": "string"
         },
         "show_hidden": {
+          "default": false,
           "description": "Whether dotfiles are shown in listings.",
           "type": "boolean"
         }
       },
-      "required": [
-        "default_sort",
-        "show_hidden",
-        "icon_pack"
-      ],
       "type": "object"
     }
   },
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "description": "The fully merged, validated configuration.\n\nModels the P1 surface (`theme` / `ui`) plus the P2 sections: `[indexing]`,\n`[search]`, `[launcher]`, and `[diagnostics]`. `[keybindings]` and\n`[plugins]` are reserved here as forward-compatible drafts — their types are\ndefined and parsed leniently so files can adopt them now, but the values do\nnot drive behaviour yet (keybindings land in P3, plugins in P4; see\n`docs/config.md` §2/§5).",
+  "description": "The fully merged, validated configuration.\n\nModels the P1 surface (`theme` / `ui`) plus the P2 sections: `[indexing]`,\n`[search]`, `[launcher]`, and `[diagnostics]`. `[keybindings]` and\n`[plugins]` are reserved here as forward-compatible drafts — their types are\ndefined and parsed leniently so files can adopt them now, but the values do\nnot drive behaviour yet (keybindings land in P3, plugins in P4; see\n`docs/config.md` §2/§5).\n\nOnly `theme`, `ui`, and `diagnostics` are consumed at runtime today. The\nremaining sections (`keybindings`, `plugins`, `indexing`, `search`,\n`launcher`) are accepted and validated now so files and editor completion can\nadopt them, but editing them has no effect until the matching subsystem is\nwired in a later phase — see the per-section notes and `docs/config.md` §5.\n\nEvery field is `#[serde(default)]`: the loader starts from\n[`Config::default`] and overlays only the keys present in the file, so a\nmissing section is filled with its default rather than rejected. The\ngenerated schema therefore has no `required` properties, matching the\nloader (an empty `config.toml` is valid).",
   "properties": {
     "diagnostics": {
       "$ref": "#/$defs/Diagnostics",
+      "default": {
+        "store": {
+          "log_all_queries": false,
+          "log_redb_ops": false,
+          "slow_query_ms": 0
+        }
+      },
       "description": "Diagnostics / performance-logging settings."
     },
     "indexing": {
       "$ref": "#/$defs/Indexing",
+      "default": {
+        "exclude": {
+          "globs": [],
+          "paths": []
+        },
+        "mode": "auto"
+      },
       "description": "Filesystem indexing strategy and exclusions."
     },
     "keybindings": {
       "$ref": "#/$defs/Keybindings",
+      "default": {},
       "description": "Keybinding overrides (draft; full support in P3). Empty means the\nbuilt-in keymap is used."
     },
     "launcher": {
       "$ref": "#/$defs/Launcher",
+      "default": {
+        "hotkey": "Cmd+Shift+Space",
+        "position_remember": true
+      },
       "description": "Launcher window settings."
     },
     "plugins": {
       "$ref": "#/$defs/Plugins",
+      "default": {
+        "community": [],
+        "core": []
+      },
       "description": "Plugin selection (reserved; full support in P4)."
     },
     "schema_version": {
+      "default": 1,
       "description": "On-disk schema version. Must be [`CURRENT_SCHEMA_VERSION`] for this build.",
       "minimum": 0,
       "type": "integer"
     },
     "search": {
       "$ref": "#/$defs/Search",
+      "default": {
+        "backend": "auto"
+      },
       "description": "Search backend selection."
     },
     "theme": {
       "$ref": "#/$defs/Theme",
+      "default": {
+        "accent": "blue",
+        "mode": "system"
+      },
       "description": "Appearance settings."
     },
     "ui": {
       "$ref": "#/$defs/Ui",
+      "default": {
+        "default_sort": "name",
+        "icon_pack": "default",
+        "show_hidden": false
+      },
       "description": "Explorer / view settings."
     }
   },
-  "required": [
-    "schema_version",
-    "theme",
-    "ui",
-    "keybindings",
-    "plugins",
-    "indexing",
-    "search",
-    "launcher",
-    "diagnostics"
-  ],
   "title": "Config",
   "type": "object"
 }

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -37,6 +37,155 @@
       ],
       "type": "object"
     },
+    "Indexing": {
+      "description": "Filesystem indexing settings.",
+      "properties": {
+        "exclude": {
+          "$ref": "#/$defs/IndexingExclude",
+          "description": "Paths and globs excluded from indexing."
+        },
+        "mode": {
+          "$ref": "#/$defs/IndexingMode",
+          "description": "When the background index is built and maintained."
+        }
+      },
+      "required": [
+        "mode",
+        "exclude"
+      ],
+      "type": "object"
+    },
+    "IndexingExclude": {
+      "description": "Paths and globs excluded from indexing.",
+      "properties": {
+        "globs": {
+          "description": "Glob patterns (e.g. `**/target/**`) to skip.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "paths": {
+          "description": "Literal paths (absolute or relative to the indexed root) to skip.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "paths",
+        "globs"
+      ],
+      "type": "object"
+    },
+    "IndexingMode": {
+      "description": "When the filesystem index is built and kept up to date.",
+      "oneOf": [
+        {
+          "const": "auto",
+          "description": "Index on demand and keep warm while the app is in use (the default).",
+          "type": "string"
+        },
+        {
+          "const": "always-on",
+          "description": "Continuously index in the background, even while idle.",
+          "type": "string"
+        },
+        {
+          "const": "manual",
+          "description": "Only index when explicitly requested.",
+          "type": "string"
+        }
+      ]
+    },
+    "Keybindings": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Keybinding overrides (config.md §2, draft for P3).\n\nA draft surface: a map of action identifier to key chord (e.g.\n`\"quit\" = \"ctrl-q\"`). An empty map — the default — means the built-in keymap\nis used. The action vocabulary and live re-binding are defined in P3; until\nthen values are stored and validated but not applied (hot reload is a\nrestart, config.md §5), so arbitrary action names are accepted without\nwarning to keep forward compatibility.",
+      "type": "object"
+    },
+    "Launcher": {
+      "description": "Launcher window settings.",
+      "properties": {
+        "hotkey": {
+          "description": "Global hotkey that summons the launcher.",
+          "type": "string"
+        },
+        "position_remember": {
+          "description": "Whether the launcher reopens at its last on-screen position.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "hotkey",
+        "position_remember"
+      ],
+      "type": "object"
+    },
+    "Plugins": {
+      "description": "Plugin selection (config.md §2, reserved for P4).\n\nType definition / reservation only: the lists are parsed and stored, but no\nplugin host loads them yet (that lands in P4).",
+      "properties": {
+        "community": {
+          "description": "Community plugins to enable, as `user/repo` or a URL.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "core": {
+          "description": "Built-in (first-party) plugins to enable, by id (e.g. `\"git\"`).",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "core",
+        "community"
+      ],
+      "type": "object"
+    },
+    "Search": {
+      "description": "Search backend selection.",
+      "properties": {
+        "backend": {
+          "$ref": "#/$defs/SearchBackend",
+          "description": "Which engine answers content searches."
+        }
+      },
+      "required": [
+        "backend"
+      ],
+      "type": "object"
+    },
+    "SearchBackend": {
+      "description": "The engine used to answer content searches.",
+      "oneOf": [
+        {
+          "const": "auto",
+          "description": "Pick the best available backend at runtime (the default).",
+          "type": "string"
+        },
+        {
+          "const": "sqlite-fts",
+          "description": "SQLite full-text search (FTS5).",
+          "type": "string"
+        },
+        {
+          "const": "tantivy",
+          "description": "The Tantivy index.",
+          "type": "string"
+        },
+        {
+          "const": "ripgrep",
+          "description": "External `ripgrep`.",
+          "type": "string"
+        }
+      ]
+    },
     "SortOrder": {
       "description": "The column a directory listing is ordered by.",
       "oneOf": [
@@ -125,16 +274,36 @@
     }
   },
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "description": "The fully merged, validated configuration.\n\nModels the P1 surface (`theme` / `ui`) plus the P2 `[diagnostics]` section.\n`[keybindings]` and `[plugins]` are recognised as reserved sections (see\n[`is_reserved_section`]) but intentionally not deserialized yet, so their\nfuture shapes can be added without breaking older files.",
+  "description": "The fully merged, validated configuration.\n\nModels the P1 surface (`theme` / `ui`) plus the P2 sections: `[indexing]`,\n`[search]`, `[launcher]`, and `[diagnostics]`. `[keybindings]` and\n`[plugins]` are reserved here as forward-compatible drafts — their types are\ndefined and parsed leniently so files can adopt them now, but the values do\nnot drive behaviour yet (keybindings land in P3, plugins in P4; see\n`docs/config.md` §2/§5).",
   "properties": {
     "diagnostics": {
       "$ref": "#/$defs/Diagnostics",
       "description": "Diagnostics / performance-logging settings."
     },
+    "indexing": {
+      "$ref": "#/$defs/Indexing",
+      "description": "Filesystem indexing strategy and exclusions."
+    },
+    "keybindings": {
+      "$ref": "#/$defs/Keybindings",
+      "description": "Keybinding overrides (draft; full support in P3). Empty means the\nbuilt-in keymap is used."
+    },
+    "launcher": {
+      "$ref": "#/$defs/Launcher",
+      "description": "Launcher window settings."
+    },
+    "plugins": {
+      "$ref": "#/$defs/Plugins",
+      "description": "Plugin selection (reserved; full support in P4)."
+    },
     "schema_version": {
       "description": "On-disk schema version. Must be [`CURRENT_SCHEMA_VERSION`] for this build.",
       "minimum": 0,
       "type": "integer"
+    },
+    "search": {
+      "$ref": "#/$defs/Search",
+      "description": "Search backend selection."
     },
     "theme": {
       "$ref": "#/$defs/Theme",
@@ -149,6 +318,11 @@
     "schema_version",
     "theme",
     "ui",
+    "keybindings",
+    "plugins",
+    "indexing",
+    "search",
+    "launcher",
     "diagnostics"
   ],
   "title": "Config",


### PR DESCRIPTION
Closes #65 (P2 config expansion).

## What changed

Extends the `config.toml` schema in `nohrs-core` and wires CI to keep the committed JSON Schema in lock-step with the Rust types.

**Schema (`config.md` §2)**
- `[indexing]` — `mode = "auto" | "always-on" | "manual"`, plus `[indexing.exclude]` with `paths` / `globs`.
- `[search]` — `backend = "sqlite-fts" | "tantivy" | "ripgrep" | "auto"`.
- `[launcher]` — `hotkey` / `position_remember`.
- `[keybindings]` (draft, P3) — free `action = "chord"` map; empty means the built-in keymap. Arbitrary action names are accepted without warning for forward-compat.
- `[plugins]` (reserved, P4) — `core` / `community` string lists, parsed and stored but not yet loaded by a host.

`[keybindings]` and `[plugins]` are defined as types and parsed leniently but do **not** drive behaviour yet — consistent with the hot-reload-is-restart rule (§5).

**Validation (§6)** — new sections follow the existing field-by-field lenient parser: unknown keys → warn + ignore, out-of-range / wrong-type values → warn + default, non-string array entries skipped. A single bad value never aborts startup.

**JSON Schema auto-sync (§4)**
- New `crates/nohrs-core/examples/schema.rs` prints the schema building only `nohrs-core` (no gpui), so it regenerates on Linux/CI and emits the same bytes as `nohrs config schema`.
- New `config schema` CI job regenerates `docs/config.schema.json` and `git diff --exit-code`s it — a stale schema fails with a visible diff. The existing `committed_schema_is_up_to_date` unit test keeps the same guarantee locally.
- `docs/config.schema.json` regenerated; `docs/config.md` §2/§4 updated.

**4-layer override (§3)** — the `defaults < file < env < CLI` mechanism (serde + sparse `apply_override`) was already in place and is unchanged; the new reservation-stage sections take `default < file` values.

## Verification

Not a user-visible/UI change (config parsing, docs, CI), so no screenshots.

- `cargo fmt --all --check` — clean
- `cargo clippy --all-targets --locked -- -D warnings` — clean
- `cargo test --locked` (default-members) — green; added `parses_p2_sections` and `p2_sections_reject_bad_values_leniently`, updated the insta snapshot
- Schema generator confirmed idempotent (committed file == generator output)

Release Notes:

- N/A

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands the `nohrs-core` config with P2 sections (`[indexing]`, `[search]`, `[launcher]`) and adds CI to auto-sync `docs/config.schema.json`. The schema has no required fields, and new sections are parsed/validated but not wired yet.

- **New Features**
  - `[indexing]` — `mode: auto | always-on | manual`; `[indexing.exclude]` with `paths` and `globs`.
  - `[search]` — `backend: sqlite-fts | tantivy | ripgrep | auto`.
  - `[launcher]` — `hotkey`, `position_remember`.
  - Draft `[keybindings]` and `[plugins]`: parsed and stored, not applied yet (P3/P4).

- **Refactors**
  - All config sections use defaults; JSON Schema has no `required` fields. Added a regression test.
  - Example schema generator in `nohrs-core`; CI job regenerates `docs/config.schema.json` and diffs it to prevent drift.
  - Docs/template clarify runtime scope; merged adjacent blockquotes to satisfy MD028.

<sup>Written for commit 7a2cea1738f84eb6ec7b051740866ecada1ffa7b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/noh-rs/nohrs/pull/162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added draft P2 config sections: keybindings, plugins, indexing, search, and launcher with defaults and lenient parsing/fallbacks.

* **Documentation**
  * Updated config guide and on-disk template to document expanded sections, defaults, draft/reserved behaviors, and schema generation workflow.

* **Chores**
  * CI now enforces the committed config schema is kept up-to-date.

* **Tests**
  * Added tests covering P2 parsing, lenient fallback behavior, and committed-schema validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->