### PR TITLE
Add 2-way split view to the explorer

### DIFF
--- a/crates/nohrs-core/src/config.rs
+++ b/crates/nohrs-core/src/config.rs
@@ -19,8 +19,8 @@ pub mod watcher;
 pub use loader::{backup, ensure_exists, needs_migration, reset, write_default};
 pub use settings::{
     json_schema_string, load_from_path, report_diagnostics, Config, ConfigOverride, Diagnostic,
-    DiagnosticLevel, Diagnostics, DiagnosticsStore, SortOrder, Theme, ThemeMode, Ui,
-    CURRENT_SCHEMA_VERSION, SCHEMA_URL,
+    DiagnosticLevel, Diagnostics, DiagnosticsStore, Explorer, SortOrder, SplitDirection, Theme,
+    ThemeMode, Ui, CURRENT_SCHEMA_VERSION, SCHEMA_URL,
 };
 pub use watcher::ConfigWatcher;
 

--- a/crates/nohrs-core/src/config/settings.rs
+++ b/crates/nohrs-core/src/config/settings.rs
@@ -34,6 +34,8 @@ pub struct Config {
     pub theme: Theme,
     /// Explorer / view settings.
     pub ui: Ui,
+    /// Split-view and pane settings.
+    pub explorer: Explorer,
     /// Diagnostics / performance-logging settings.
     pub diagnostics: Diagnostics,
 }
@@ -44,6 +46,7 @@ impl Default for Config {
             schema_version: CURRENT_SCHEMA_VERSION,
             theme: Theme::default(),
             ui: Ui::default(),
+            explorer: Explorer::default(),
             diagnostics: Diagnostics::default(),
         }
     }
@@ -85,6 +88,46 @@ impl Default for Ui {
             default_sort: SortOrder::Name,
             show_hidden: false,
             icon_pack: "default".to_string(),
+        }
+    }
+}
+
+/// Split-view and pane settings (see `docs/explorer-essentials.md` §3).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct Explorer {
+    /// Orientation a fresh split uses unless overridden by the split shortcut.
+    pub split_direction: SplitDirection,
+    /// When enabled, navigating in one pane mirrors the path into the others.
+    pub synced_panes: bool,
+}
+
+impl Default for Explorer {
+    fn default() -> Self {
+        Self {
+            split_direction: SplitDirection::Vertical,
+            synced_panes: false,
+        }
+    }
+}
+
+/// How a 2-way split arranges its panes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum SplitDirection {
+    /// Panes side by side, separated by a vertical divider (`Cmd+\`).
+    #[default]
+    Vertical,
+    /// Panes stacked, separated by a horizontal divider (`Cmd+Shift+\`).
+    Horizontal,
+}
+
+impl SplitDirection {
+    /// Parse the `config.toml` spelling (`vertical`/`horizontal`).
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "vertical" => Some(Self::Vertical),
+            "horizontal" => Some(Self::Horizontal),
+            _ => None,
         }
     }
 }
@@ -333,6 +376,12 @@ impl Config {
                 None => diagnostics.push(Diagnostic::warn("[ui] is not a table; ignoring")),
             }
         }
+        if let Some(value) = table.get("explorer") {
+            match value.as_table() {
+                Some(explorer) => read_explorer(explorer, &mut config.explorer, &mut diagnostics),
+                None => diagnostics.push(Diagnostic::warn("[explorer] is not a table; ignoring")),
+            }
+        }
         if let Some(value) = table.get("diagnostics") {
             match value.as_table() {
                 Some(diag) => read_diagnostics(diag, &mut config.diagnostics, &mut diagnostics),
@@ -348,6 +397,7 @@ impl Config {
                 "schema_version",
                 "theme",
                 "ui",
+                "explorer",
                 "diagnostics",
                 "keybindings",
                 "plugins",
@@ -379,6 +429,10 @@ impl Config {
              default_sort = \"name\"   # \"name\" | \"modified\" | \"size\" | \"kind\"\n\
              show_hidden = false\n\
              icon_pack = \"default\"\n\
+             \n\
+             [explorer]\n\
+             split_direction = \"vertical\"   # \"vertical\" (left/right) | \"horizontal\" (top/bottom)\n\
+             synced_panes = false            # when true, panes mirror the same path\n\
              \n\
              # Store performance logging for analysis; all off by default.\n\
              # Output via tracing (RUST_LOG), see docs/persistence.md §5.\n\
@@ -455,6 +509,33 @@ fn read_ui(table: &toml::Table, ui: &mut Ui, diagnostics: &mut Vec<Diagnostic>) 
         table,
         &["default_sort", "show_hidden", "icon_pack"],
         "ui.",
+        diagnostics,
+    );
+}
+
+fn read_explorer(table: &toml::Table, explorer: &mut Explorer, diagnostics: &mut Vec<Diagnostic>) {
+    if let Some(value) = table.get("split_direction") {
+        match value.as_str().and_then(SplitDirection::parse) {
+            Some(direction) => explorer.split_direction = direction,
+            None => diagnostics.push(Diagnostic::warn(format!(
+                "invalid explorer.split_direction {value}; using {:?}",
+                explorer.split_direction
+            ))),
+        }
+    }
+    if let Some(value) = table.get("synced_panes") {
+        match value.as_bool() {
+            Some(flag) => explorer.synced_panes = flag,
+            None => diagnostics.push(Diagnostic::warn(format!(
+                "invalid explorer.synced_panes {value}; using {}",
+                explorer.synced_panes
+            ))),
+        }
+    }
+    warn_unknown_keys(
+        table,
+        &["split_direction", "synced_panes"],
+        "explorer.",
         diagnostics,
     );
 }
@@ -697,6 +778,34 @@ mod tests {
         // Bad values fall back to defaults.
         assert_eq!(config.diagnostics.store.slow_query_ms, 0);
         assert!(!config.diagnostics.store.log_all_queries);
+        assert_eq!(diagnostics.len(), 2);
+    }
+
+    #[test]
+    fn explorer_section_parses_direction_and_sync() {
+        let toml = r#"
+            [explorer]
+            split_direction = "horizontal"
+            synced_panes = true
+        "#;
+        let (config, diagnostics) = Config::from_toml_str(toml);
+        assert!(diagnostics.is_empty(), "{diagnostics:?}");
+        assert_eq!(config.explorer.split_direction, SplitDirection::Horizontal);
+        assert!(config.explorer.synced_panes);
+    }
+
+    #[test]
+    fn explorer_section_rejects_bad_values_leniently() {
+        let toml = r#"
+            [explorer]
+            split_direction = "diagonal"
+            synced_panes = "maybe"
+        "#;
+        let (config, diagnostics) = Config::from_toml_str(toml);
+        assert!(errors(&diagnostics).is_empty());
+        // Bad values fall back to defaults.
+        assert_eq!(config.explorer.split_direction, SplitDirection::Vertical);
+        assert!(!config.explorer.synced_panes);
         assert_eq!(diagnostics.len(), 2);
     }
 

--- a/crates/nohrs-core/src/config/snapshots/nohrs_core__config__settings__tests__from_toml_str_output_snapshot.snap
+++ b/crates/nohrs-core/src/config/snapshots/nohrs_core__config__settings__tests__from_toml_str_output_snapshot.snap
@@ -14,6 +14,10 @@ expression: parsed
             show_hidden: true,
             icon_pack: "default",
         },
+        explorer: Explorer {
+            split_direction: Vertical,
+            synced_panes: false,
+        },
         diagnostics: Diagnostics {
             store: DiagnosticsStore {
                 log_all_queries: false,

--- a/crates/nohrs-pages/src/explorer.rs
+++ b/crates/nohrs-pages/src/explorer.rs
@@ -1,28 +1,25 @@
 mod entries;
 mod list_setup;
 mod navigation;
+/// The split-view container that owns one or more panes (`docs/explorer-essentials.md` §3).
+mod page;
 mod preview;
 mod search;
 mod state;
 mod types;
-/// Rendering of the explorer page: header, sidebar, listing, and preview.
+/// Rendering of a single explorer pane: header, sidebar, listing, and preview.
 pub mod view;
 
 #[cfg(test)]
 mod tests;
 
-pub use state::ExplorerPage;
+pub use page::ExplorerPage;
+pub use state::ExplorerPane;
 
-use gpui::{AnyElement, Context, IntoElement, Render, Window};
+use gpui::{Context, IntoElement, Render, Window};
 
-impl Render for ExplorerPage {
+impl Render for ExplorerPane {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         view::render(self, window, cx)
-    }
-}
-
-impl crate::Page for ExplorerPage {
-    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> AnyElement {
-        <Self as Render>::render(self, window, cx).into_any_element()
     }
 }

--- a/crates/nohrs-pages/src/explorer/list_setup.rs
+++ b/crates/nohrs-pages/src/explorer/list_setup.rs
@@ -5,9 +5,9 @@ use gpui::{AppContext, Context, Window};
 use gpui_component::list::{List, ListEvent};
 
 use super::types::ResizingColumn;
-use super::ExplorerPage;
+use super::ExplorerPane;
 
-impl ExplorerPage {
+impl ExplorerPane {
     pub(crate) fn ensure_list_initialized(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         if self.list.is_none() {
             let mut delegate = FileListDelegate::new();

--- a/crates/nohrs-pages/src/explorer/navigation.rs
+++ b/crates/nohrs-pages/src/explorer/navigation.rs
@@ -83,6 +83,13 @@ impl ExplorerPane {
         if path == self.cwd {
             return;
         }
+        // Clear search state so mirrored navigation doesn't leave a stale filter
+        // or full-text results from the previous directory visible. This mirrors
+        // the `close_search` reset on `change_dir`, minus the window-bound editor
+        // sync (the subscription that drives sync has no `Window`).
+        self.search_visible = false;
+        self.search_results = None;
+        self.search_query.clear();
         self.push_history(path.clone());
         self.cwd = path;
         self.entries.clear();

--- a/crates/nohrs-pages/src/explorer/navigation.rs
+++ b/crates/nohrs-pages/src/explorer/navigation.rs
@@ -4,10 +4,10 @@ use nohrs_services::fs::listing::{list_dir_sync, FileEntryDto, ListParams};
 use gpui::{Context, Window};
 
 use super::entries;
-use super::types::StatusLevel;
-use super::ExplorerPage;
+use super::types::{PaneEvent, StatusLevel};
+use super::ExplorerPane;
 
-impl ExplorerPage {
+impl ExplorerPane {
     pub(crate) fn ensure_loaded(&mut self) {
         if !self.loaded {
             self.reload();
@@ -54,6 +54,17 @@ impl ExplorerPage {
             return;
         }
         self.close_search(window, cx);
+        self.push_history(path.clone());
+        self.cwd = path;
+        self.entries.clear();
+        self.reload();
+        cx.emit(PaneEvent::Navigated(self.cwd.clone()));
+        cx.notify();
+    }
+
+    // Records a forward navigation in the back/forward history, seeding the
+    // starting directory on first use and dropping any forward entries.
+    fn push_history(&mut self, path: String) {
         if self.history.is_empty() {
             self.history.push(self.cwd.clone());
             self.history_index = 0;
@@ -61,8 +72,18 @@ impl ExplorerPage {
         if self.history_index + 1 < self.history.len() {
             self.history.truncate(self.history_index + 1);
         }
-        self.history.push(path.clone());
+        self.history.push(path);
         self.history_index += 1;
+    }
+
+    /// Mirrors a path requested by a sibling pane while `synced_panes` is on
+    /// (§3.2). Unlike [`change_dir`], it does not re-emit a navigation event, so
+    /// the originating pane is not driven back into an update loop.
+    pub(crate) fn navigate_to_synced(&mut self, path: String, cx: &mut Context<Self>) {
+        if path == self.cwd {
+            return;
+        }
+        self.push_history(path.clone());
         self.cwd = path;
         self.entries.clear();
         self.reload();
@@ -77,6 +98,7 @@ impl ExplorerPage {
                 self.entries.clear();
                 self.close_search(window, cx);
                 self.reload();
+                cx.emit(PaneEvent::Navigated(self.cwd.clone()));
                 cx.notify();
             }
         }
@@ -90,6 +112,7 @@ impl ExplorerPage {
                 self.entries.clear();
                 self.close_search(window, cx);
                 self.reload();
+                cx.emit(PaneEvent::Navigated(self.cwd.clone()));
                 cx.notify();
             }
         }

--- a/crates/nohrs-pages/src/explorer/page.rs
+++ b/crates/nohrs-pages/src/explorer/page.rs
@@ -1,0 +1,466 @@
+//! The split-view container that owns the explorer's panes.
+//!
+//! A single [`ExplorerPage`] holds one or two [`ExplorerPane`]s (2-way split is
+//! the P2 cap; `docs/explorer-essentials.md` §3.1). Each pane navigates
+//! independently and renders its own header / listing / preview. The container
+//! arranges the panes (left/right or top/bottom), routes the split / focus /
+//! close shortcuts (§3.2, §6), and mirrors navigation across panes when
+//! `synced_panes` is enabled.
+
+use std::sync::{Arc, Once};
+
+use gpui::prelude::FluentBuilder;
+use gpui::*;
+use gpui_component::resizable::{h_resizable, resizable_panel, v_resizable, ResizableState};
+use gpui_component::{Icon, IconName};
+use nohrs_core::config::{Explorer as ExplorerConfig, SplitDirection, Ui};
+use nohrs_services::search::SearchService;
+use nohrs_ui::theme::theme;
+
+use super::state::ExplorerPane;
+use super::types::PaneEvent;
+
+// Key context the pane shortcuts are bound under, so they only fire while the
+// explorer (and not another page) is focused.
+const PANES_CONTEXT: &str = "ExplorerPanes";
+
+actions!(
+    explorer_panes,
+    [
+        /// Split the explorer into left/right panes (or flip an existing split).
+        SplitVertical,
+        /// Split the explorer into top/bottom panes (or flip an existing split).
+        SplitHorizontal,
+        /// Move focus to the first pane.
+        FocusPane1,
+        /// Move focus to the second pane.
+        FocusPane2,
+        /// Move focus to the next pane, wrapping around.
+        FocusNextPane,
+        /// Move focus to the previous pane, wrapping around.
+        FocusPrevPane,
+    ]
+);
+
+static BIND_PANE_KEYS: Once = Once::new();
+
+fn bind_pane_keys(cx: &mut App) {
+    BIND_PANE_KEYS.call_once(|| {
+        cx.bind_keys(vec![
+            KeyBinding::new("cmd-\\", SplitVertical, Some(PANES_CONTEXT)),
+            KeyBinding::new("ctrl-\\", SplitVertical, Some(PANES_CONTEXT)),
+            // `Shift+\` resolves to the `|` keysym; gpui's Linux layer then drops
+            // the shift modifier for symbols, so the shortcut arrives as `cmd-|`
+            // / `ctrl-|` rather than `*-shift-\`. Bind every spelling so the
+            // documented `Cmd/Ctrl+Shift+\` works across platforms and layouts.
+            KeyBinding::new("cmd-shift-\\", SplitHorizontal, Some(PANES_CONTEXT)),
+            KeyBinding::new("ctrl-shift-\\", SplitHorizontal, Some(PANES_CONTEXT)),
+            KeyBinding::new("cmd-|", SplitHorizontal, Some(PANES_CONTEXT)),
+            KeyBinding::new("ctrl-|", SplitHorizontal, Some(PANES_CONTEXT)),
+            KeyBinding::new("cmd-shift-|", SplitHorizontal, Some(PANES_CONTEXT)),
+            KeyBinding::new("ctrl-shift-|", SplitHorizontal, Some(PANES_CONTEXT)),
+            KeyBinding::new("cmd-1", FocusPane1, Some(PANES_CONTEXT)),
+            KeyBinding::new("ctrl-1", FocusPane1, Some(PANES_CONTEXT)),
+            KeyBinding::new("cmd-2", FocusPane2, Some(PANES_CONTEXT)),
+            KeyBinding::new("ctrl-2", FocusPane2, Some(PANES_CONTEXT)),
+            KeyBinding::new("cmd-]", FocusNextPane, Some(PANES_CONTEXT)),
+            KeyBinding::new("ctrl-]", FocusNextPane, Some(PANES_CONTEXT)),
+            KeyBinding::new("cmd-[", FocusPrevPane, Some(PANES_CONTEXT)),
+            KeyBinding::new("ctrl-[", FocusPrevPane, Some(PANES_CONTEXT)),
+        ]);
+    });
+}
+
+/// The explorer page: a 2-way split container over independently-navigating
+/// panes. With a single pane it renders exactly like an unsplit explorer.
+pub struct ExplorerPage {
+    // Invariant: always non-empty and at most two entries (2-way cap, §3.1).
+    panes: Vec<Entity<ExplorerPane>>,
+    // Subscriptions for pane navigation events, index-aligned with `panes`.
+    pane_subscriptions: Vec<Subscription>,
+    /// Index of the pane keyboard input and shortcuts act on.
+    active: usize,
+    /// Orientation a split uses; seeded from config, toggled by the shortcuts.
+    direction: SplitDirection,
+    /// Whether navigation in one pane mirrors into the others (§3.2).
+    synced_panes: bool,
+    // Resizable state for the divider between the two panes.
+    pane_resizable: Entity<ResizableState>,
+    search_service: Option<Arc<SearchService>>,
+    focus_handle: FocusHandle,
+}
+
+impl Focusable for ExplorerPage {
+    fn focus_handle(&self, _cx: &App) -> FocusHandle {
+        self.focus_handle.clone()
+    }
+}
+
+impl ExplorerPage {
+    /// Builds the explorer with a single pane. The pane resizable is supplied by
+    /// the application (it owns the app-level state); each pane creates its own
+    /// listing/preview resizable and search input.
+    pub fn new(
+        pane_resizable: Entity<ResizableState>,
+        search_service: Option<Arc<SearchService>>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        bind_pane_keys(cx);
+        let mut page = Self {
+            panes: Vec::new(),
+            pane_subscriptions: Vec::new(),
+            active: 0,
+            direction: SplitDirection::default(),
+            synced_panes: false,
+            pane_resizable,
+            search_service,
+            focus_handle: cx.focus_handle(),
+        };
+        page.add_pane(None, window, cx);
+        page
+    }
+
+    // Creates a pane (optionally rooted at `cwd`), subscribes to its navigation
+    // events, and appends it. Returns the new pane's index.
+    fn add_pane(
+        &mut self,
+        cwd: Option<String>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> usize {
+        let search_service = self.search_service.clone();
+        let pane = cx.new(|cx| ExplorerPane::build(search_service, window, cx));
+        if let Some(cwd) = cwd {
+            pane.update(cx, |pane, _cx| {
+                pane.cwd = cwd;
+                // Force a reload of the new root on the next render.
+                pane.loaded = false;
+            });
+        }
+        let subscription = cx.subscribe(&pane, Self::on_pane_event);
+        self.panes.push(pane);
+        self.pane_subscriptions.push(subscription);
+        self.panes.len() - 1
+    }
+
+    // Mirrors a pane's navigation into its siblings while syncing is enabled.
+    fn on_pane_event(
+        &mut self,
+        source: Entity<ExplorerPane>,
+        event: &PaneEvent,
+        cx: &mut Context<Self>,
+    ) {
+        if !self.synced_panes {
+            return;
+        }
+        let PaneEvent::Navigated(path) = event;
+        let targets: Vec<Entity<ExplorerPane>> = self
+            .panes
+            .iter()
+            .filter(|pane| pane.entity_id() != source.entity_id())
+            .cloned()
+            .collect();
+        for pane in targets {
+            let path = path.clone();
+            pane.update(cx, |pane, cx| pane.navigate_to_synced(path, cx));
+        }
+    }
+
+    /// Ensures a split exists and uses `direction`. With one pane it opens a
+    /// second rooted at the active pane's directory; with two it just re-orients
+    /// (so the other split shortcut flips horizontal/vertical). Always keeps the
+    /// 2-way cap (§3.1).
+    pub fn split(
+        &mut self,
+        direction: SplitDirection,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.direction = direction;
+        if self.panes.len() < 2 {
+            let cwd = self.active_pane().read(cx).cwd.clone();
+            let index = self.add_pane(Some(cwd), window, cx);
+            self.active = index;
+        }
+        self.focus_active(window, cx);
+        cx.notify();
+    }
+
+    /// Closes a pane, keeping at least one open (§3.1). No-op for the last pane.
+    pub fn close_pane(&mut self, index: usize, window: &mut Window, cx: &mut Context<Self>) {
+        if self.panes.len() <= 1 || index >= self.panes.len() {
+            return;
+        }
+        self.panes.remove(index);
+        // Dropping the subscription deregisters the removed pane's event handler.
+        drop(self.pane_subscriptions.remove(index));
+        if self.active >= self.panes.len() {
+            self.active = self.panes.len() - 1;
+        }
+        self.focus_active(window, cx);
+        cx.notify();
+    }
+
+    /// Makes `index` the active pane and moves keyboard focus to it.
+    pub fn set_active(&mut self, index: usize, window: &mut Window, cx: &mut Context<Self>) {
+        if index >= self.panes.len() || index == self.active {
+            return;
+        }
+        self.active = index;
+        self.focus_active(window, cx);
+        cx.notify();
+    }
+
+    fn focus_next(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if self.panes.len() < 2 {
+            return;
+        }
+        self.set_active((self.active + 1) % self.panes.len(), window, cx);
+    }
+
+    fn focus_prev(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if self.panes.len() < 2 {
+            return;
+        }
+        let count = self.panes.len();
+        self.set_active((self.active + count - 1) % count, window, cx);
+    }
+
+    fn active_pane(&self) -> &Entity<ExplorerPane> {
+        // `active` is kept in bounds by every mutator; fall back to the first
+        // pane rather than panicking should that invariant ever be violated.
+        self.panes.get(self.active).unwrap_or(&self.panes[0])
+    }
+
+    fn focus_active(&self, window: &mut Window, cx: &mut Context<Self>) {
+        let handle = self.active_pane().read(cx).focus_handle.clone();
+        handle.focus(window);
+    }
+
+    /// Applies the `[ui]` config section to every pane (§5 of `config.md`).
+    pub fn apply_config_ui(&mut self, ui: &Ui, cx: &mut Context<Self>) {
+        for pane in self.panes.clone() {
+            pane.update(cx, |pane, cx| pane.apply_config_ui(ui, cx));
+        }
+    }
+
+    /// Applies the `[explorer]` config section: the default split orientation and
+    /// the synced-panes opt-in. Enabling sync immediately mirrors the active
+    /// pane's directory into the others.
+    pub fn apply_config_explorer(&mut self, explorer: &ExplorerConfig, cx: &mut Context<Self>) {
+        // Only adopt the configured orientation while unsplit, so a config reload
+        // does not silently flip a split the user arranged via the shortcuts.
+        if self.panes.len() < 2 {
+            self.direction = explorer.split_direction;
+        }
+        let enabling = explorer.synced_panes && !self.synced_panes;
+        self.synced_panes = explorer.synced_panes;
+        if enabling {
+            let path = self.active_pane().read(cx).cwd.clone();
+            let active_id = self.active_pane().entity_id();
+            for pane in self.panes.clone() {
+                if pane.entity_id() != active_id {
+                    let path = path.clone();
+                    pane.update(cx, |pane, cx| pane.navigate_to_synced(path, cx));
+                }
+            }
+        }
+        cx.notify();
+    }
+
+    /// Footer status for the active pane (a config error in `RootView` still
+    /// takes precedence over this).
+    pub fn status_for_footer(&self, cx: &App) -> Option<(String, bool)> {
+        self.active_pane().read(cx).status_for_footer()
+    }
+
+    fn render_pane(&mut self, index: usize, cx: &mut Context<Self>) -> AnyElement {
+        let pane = self.panes[index].clone();
+        let split = self.panes.len() > 1;
+        let is_active = split && index == self.active;
+        div()
+            .flex()
+            .flex_col()
+            .size_full()
+            .min_w(px(0.0))
+            .min_h(px(0.0))
+            .when(is_active, |this| {
+                this.border_t_2().border_color(rgb(theme::ACCENT))
+            })
+            .when(split && !is_active, |this| {
+                this.border_t_2().border_color(rgb(theme::BG))
+            })
+            // Clicking anywhere in a pane makes it the active one.
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(move |this, _event, window, cx| this.set_active(index, window, cx)),
+            )
+            .child(self.render_tab_bar(index, split, cx))
+            .child(div().flex_1().min_h(px(0.0)).overflow_hidden().child(pane))
+            .into_any_element()
+    }
+
+    // The pane-local tab bar: foundation for per-pane tabs (§3.3, full tabs in
+    // #62). For now it shows the current directory as a single tab plus the
+    // pane-close button, which only appears once a split exists.
+    fn render_tab_bar(
+        &self,
+        index: usize,
+        split: bool,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        let cwd = self.panes[index].read(cx).cwd.clone();
+        let label = std::path::Path::new(&cwd)
+            .file_name()
+            .map(|name| name.to_string_lossy().to_string())
+            .unwrap_or(cwd);
+        let is_active = split && index == self.active;
+
+        div()
+            .flex()
+            .flex_row()
+            .items_center()
+            .h(px(32.0))
+            .w_full()
+            .px(px(6.0))
+            .gap(px(4.0))
+            .bg(rgb(theme::TOOLBAR_BG))
+            .border_b_1()
+            .border_color(rgb(theme::BORDER))
+            .child(
+                div()
+                    .flex()
+                    .items_center()
+                    .h(px(24.0))
+                    .px(px(10.0))
+                    .rounded(px(6.0))
+                    .text_sm()
+                    .when(is_active, |this| {
+                        this.bg(rgb(theme::TOOLBAR_ACTIVE_BG))
+                            .text_color(rgb(theme::TOOLBAR_ACTIVE_TEXT))
+                    })
+                    .when(!is_active, |this| this.text_color(rgb(theme::TOOLBAR_TEXT)))
+                    .child(label),
+            )
+            // Placeholder for the new-tab affordance fleshed out in #62.
+            .child(
+                div()
+                    .flex()
+                    .items_center()
+                    .justify_center()
+                    .size(px(20.0))
+                    .rounded(px(4.0))
+                    .child(
+                        Icon::new(IconName::Plus)
+                            .size_4()
+                            .text_color(rgb(theme::MUTED)),
+                    ),
+            )
+            .child(div().flex_grow())
+            .when(split, |this| {
+                this.child(
+                    div()
+                        .id(("close-pane", index))
+                        .flex()
+                        .items_center()
+                        .justify_center()
+                        .size(px(22.0))
+                        .rounded(px(4.0))
+                        .cursor_pointer()
+                        .hover(|style| style.bg(rgb(theme::TOOLBAR_HOVER)))
+                        .on_click(cx.listener(move |this, _event, window, cx| {
+                            this.close_pane(index, window, cx);
+                        }))
+                        .child(
+                            Icon::new(IconName::Close)
+                                .size_4()
+                                .text_color(rgb(theme::TOOLBAR_TEXT)),
+                        ),
+                )
+            })
+    }
+}
+
+impl Render for ExplorerPage {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let body = if self.panes.len() > 1 {
+            let first = self.render_pane(0, cx);
+            let second = self.render_pane(1, cx);
+            let group = match self.direction {
+                SplitDirection::Vertical => {
+                    h_resizable("explorer-panes", self.pane_resizable.clone())
+                }
+                SplitDirection::Horizontal => {
+                    v_resizable("explorer-panes", self.pane_resizable.clone())
+                }
+            };
+            group
+                .child(resizable_panel().child(first))
+                .child(resizable_panel().child(second))
+                .into_any_element()
+        } else {
+            self.render_pane(0, cx)
+        };
+
+        div()
+            .size_full()
+            .flex()
+            .flex_col()
+            .bg(rgb(theme::BG))
+            .key_context(PANES_CONTEXT)
+            .track_focus(&self.focus_handle)
+            .on_action(cx.listener(|this, _: &SplitVertical, window, cx| {
+                this.split(SplitDirection::Vertical, window, cx);
+            }))
+            .on_action(cx.listener(|this, _: &SplitHorizontal, window, cx| {
+                this.split(SplitDirection::Horizontal, window, cx);
+            }))
+            .on_action(cx.listener(|this, _: &FocusPane1, window, cx| {
+                this.set_active(0, window, cx);
+            }))
+            .on_action(cx.listener(|this, _: &FocusPane2, window, cx| {
+                this.set_active(1, window, cx);
+            }))
+            .on_action(cx.listener(|this, _: &FocusNextPane, window, cx| {
+                this.focus_next(window, cx);
+            }))
+            .on_action(cx.listener(|this, _: &FocusPrevPane, window, cx| {
+                this.focus_prev(window, cx);
+            }))
+            .child(body)
+    }
+}
+
+impl crate::Page for ExplorerPage {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> AnyElement {
+        <Self as Render>::render(self, window, cx).into_any_element()
+    }
+}
+
+#[cfg(test)]
+impl ExplorerPage {
+    pub(crate) fn pane_count(&self) -> usize {
+        self.panes.len()
+    }
+
+    pub(crate) fn active_index(&self) -> usize {
+        self.active
+    }
+
+    pub(crate) fn direction(&self) -> SplitDirection {
+        self.direction
+    }
+
+    pub(crate) fn is_synced(&self) -> bool {
+        self.synced_panes
+    }
+
+    pub(crate) fn pane(&self, index: usize) -> Entity<ExplorerPane> {
+        self.panes[index].clone()
+    }
+
+    pub(crate) fn pane_cwd(&self, index: usize, cx: &App) -> Option<String> {
+        self.panes.get(index).map(|pane| pane.read(cx).cwd.clone())
+    }
+}

--- a/crates/nohrs-pages/src/explorer/page.rs
+++ b/crates/nohrs-pages/src/explorer/page.rs
@@ -84,6 +84,9 @@ pub struct ExplorerPage {
     direction: SplitDirection,
     /// Whether navigation in one pane mirrors into the others (§3.2).
     synced_panes: bool,
+    // Last-applied `[ui]` settings, replayed onto panes opened by a later split
+    // so they match config rather than reverting to pane defaults.
+    ui: Ui,
     // Resizable state for the divider between the two panes.
     pane_resizable: Entity<ResizableState>,
     search_service: Option<Arc<SearchService>>,
@@ -113,6 +116,7 @@ impl ExplorerPage {
             active: 0,
             direction: SplitDirection::default(),
             synced_panes: false,
+            ui: Ui::default(),
             pane_resizable,
             search_service,
             focus_handle: cx.focus_handle(),
@@ -131,13 +135,17 @@ impl ExplorerPage {
     ) -> usize {
         let search_service = self.search_service.clone();
         let pane = cx.new(|cx| ExplorerPane::build(search_service, window, cx));
-        if let Some(cwd) = cwd {
-            pane.update(cx, |pane, _cx| {
+        // Replay the active `[ui]` config so a pane opened by a split inherits the
+        // user's sort/hidden/icon settings instead of reverting to pane defaults.
+        let ui = self.ui.clone();
+        pane.update(cx, |pane, cx| {
+            pane.apply_config_ui(&ui, cx);
+            if let Some(cwd) = cwd {
                 pane.cwd = cwd;
                 // Force a reload of the new root on the next render.
                 pane.loaded = false;
-            });
-        }
+            }
+        });
         let subscription = cx.subscribe(&pane, Self::on_pane_event);
         self.panes.push(pane);
         self.pane_subscriptions.push(subscription);
@@ -163,6 +171,10 @@ impl ExplorerPage {
             .collect();
         for pane in targets {
             let path = path.clone();
+            // `navigate_to_synced` (not `change_dir`) is deliberate: it does not
+            // re-emit `PaneEvent::Navigated`, which would mirror back to the
+            // source pane and loop indefinitely. Don't replace it with a regular
+            // navigation method.
             pane.update(cx, |pane, cx| pane.navigate_to_synced(path, cx));
         }
     }
@@ -240,6 +252,7 @@ impl ExplorerPage {
 
     /// Applies the `[ui]` config section to every pane (§5 of `config.md`).
     pub fn apply_config_ui(&mut self, ui: &Ui, cx: &mut Context<Self>) {
+        self.ui = ui.clone();
         for pane in self.panes.clone() {
             pane.update(cx, |pane, cx| pane.apply_config_ui(ui, cx));
         }

--- a/crates/nohrs-pages/src/explorer/preview.rs
+++ b/crates/nohrs-pages/src/explorer/preview.rs
@@ -3,7 +3,7 @@ use nohrs_core::config;
 use gpui::{AppContext, AsyncWindowContext, Context, Window};
 
 use super::view::preview::editor::PreviewEditor;
-use super::ExplorerPage;
+use super::ExplorerPane;
 
 /// Result of reading a file for preview off the UI thread.
 enum PreviewOutcome {
@@ -118,7 +118,7 @@ fn line_start_offset(text: &str, target_line: usize) -> Option<usize> {
     None
 }
 
-impl ExplorerPage {
+impl ExplorerPane {
     pub(crate) fn open_preview(
         &mut self,
         path: String,
@@ -142,7 +142,7 @@ impl ExplorerPage {
 
         cx.spawn_in(
             window,
-            move |this: gpui::WeakEntity<ExplorerPage>, cx: &mut AsyncWindowContext| {
+            move |this: gpui::WeakEntity<ExplorerPane>, cx: &mut AsyncWindowContext| {
                 let mut cx = cx.clone();
                 async move {
                     let outcome = read_task.await;

--- a/crates/nohrs-pages/src/explorer/search.rs
+++ b/crates/nohrs-pages/src/explorer/search.rs
@@ -1,11 +1,11 @@
 use super::types::{SearchFileResult, SearchMatch, StatusLevel};
-use super::ExplorerPage;
+use super::ExplorerPane;
 use gpui::{AppContext, AsyncApp, Context, Window};
 use nohrs_services::fs::listing::FileEntryDto;
 use nohrs_services::search::SearchResult;
 use std::collections::HashMap;
 
-impl ExplorerPage {
+impl ExplorerPane {
     pub(crate) fn trigger_search(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
         // Invalidate any in-flight search; only the latest request may apply its
         // results (including the empty-query and degraded-mode early returns,
@@ -42,7 +42,7 @@ impl ExplorerPage {
         let scope = self.search_scope;
 
         cx.spawn(
-            move |this: gpui::WeakEntity<ExplorerPage>, cx: &mut AsyncApp| {
+            move |this: gpui::WeakEntity<ExplorerPane>, cx: &mut AsyncApp| {
                 let mut cx = cx.clone();
                 async move {
                     // `SearchService::search` is synchronous, and grouping plus

--- a/crates/nohrs-pages/src/explorer/state.rs
+++ b/crates/nohrs-pages/src/explorer/state.rs
@@ -4,7 +4,7 @@ use nohrs_services::search::{SearchScope, SearchService};
 use nohrs_services::syntax::SyntaxService;
 use nohrs_ui::components::file_list::FileListDelegate;
 
-use gpui::{px, size, Context, Entity, FocusHandle, Focusable};
+use gpui::{px, size, AppContext, Context, Entity, EventEmitter, FocusHandle, Focusable, Window};
 use gpui_component::input::InputState;
 use gpui_component::list::List;
 use gpui_component::resizable::ResizableState;
@@ -17,7 +17,7 @@ use super::view::preview::editor::PreviewEditor;
 
 /// State for the file explorer page: the current directory listing, navigation
 /// history, sorting and filtering, search, preview, and view layout.
-pub struct ExplorerPage {
+pub struct ExplorerPane {
     /// Absolute path of the currently displayed directory.
     pub cwd: String,
     /// Navigation history of visited directories for back/forward.
@@ -126,14 +126,29 @@ pub struct ExplorerPage {
     pub status_message: Option<StatusMessage>,
 }
 
-impl Focusable for ExplorerPage {
+impl Focusable for ExplorerPane {
     fn focus_handle(&self, _cx: &gpui::App) -> FocusHandle {
         self.focus_handle.clone()
     }
 }
 
-impl ExplorerPage {
-    /// Creates a new explorer page rooted at the current working directory,
+impl EventEmitter<PaneEvent> for ExplorerPane {}
+
+impl ExplorerPane {
+    /// Builds a self-contained pane, creating the window-bound sub-entities
+    /// (listing/preview resizable, search input) and focus handle it owns. Used
+    /// by the split-view container, which may hold several independent panes.
+    pub fn build(
+        search_service: Option<Arc<SearchService>>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        let resizable = ResizableState::new(cx);
+        let search_input = cx.new(|cx| InputState::new(window, cx));
+        Self::new(resizable, search_input, search_service, cx.focus_handle())
+    }
+
+    /// Creates a new explorer pane rooted at the current working directory,
     /// wired to the given resizable, search input, and optional search service.
     pub fn new(
         resizable: Entity<ResizableState>,

--- a/crates/nohrs-pages/src/explorer/tests.rs
+++ b/crates/nohrs-pages/src/explorer/tests.rs
@@ -17,21 +17,32 @@ use gpui_component::resizable::ResizableState;
 use nohrs_core::config;
 use nohrs_services::fs::listing::FileEntryDto;
 
-use super::types::{SortKey, StatusLevel, ViewMode};
-use super::ExplorerPage;
+use nohrs_core::config::SplitDirection;
 
-/// Build a real `ExplorerPage` inside a test window. The sub-entities
+use super::types::{SortKey, StatusLevel, ViewMode};
+use super::{ExplorerPage, ExplorerPane};
+
+/// Build a real `ExplorerPane` inside a test window. The sub-entities
 /// (`ResizableState`, `InputState`) are window-bound, so the page is
 /// constructed in the `add_window` build closure — the canonical pattern for
 /// views whose dependencies need a `Window`.
-fn new_explorer(cx: &mut TestAppContext) -> WindowHandle<ExplorerPage> {
+fn new_explorer(cx: &mut TestAppContext) -> WindowHandle<ExplorerPane> {
     // gpui-component installs the `Theme` global and input/list subsystems its
     // widgets rely on; initialize it once before building any window.
     cx.update(gpui_component::init);
     cx.add_window(|window, cx| {
         let resizable = ResizableState::new(cx);
         let search_input = cx.new(|cx| InputState::new(window, cx));
-        ExplorerPage::new(resizable, search_input, None, cx.focus_handle())
+        ExplorerPane::new(resizable, search_input, None, cx.focus_handle())
+    })
+}
+
+/// Build the split-view container (`ExplorerPage`), which owns its panes.
+fn new_explorer_page(cx: &mut TestAppContext) -> WindowHandle<ExplorerPage> {
+    cx.update(gpui_component::init);
+    cx.add_window(|window, cx| {
+        let resizable = ResizableState::new(cx);
+        ExplorerPage::new(resizable, None, window, cx)
     })
 }
 
@@ -362,6 +373,136 @@ async fn reload_reports_error_for_unreadable_dir(cx: &mut TestAppContext) {
             let (_, is_error) = page.status_for_footer().expect("error status set");
             assert!(is_error);
             assert!(page.entries.is_empty());
+        })
+        .unwrap();
+}
+
+#[gpui::test]
+async fn explorer_page_starts_with_single_pane(cx: &mut TestAppContext) {
+    let window = new_explorer_page(cx);
+    window
+        .read_with(cx, |page, _cx| {
+            assert_eq!(page.pane_count(), 1);
+            assert_eq!(page.active_index(), 0);
+            assert!(!page.is_synced());
+        })
+        .unwrap();
+}
+
+#[gpui::test]
+async fn split_opens_second_pane_then_reorients(cx: &mut TestAppContext) {
+    let window = new_explorer_page(cx);
+    window
+        .update(cx, |page, window, cx| {
+            page.split(SplitDirection::Vertical, window, cx);
+            assert_eq!(page.pane_count(), 2, "first split opens a second pane");
+            assert_eq!(page.active_index(), 1, "the new pane becomes active");
+            assert_eq!(page.direction(), SplitDirection::Vertical);
+
+            // The opposite split shortcut flips orientation without adding a pane
+            // (2-way cap, §3.1).
+            page.split(SplitDirection::Horizontal, window, cx);
+            assert_eq!(page.pane_count(), 2);
+            assert_eq!(page.direction(), SplitDirection::Horizontal);
+        })
+        .unwrap();
+}
+
+#[gpui::test]
+async fn close_pane_keeps_at_least_one(cx: &mut TestAppContext) {
+    let window = new_explorer_page(cx);
+    window
+        .update(cx, |page, window, cx| {
+            page.split(SplitDirection::Vertical, window, cx);
+            assert_eq!(page.pane_count(), 2);
+
+            page.close_pane(1, window, cx);
+            assert_eq!(page.pane_count(), 1);
+            assert_eq!(page.active_index(), 0);
+
+            // The final pane can never be closed.
+            page.close_pane(0, window, cx);
+            assert_eq!(page.pane_count(), 1);
+        })
+        .unwrap();
+}
+
+#[gpui::test]
+async fn set_active_selects_pane_in_bounds(cx: &mut TestAppContext) {
+    let window = new_explorer_page(cx);
+    window
+        .update(cx, |page, window, cx| {
+            page.split(SplitDirection::Vertical, window, cx);
+            page.set_active(0, window, cx);
+            assert_eq!(page.active_index(), 0);
+
+            // Out-of-range indices are ignored rather than panicking.
+            page.set_active(5, window, cx);
+            assert_eq!(page.active_index(), 0);
+        })
+        .unwrap();
+}
+
+#[gpui::test]
+async fn panes_navigate_independently_by_default(cx: &mut TestAppContext) {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    std::fs::create_dir(root.join("left")).unwrap();
+    std::fs::create_dir(root.join("right")).unwrap();
+    let left = root.join("left").to_string_lossy().to_string();
+    let right = root.join("right").to_string_lossy().to_string();
+
+    let window = new_explorer_page(cx);
+    window
+        .update(cx, |page, window, cx| {
+            page.split(SplitDirection::Vertical, window, cx);
+            let pane0 = page.pane(0);
+            let pane1 = page.pane(1);
+            pane0.update(cx, |pane, cx| pane.change_dir(left.clone(), window, cx));
+            pane1.update(cx, |pane, cx| pane.change_dir(right.clone(), window, cx));
+        })
+        .unwrap();
+    cx.run_until_parked();
+    window
+        .read_with(cx, |page, cx| {
+            assert_eq!(page.pane_cwd(0, cx).as_deref(), Some(left.as_str()));
+            assert_eq!(page.pane_cwd(1, cx).as_deref(), Some(right.as_str()));
+        })
+        .unwrap();
+}
+
+#[gpui::test]
+async fn synced_panes_mirror_navigation(cx: &mut TestAppContext) {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    std::fs::create_dir(root.join("shared")).unwrap();
+    let shared = root.join("shared").to_string_lossy().to_string();
+
+    let window = new_explorer_page(cx);
+    window
+        .update(cx, |page, window, cx| {
+            page.split(SplitDirection::Vertical, window, cx);
+            let synced = config::Explorer {
+                split_direction: SplitDirection::Vertical,
+                synced_panes: true,
+            };
+            page.apply_config_explorer(&synced, cx);
+            assert!(page.is_synced());
+
+            let pane0 = page.pane(0);
+            pane0.update(cx, |pane, cx| pane.change_dir(shared.clone(), window, cx));
+        })
+        .unwrap();
+    // Navigation events are delivered on the next effect flush; mirror happens there.
+    cx.run_until_parked();
+    window
+        .read_with(cx, |page, cx| {
+            assert_eq!(page.pane_cwd(0, cx).as_deref(), Some(shared.as_str()));
+            assert_eq!(
+                page.pane_cwd(1, cx).as_deref(),
+                Some(shared.as_str()),
+                "sibling pane mirrors the active pane's path"
+            );
         })
         .unwrap();
 }

--- a/crates/nohrs-pages/src/explorer/tests.rs
+++ b/crates/nohrs-pages/src/explorer/tests.rs
@@ -506,3 +506,67 @@ async fn synced_panes_mirror_navigation(cx: &mut TestAppContext) {
         })
         .unwrap();
 }
+
+#[gpui::test]
+async fn synced_navigation_clears_stale_search_state(cx: &mut TestAppContext) {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    std::fs::create_dir(root.join("shared")).unwrap();
+    let shared = root.join("shared").to_string_lossy().to_string();
+
+    let window = new_explorer_page(cx);
+    window
+        .update(cx, |page, window, cx| {
+            page.split(SplitDirection::Vertical, window, cx);
+            let synced = config::Explorer {
+                split_direction: SplitDirection::Vertical,
+                synced_panes: true,
+            };
+            page.apply_config_explorer(&synced, cx);
+
+            // Leave the mirrored pane with a stale filter from a prior search.
+            page.pane(1).update(cx, |pane, _cx| {
+                pane.search_query = "stale".to_string();
+                pane.search_visible = true;
+            });
+            page.pane(0)
+                .update(cx, |pane, cx| pane.change_dir(shared.clone(), window, cx));
+        })
+        .unwrap();
+    cx.run_until_parked();
+    window
+        .read_with(cx, |page, cx| {
+            let pane1 = page.pane(1);
+            let pane1 = pane1.read(cx);
+            assert!(
+                pane1.search_query.is_empty(),
+                "stale filter cleared on sync"
+            );
+            assert!(!pane1.search_visible);
+            assert!(pane1.search_results.is_none());
+        })
+        .unwrap();
+}
+
+#[gpui::test]
+async fn split_pane_inherits_applied_ui_config(cx: &mut TestAppContext) {
+    let window = new_explorer_page(cx);
+    window
+        .update(cx, |page, window, cx| {
+            let ui = config::Ui {
+                default_sort: config::SortOrder::Size,
+                show_hidden: true,
+                icon_pack: "default".to_string(),
+            };
+            page.apply_config_ui(&ui, cx);
+
+            // A pane opened by a later split should pick up the applied config
+            // rather than reverting to pane defaults.
+            page.split(SplitDirection::Vertical, window, cx);
+            let pane1 = page.pane(1);
+            let pane1 = pane1.read(cx);
+            assert!(pane1.show_hidden, "new pane inherits show_hidden");
+            assert!(pane1.sort_key == SortKey::Size, "new pane inherits sort");
+        })
+        .unwrap();
+}

--- a/crates/nohrs-pages/src/explorer/tests.rs
+++ b/crates/nohrs-pages/src/explorer/tests.rs
@@ -524,10 +524,12 @@ async fn synced_navigation_clears_stale_search_state(cx: &mut TestAppContext) {
             };
             page.apply_config_explorer(&synced, cx);
 
-            // Leave the mirrored pane with a stale filter from a prior search.
+            // Leave the mirrored pane with a stale filter and results from a
+            // prior search so the reset is actually exercised (not vacuous).
             page.pane(1).update(cx, |pane, _cx| {
                 pane.search_query = "stale".to_string();
                 pane.search_visible = true;
+                pane.search_results = Some(Vec::new());
             });
             page.pane(0)
                 .update(cx, |pane, cx| pane.change_dir(shared.clone(), window, cx));

--- a/crates/nohrs-pages/src/explorer/types.rs
+++ b/crates/nohrs-pages/src/explorer/types.rs
@@ -67,3 +67,11 @@ pub struct StatusMessage {
     pub text: String,
     pub level: StatusLevel,
 }
+
+/// Events a single pane emits to its containing split view, so the container can
+/// mirror navigation across panes when `synced_panes` is enabled (§3.2).
+#[derive(Clone)]
+pub enum PaneEvent {
+    /// The pane navigated to a new directory (carries the new absolute path).
+    Navigated(String),
+}

--- a/crates/nohrs-pages/src/explorer/view.rs
+++ b/crates/nohrs-pages/src/explorer/view.rs
@@ -1,4 +1,4 @@
-use crate::explorer::ExplorerPage;
+use crate::explorer::ExplorerPane;
 use gpui::*;
 use nohrs_ui::theme::theme;
 
@@ -13,9 +13,9 @@ pub mod sidebar;
 
 /// Renders the explorer page: header, sidebar, listing, and preview panes.
 pub fn render(
-    page: &mut ExplorerPage,
+    page: &mut ExplorerPane,
     window: &mut Window,
-    cx: &mut Context<ExplorerPage>,
+    cx: &mut Context<ExplorerPane>,
 ) -> impl IntoElement {
     page.ensure_loaded();
     page.update_editor_search(window, cx);

--- a/crates/nohrs-pages/src/explorer/view/header.rs
+++ b/crates/nohrs-pages/src/explorer/view/header.rs
@@ -1,5 +1,5 @@
 use super::super::types::ViewMode;
-use crate::explorer::ExplorerPage;
+use crate::explorer::ExplorerPane;
 use gpui::prelude::*;
 use gpui::*;
 use gpui_component::breadcrumb::{Breadcrumb, BreadcrumbItem};
@@ -9,9 +9,9 @@ use nohrs_ui::theme::theme;
 /// Renders the explorer header with navigation buttons, the breadcrumb path
 /// bar, and view-mode controls.
 pub fn render(
-    page: &mut ExplorerPage,
+    page: &mut ExplorerPane,
     _window: &mut Window,
-    cx: &mut Context<ExplorerPage>,
+    cx: &mut Context<ExplorerPane>,
 ) -> impl IntoElement {
     let parts = path_parts(&page.cwd);
 
@@ -162,8 +162,8 @@ pub fn render(
 }
 
 fn render_view_mode_toggle(
-    page: &mut ExplorerPage,
-    cx: &mut Context<ExplorerPage>,
+    page: &mut ExplorerPane,
+    cx: &mut Context<ExplorerPane>,
 ) -> impl IntoElement {
     div()
         .flex()
@@ -188,12 +188,12 @@ fn render_view_mode_toggle(
 }
 
 fn view_mode_button(
-    page: &mut ExplorerPage,
+    page: &mut ExplorerPane,
     mode: ViewMode,
     id: &'static str,
     icon: IconName,
     label: &'static str,
-    cx: &mut Context<ExplorerPage>,
+    cx: &mut Context<ExplorerPane>,
 ) -> impl IntoElement {
     let is_active = page.view_mode == mode;
     ListItem::new(id)

--- a/crates/nohrs-pages/src/explorer/view/listing.rs
+++ b/crates/nohrs-pages/src/explorer/view/listing.rs
@@ -1,5 +1,5 @@
 use super::super::types::ViewMode;
-use crate::explorer::ExplorerPage;
+use crate::explorer::ExplorerPane;
 use gpui::*;
 
 /// Grid-mode rendering of the listing.
@@ -14,9 +14,9 @@ pub mod search_bar;
 /// Renders the file listing in the active view mode, with the search bar when
 /// search is visible.
 pub fn render(
-    page: &mut ExplorerPage,
+    page: &mut ExplorerPane,
     window: &mut Window,
-    cx: &mut Context<ExplorerPage>,
+    cx: &mut Context<ExplorerPane>,
 ) -> AnyElement {
     page.ensure_list_initialized(window, cx);
 

--- a/crates/nohrs-pages/src/explorer/view/listing/grid.rs
+++ b/crates/nohrs-pages/src/explorer/view/listing/grid.rs
@@ -1,5 +1,5 @@
 use super::truncate_middle;
-use crate::explorer::ExplorerPage;
+use crate::explorer::ExplorerPane;
 use gpui::prelude::*;
 use gpui::*;
 use gpui_component::{Icon, IconName};
@@ -8,9 +8,9 @@ use nohrs_ui::theme::theme;
 
 /// Renders the file listing as a grid of icon tiles.
 pub fn render(
-    page: &mut ExplorerPage,
+    page: &mut ExplorerPane,
     window: &mut Window,
-    cx: &mut Context<ExplorerPage>,
+    cx: &mut Context<ExplorerPane>,
 ) -> AnyElement {
     let items = page.filtered_entries.clone();
     let mut grid = div()
@@ -36,12 +36,12 @@ pub fn render(
 }
 
 fn render_grid_item(
-    _page: &mut ExplorerPage,
+    _page: &mut ExplorerPane,
     item: FileEntryDto,
     ix: usize,
     selected: bool,
     _window: &mut Window,
-    cx: &mut Context<ExplorerPage>,
+    cx: &mut Context<ExplorerPane>,
 ) -> AnyElement {
     use nohrs_ui::components::file_list::{format_date, get_file_type, human_bytes};
 

--- a/crates/nohrs-pages/src/explorer/view/listing/list.rs
+++ b/crates/nohrs-pages/src/explorer/view/listing/list.rs
@@ -1,6 +1,6 @@
 use super::row;
 use crate::explorer::types::SortKey;
-use crate::explorer::ExplorerPage;
+use crate::explorer::ExplorerPane;
 use gpui::prelude::*;
 use gpui::*;
 use gpui_component::{v_virtual_list, ListItem};
@@ -8,7 +8,7 @@ use nohrs_ui::theme::theme;
 use std::rc::Rc;
 
 /// Renders the file listing as a virtualized multi-column table.
-pub fn render(page: &mut ExplorerPage, cx: &mut Context<ExplorerPage>) -> AnyElement {
+pub fn render(page: &mut ExplorerPane, cx: &mut Context<ExplorerPane>) -> AnyElement {
     let table_width = page.total_table_width();
     let col_name = page.col_name_width;
     let col_type = page.col_type_width;
@@ -39,14 +39,14 @@ pub fn render(page: &mut ExplorerPage, cx: &mut Context<ExplorerPage>) -> AnyEle
 // them into a struct would not improve clarity here.
 #[allow(clippy::too_many_arguments)]
 fn render_table_with_header(
-    page: &mut ExplorerPage,
+    page: &mut ExplorerPane,
     table_width: f32,
     col_name: f32,
     col_type: f32,
     col_size: f32,
     col_modified: f32,
     col_action: f32,
-    cx: &mut Context<ExplorerPage>,
+    cx: &mut Context<ExplorerPane>,
 ) -> impl IntoElement {
     let entity = cx.entity().clone();
 
@@ -93,14 +93,14 @@ fn render_table_with_header(
 
 #[allow(clippy::too_many_arguments)]
 fn render_header_row(
-    page: &ExplorerPage,
+    page: &ExplorerPane,
     table_width: f32,
     col_name: f32,
     col_type: f32,
     col_size: f32,
     col_modified: f32,
     col_action: f32,
-    cx: &mut Context<ExplorerPage>,
+    cx: &mut Context<ExplorerPane>,
 ) -> impl IntoElement {
     div()
         .w(px(table_width))
@@ -152,22 +152,22 @@ fn render_header_row(
 }
 
 fn render_resizable_column_header(
-    page: &ExplorerPage,
+    page: &ExplorerPane,
     label: &str,
     key: SortKey,
     column_index: usize,
     width: f32,
-    cx: &mut Context<ExplorerPage>,
+    cx: &mut Context<ExplorerPane>,
 ) -> impl IntoElement {
     // We need to call page methods like start_column_resize which take &mut self.
-    // But `v_virtual_list` closure gives `view` (&mut ExplorerPage), so `page` here could be &mut?
+    // But `v_virtual_list` closure gives `view` (&mut ExplorerPane), so `page` here could be &mut?
     // In `render_table_with_header` closure, `view` is passed to `render_header_row`.
-    // So `page` is &mut ExplorerPage.
-    // I should change signature to &mut ExplorerPage if needed.
+    // So `page` is &mut ExplorerPane.
+    // I should change signature to &mut ExplorerPane if needed.
     // But `start_column_resize` is called in event handler which takes `this` (mut).
     // The `page` argument is used to bind listener.
     // So `page` doesn't need to be mut here, the lambda captures things?
-    // Wait, `cx.listener` callback receives `this: &mut V` (ExplorerPage).
+    // Wait, `cx.listener` callback receives `this: &mut V` (ExplorerPane).
     // So `page` is just used for rendering state (width etc).
     // `render_resizable_column_header` logic:
     // ... .child(render_column_header(...))
@@ -205,12 +205,12 @@ fn render_resizable_column_header(
 }
 
 fn render_column_header(
-    page: &ExplorerPage,
+    page: &ExplorerPane,
     label: &str,
     key: SortKey,
     key_idx: usize,
     flex: bool,
-    cx: &mut Context<ExplorerPage>,
+    cx: &mut Context<ExplorerPane>,
 ) -> gpui::Div {
     let is_active = page.sort_key == key;
     let label_str = label.to_string();

--- a/crates/nohrs-pages/src/explorer/view/listing/row.rs
+++ b/crates/nohrs-pages/src/explorer/view/listing/row.rs
@@ -1,6 +1,6 @@
 use super::truncate_middle;
 
-use crate::explorer::ExplorerPage;
+use crate::explorer::ExplorerPane;
 use gpui::prelude::*;
 use gpui::*;
 use gpui_component::{Icon, IconName, ListItem};
@@ -9,10 +9,10 @@ use nohrs_ui::theme::theme;
 
 /// Renders a single listing row for the given entry at row index `ix`.
 pub fn render(
-    page: &ExplorerPage,
+    page: &ExplorerPane,
     item: &FileEntryDto,
     ix: usize,
-    cx: &mut Context<ExplorerPage>,
+    cx: &mut Context<ExplorerPane>,
 ) -> impl IntoElement {
     use nohrs_ui::components::file_list::{format_date, get_file_type, human_bytes};
 
@@ -93,7 +93,7 @@ pub fn render(
 
     // ... rendering ...
     // Note: page.total_table_width() method is needed.
-    // I need to make `total_table_width` pub on ExplorerPage. I did make fields pub, but method?
+    // I need to make `total_table_width` pub on ExplorerPane. I did make fields pub, but method?
     // I should check if `total_table_width` is a method. Yes (line 347 in original).
     // I need to ensure that method is `pub` or copy logic.
     // Copying logic is safer: `page.col_name_width + ...`.

--- a/crates/nohrs-pages/src/explorer/view/listing/search_bar.rs
+++ b/crates/nohrs-pages/src/explorer/view/listing/search_bar.rs
@@ -1,5 +1,5 @@
 use crate::explorer::types::SearchType;
-use crate::explorer::ExplorerPage;
+use crate::explorer::ExplorerPane;
 use gpui::prelude::*;
 use gpui::*;
 use gpui_component::input::TextInput;
@@ -8,7 +8,7 @@ use nohrs_services::search::SearchScope;
 use nohrs_ui::theme::theme;
 
 /// Renders the search bar with the query input and search option toggles.
-pub fn render(page: &mut ExplorerPage, cx: &mut Context<ExplorerPage>) -> impl IntoElement {
+pub fn render(page: &mut ExplorerPane, cx: &mut Context<ExplorerPane>) -> impl IntoElement {
     let current_text = page.search_input.read(cx).text().to_string();
     if current_text != page.search_query {
         page.search_query = current_text;
@@ -206,10 +206,10 @@ pub fn render(page: &mut ExplorerPage, cx: &mut Context<ExplorerPage>) -> impl I
 }
 
 fn render_scope_button(
-    page: &ExplorerPage,
+    page: &ExplorerPane,
     scope: SearchScope,
     label: &str,
-    cx: &mut Context<ExplorerPage>,
+    cx: &mut Context<ExplorerPane>,
 ) -> impl IntoElement {
     let is_active = page.search_scope == scope;
     div()
@@ -232,10 +232,10 @@ fn render_scope_button(
 }
 
 fn render_type_button(
-    page: &ExplorerPage,
+    page: &ExplorerPane,
     search_type: SearchType,
     label: &str,
-    cx: &mut Context<ExplorerPage>,
+    cx: &mut Context<ExplorerPane>,
 ) -> impl IntoElement {
     let is_active = page.search_type == search_type;
     div()
@@ -261,8 +261,8 @@ fn render_type_button(
 fn render_toggle_button(
     label: &str,
     active: bool,
-    on_click: impl Fn(&mut ExplorerPage, &mut Context<ExplorerPage>) + 'static + Copy,
-    cx: &mut Context<ExplorerPage>,
+    on_click: impl Fn(&mut ExplorerPane, &mut Context<ExplorerPane>) + 'static + Copy,
+    cx: &mut Context<ExplorerPane>,
 ) -> impl IntoElement {
     div()
         .cursor_pointer()

--- a/crates/nohrs-pages/src/explorer/view/preview.rs
+++ b/crates/nohrs-pages/src/explorer/view/preview.rs
@@ -1,4 +1,4 @@
-use crate::explorer::ExplorerPage;
+use crate::explorer::ExplorerPane;
 use gpui::prelude::*;
 use gpui::*;
 use nohrs_ui::theme::theme;
@@ -6,7 +6,7 @@ use nohrs_ui::theme::theme;
 // Calculate the maximum line width in characters for horizontal scroll sizing
 /// Renders the preview pane for the selected file, showing a text editor,
 /// image, status message, or an empty placeholder.
-pub fn render(page: &mut ExplorerPage, _window: &mut Window) -> impl IntoElement {
+pub fn render(page: &mut ExplorerPane, _window: &mut Window) -> impl IntoElement {
     let title = page
         .preview_path
         .as_ref()

--- a/crates/nohrs-pages/src/explorer/view/sidebar.rs
+++ b/crates/nohrs-pages/src/explorer/view/sidebar.rs
@@ -1,4 +1,4 @@
-use crate::explorer::ExplorerPage;
+use crate::explorer::ExplorerPane;
 use gpui::prelude::*;
 use gpui::*;
 use gpui_component::{Icon, IconName, ListItem};
@@ -6,9 +6,9 @@ use nohrs_ui::theme::theme; // Assuming theme is accessible
 
 /// Renders the explorer sidebar listing quick-access locations.
 pub fn render(
-    page: &mut ExplorerPage,
+    page: &mut ExplorerPane,
     _window: &mut Window,
-    cx: &mut Context<ExplorerPage>,
+    cx: &mut Context<ExplorerPane>,
 ) -> impl IntoElement {
     div()
         .size_full()
@@ -61,7 +61,7 @@ fn sidebar_item(icon: IconName, label: &str, _active: bool) -> impl IntoElement 
         .child(div().text_sm().text_color(rgb(theme::FG)).child(label))
 }
 
-fn render_shortcuts(_page: &mut ExplorerPage, cx: &mut Context<ExplorerPage>) -> impl IntoElement {
+fn render_shortcuts(_page: &mut ExplorerPane, cx: &mut Context<ExplorerPane>) -> impl IntoElement {
     let shortcuts = get_shortcuts();
     let mut shortcuts_el = div().flex().flex_col().gap_1().px(px(8.0));
 

--- a/crates/nohrs-pages/src/root.rs
+++ b/crates/nohrs-pages/src/root.rs
@@ -15,7 +15,6 @@ use gpui::{
     div, prelude::*, px, rgb, AnyElement, App, AsyncWindowContext, Context, Entity, FocusHandle,
     Focusable, InteractiveElement, Render, WeakEntity, Window,
 };
-use gpui_component::input::InputState;
 use gpui_component::resizable::ResizableState;
 use gpui_component::{Icon, Root, Theme, ThemeMode as GpuiThemeMode};
 use nohrs_core::config::{self, Config, ConfigOverride, ConfigWatcher};
@@ -75,17 +74,10 @@ impl RootView {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
-        let search_input = cx.new(|cx| InputState::new(window, cx));
         let focus_handle = cx.focus_handle();
 
-        let explorer = cx.new(|cx| {
-            ExplorerPage::new(
-                resizable,
-                search_input.clone(),
-                search_service.clone(),
-                cx.focus_handle(),
-            )
-        });
+        let explorer =
+            cx.new(|cx| ExplorerPage::new(resizable, search_service.clone(), window, cx));
         let git = cx.new(|_cx| GitPage::new());
         let s3 = cx.new(|_cx| S3Page::new());
         let extensions = cx.new(|_cx| ExtensionsPage::new());
@@ -143,8 +135,11 @@ impl RootView {
         });
 
         let ui = config.ui.clone();
-        self.explorer
-            .update(cx, |page, cx| page.apply_config_ui(&ui, cx));
+        let explorer_cfg = config.explorer.clone();
+        self.explorer.update(cx, |page, cx| {
+            page.apply_config_ui(&ui, cx);
+            page.apply_config_explorer(&explorer_cfg, cx);
+        });
 
         self.config = config;
         cx.notify();
@@ -302,7 +297,7 @@ impl Render for RootView {
                     // transient status and is always shown as an error.
                     let (status_message, status_is_error) = match &self.config_status {
                         Some(message) => (Some(message.clone()), true),
-                        None => match self.explorer.read(cx).status_for_footer() {
+                        None => match self.explorer.read(cx).status_for_footer(cx) {
                             Some((text, is_error)) => (Some(text), is_error),
                             None => (None, false),
                         },

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -37,6 +37,24 @@
       ],
       "type": "object"
     },
+    "Explorer": {
+      "description": "Split-view and pane settings (see `docs/explorer-essentials.md` §3).",
+      "properties": {
+        "split_direction": {
+          "$ref": "#/$defs/SplitDirection",
+          "description": "Orientation a fresh split uses unless overridden by the split shortcut."
+        },
+        "synced_panes": {
+          "description": "When enabled, navigating in one pane mirrors the path into the others.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "split_direction",
+        "synced_panes"
+      ],
+      "type": "object"
+    },
     "SortOrder": {
       "description": "The column a directory listing is ordered by.",
       "oneOf": [
@@ -58,6 +76,21 @@
         {
           "const": "kind",
           "description": "Sort by entry kind (file/directory/...).",
+          "type": "string"
+        }
+      ]
+    },
+    "SplitDirection": {
+      "description": "How a 2-way split arranges its panes.",
+      "oneOf": [
+        {
+          "const": "vertical",
+          "description": "Panes side by side, separated by a vertical divider (`Cmd+\\`).",
+          "type": "string"
+        },
+        {
+          "const": "horizontal",
+          "description": "Panes stacked, separated by a horizontal divider (`Cmd+Shift+\\`).",
           "type": "string"
         }
       ]
@@ -131,6 +164,10 @@
       "$ref": "#/$defs/Diagnostics",
       "description": "Diagnostics / performance-logging settings."
     },
+    "explorer": {
+      "$ref": "#/$defs/Explorer",
+      "description": "Split-view and pane settings."
+    },
     "schema_version": {
       "description": "On-disk schema version. Must be [`CURRENT_SCHEMA_VERSION`] for this build.",
       "minimum": 0,
@@ -149,6 +186,7 @@
     "schema_version",
     "theme",
     "ui",
+    "explorer",
     "diagnostics"
   ],
   "title": "Config",


### PR DESCRIPTION
Implements the 2-way split view from `docs/explorer-essentials.md` §3 (issue #61).

## What changed

The explorer is now two types:

- **`ExplorerPane`** (`explorer/state.rs`, the former monolithic `ExplorerPage`) — one independently-navigating directory view: cwd, history, search, preview. Emits `PaneEvent::Navigated` on directory change.
- **`ExplorerPage`** (`explorer/page.rs`, new) — the split container `RootView` holds. Owns `Vec<Entity<ExplorerPane>>` (2-way cap), active index, split direction, and sync.

### Layout (§3.1)
- 2-way cap (left/right or top/bottom).
- Vertical split `Cmd/Ctrl+\`, horizontal split `Cmd/Ctrl+Shift+\`; pressing the opposite shortcut re-orients an existing split.
- Default orientation from a new `[explorer] split_direction` config key.
- Pane-close `×` in the tab bar; the last pane can never be closed.

### Navigation (§3.2)
- Independent navigation per pane by default.
- `Cmd/Ctrl+1`/`2` focus a pane directly; `Cmd/Ctrl+[`/`]` cycle; clicking a pane activates it.
- Opt-in `[explorer] synced_panes = true` mirrors paths across panes (via pane navigation events).
- In-pane `Cmd+F` search is scoped to the focused pane's directory by construction.

### Tabs (§3.3)
- Pane-local tab-bar foundation (current-dir tab + `+` placeholder); full tabs are tracked in #62.

### Config
- New `[explorer]` section (`split_direction`, `synced_panes`) with lenient parsing, default template, and regenerated `docs/config.schema.json`.

### Cross-platform shortcut note
On Linux, `Shift+\` resolves to the `|` keysym and gpui drops the shift modifier for symbols, so the horizontal-split shortcut is bound under every spelling (`*-shift-\`, `*-|`, `*-shift-|`).

## Verification

`cargo fmt` / `cargo clippy --all-targets -- -D warnings` / `cargo build` / `cargo test` all pass (89 tests: 48 `nohrs-core` + 41 `nohrs-pages`, including 6 new split-container tests covering split/reorient, close-keeps-one, active-bounds, independent navigation, and synced mirroring).

Manually verified in the GUI:

| Single pane (tab-bar foundation) | Vertical split |
| --- | --- |
| ![single](https://raw.githubusercontent.com/noh-rs/nohrs/pr-assets/screenshots/explorer-split-view/3641916-284/explorer_single.png) | ![vertical](https://raw.githubusercontent.com/noh-rs/nohrs/pr-assets/screenshots/explorer-split-view/3641916-284/explorer_split_v.png) |

| Independent navigation (left in `crates/`, right at root) | Horizontal split |
| --- | --- |
| ![independent](https://raw.githubusercontent.com/noh-rs/nohrs/pr-assets/screenshots/explorer-split-view/3641916-284/explorer_independent.png) | ![horizontal](https://raw.githubusercontent.com/noh-rs/nohrs/pr-assets/screenshots/explorer-split-view/3641916-284/explorer_split_h.png) |

## Notes / out of scope

Cross-pane DnD (mentioned in the issue's completion criteria) is tracked separately in #59; this split view provides the pane structure it builds on.

Release Notes:

- Added a 2-way split view to the explorer with independent per-pane navigation, horizontal/vertical layouts, and keyboard shortcuts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a 2-way split view to the explorer so you can view two panes side by side or stacked, navigate them independently, and switch focus with shortcuts. Implements the split-view requirements from issue #61; new panes inherit applied `[ui]` config, and enabling synced navigation mirrors paths immediately and clears stale search state.

- **New Features**
  - 2-way split: vertical (Cmd/Ctrl+\) or horizontal (Cmd/Ctrl+Shift+\); pressing the other shortcut flips orientation.
  - Per-pane focus: Cmd/Ctrl+1 or 2, Cmd/Ctrl+[ or ]; click to activate.
  - Independent navigation per pane; optional synced navigation mirrors paths across panes (turning it on mirrors the active path right away).
  - Pane-local tab bar foundation with a close button; at least one pane stays open.
  - Refactor: `ExplorerPage` is now a split container over one or two `ExplorerPane`s.
  - New `[explorer]` config: `split_direction = "vertical" | "horizontal"`, `synced_panes = bool` (defaults: vertical/false).

- **Bug Fixes**
  - Panes opened by a split inherit applied `[ui]` settings (sort, hidden files, icons).
  - Synced navigation clears stale search/filter state on mirrored panes.

<sup>Written for commit ef927520dc6cec0defcaa5fff28b05e235421fa1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/noh-rs/nohrs/pull/163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Split-view explorer UI with resizable panes, per-pane tabs, configurable split direction, and optional synchronized navigation
  * New explorer configuration section ([explorer]) with split_direction and synced_panes
* **Refactor**
  * Explorer reorganized into page/pane separation; many behaviors moved to per-pane implementations
* **Documentation**
  * Config schema updated to include explorer settings
* **Tests**
  * Added tests for pane semantics, syncing, and config parsing (including lenient warnings)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->