### PR TITLE
Generalize the split view and add a collapsible explorer sidebar

### DIFF
--- a/crates/nohrs-pages/src/explorer/page.rs
+++ b/crates/nohrs-pages/src/explorer/page.rs
@@ -141,8 +141,8 @@ impl ExplorerPage {
         cwd: Option<String>,
         window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> usize {
-        let (index, pane) = self.group.add_pane(window, cx);
+    ) -> Option<usize> {
+        let (index, pane) = self.group.add_pane(window, cx)?;
         let subscription = cx.subscribe(&pane, Self::on_pane_event);
         self.pane_subscriptions.push(subscription);
         // Replay the active `[ui]` config so a pane opened by a split inherits the
@@ -158,7 +158,7 @@ impl ExplorerPage {
                 pane.loaded = false;
             }
         });
-        index
+        Some(index)
     }
 
     // Mirrors a pane's navigation into its siblings while syncing is enabled.
@@ -202,8 +202,9 @@ impl ExplorerPage {
         self.group.set_direction(direction);
         if self.group.pane_count() < 2 {
             let cwd = self.group.active_pane().read(cx).cwd.clone();
-            let index = self.add_explorer_pane(Some(cwd), window, cx);
-            self.group.set_active(index, window, cx);
+            if let Some(index) = self.add_explorer_pane(Some(cwd), window, cx) {
+                self.group.set_active(index, window, cx);
+            }
         } else {
             self.group.focus_active(window, cx);
         }

--- a/crates/nohrs-pages/src/explorer/page.rs
+++ b/crates/nohrs-pages/src/explorer/page.rs
@@ -9,16 +9,15 @@
 
 use std::sync::{Arc, Once};
 
-use gpui::prelude::FluentBuilder;
 use gpui::*;
-use gpui_component::resizable::{h_resizable, resizable_panel, v_resizable, ResizableState};
-use gpui_component::{Icon, IconName};
+use gpui_component::resizable::ResizableState;
 use nohrs_core::config::{Explorer as ExplorerConfig, SplitDirection, Ui};
 use nohrs_services::search::SearchService;
 use nohrs_ui::theme::theme;
 
 use super::state::ExplorerPane;
 use super::types::PaneEvent;
+use crate::pane_group::PaneGroup;
 
 // Key context the pane shortcuts are bound under, so they only fire while the
 // explorer (and not another page) is focused.
@@ -73,23 +72,22 @@ fn bind_pane_keys(cx: &mut App) {
 
 /// The explorer page: a 2-way split container over independently-navigating
 /// panes. With a single pane it renders exactly like an unsplit explorer.
+///
+/// The split/tab/resize machinery lives in the content-agnostic [`PaneGroup`];
+/// `ExplorerPage` adds the explorer-specific layer on top: replaying `[ui]`
+/// config onto new panes and mirroring navigation across panes when
+/// `synced_panes` is enabled (§3.2). It keeps a per-pane subscription Vec
+/// index-aligned with `group.panes()` by funneling every create/remove through
+/// `add_explorer_pane` / `close_pane`.
 pub struct ExplorerPage {
-    // Invariant: always non-empty and at most two entries (2-way cap, §3.1).
-    panes: Vec<Entity<ExplorerPane>>,
-    // Subscriptions for pane navigation events, index-aligned with `panes`.
+    group: PaneGroup<ExplorerPane>,
+    // Subscriptions for pane navigation events, index-aligned with `group.panes()`.
     pane_subscriptions: Vec<Subscription>,
-    /// Index of the pane keyboard input and shortcuts act on.
-    active: usize,
-    /// Orientation a split uses; seeded from config, toggled by the shortcuts.
-    direction: SplitDirection,
     /// Whether navigation in one pane mirrors into the others (§3.2).
     synced_panes: bool,
     // Last-applied `[ui]` settings, replayed onto panes opened by a later split
     // so they match config rather than reverting to pane defaults.
     ui: Ui,
-    // Resizable state for the divider between the two panes.
-    pane_resizable: Entity<ResizableState>,
-    search_service: Option<Arc<SearchService>>,
     focus_handle: FocusHandle,
 }
 
@@ -110,46 +108,57 @@ impl ExplorerPage {
         cx: &mut Context<Self>,
     ) -> Self {
         bind_pane_keys(cx);
+        let build_search_service = search_service.clone();
+        let (group, first_pane) = PaneGroup::new(
+            Box::new(move |window, cx| {
+                let search_service = build_search_service.clone();
+                cx.new(|cx| ExplorerPane::build(search_service, window, cx))
+            }),
+            pane_resizable,
+            window,
+            cx,
+        );
         let mut page = Self {
-            panes: Vec::new(),
+            group,
             pane_subscriptions: Vec::new(),
-            active: 0,
-            direction: SplitDirection::default(),
             synced_panes: false,
             ui: Ui::default(),
-            pane_resizable,
-            search_service,
             focus_handle: cx.focus_handle(),
         };
-        page.add_pane(None, window, cx);
+        let subscription = cx.subscribe(&first_pane, Self::on_pane_event);
+        page.pane_subscriptions.push(subscription);
+        // The root pane shows its sidebar; panes opened by a later split default
+        // to hidden (issue #164, §2).
+        first_pane.update(cx, |pane, _cx| pane.sidebar_visible = true);
         page
     }
 
-    // Creates a pane (optionally rooted at `cwd`), subscribes to its navigation
-    // events, and appends it. Returns the new pane's index.
-    fn add_pane(
+    // Creates a pane (optionally rooted at `cwd`) through the group, subscribes to
+    // its navigation events keeping `pane_subscriptions` index-aligned, and
+    // replays the active `[ui]` config. Returns the new pane's index.
+    fn add_explorer_pane(
         &mut self,
         cwd: Option<String>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> usize {
-        let search_service = self.search_service.clone();
-        let pane = cx.new(|cx| ExplorerPane::build(search_service, window, cx));
+        let (index, pane) = self.group.add_pane(window, cx);
+        let subscription = cx.subscribe(&pane, Self::on_pane_event);
+        self.pane_subscriptions.push(subscription);
         // Replay the active `[ui]` config so a pane opened by a split inherits the
         // user's sort/hidden/icon settings instead of reverting to pane defaults.
         let ui = self.ui.clone();
         pane.update(cx, |pane, cx| {
             pane.apply_config_ui(&ui, cx);
+            // Split-created panes start with the sidebar collapsed (issue #164).
+            pane.sidebar_visible = false;
             if let Some(cwd) = cwd {
                 pane.cwd = cwd;
                 // Force a reload of the new root on the next render.
                 pane.loaded = false;
             }
         });
-        let subscription = cx.subscribe(&pane, Self::on_pane_event);
-        self.panes.push(pane);
-        self.pane_subscriptions.push(subscription);
-        self.panes.len() - 1
+        index
     }
 
     // Mirrors a pane's navigation into its siblings while syncing is enabled.
@@ -164,7 +173,8 @@ impl ExplorerPage {
         }
         let PaneEvent::Navigated(path) = event;
         let targets: Vec<Entity<ExplorerPane>> = self
-            .panes
+            .group
+            .panes()
             .iter()
             .filter(|pane| pane.entity_id() != source.entity_id())
             .cloned()
@@ -189,71 +199,50 @@ impl ExplorerPage {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.direction = direction;
-        if self.panes.len() < 2 {
-            let cwd = self.active_pane().read(cx).cwd.clone();
-            let index = self.add_pane(Some(cwd), window, cx);
-            self.active = index;
+        self.group.set_direction(direction);
+        if self.group.pane_count() < 2 {
+            let cwd = self.group.active_pane().read(cx).cwd.clone();
+            let index = self.add_explorer_pane(Some(cwd), window, cx);
+            self.group.set_active(index, window, cx);
+        } else {
+            self.group.focus_active(window, cx);
         }
-        self.focus_active(window, cx);
         cx.notify();
     }
 
     /// Closes a pane, keeping at least one open (§3.1). No-op for the last pane.
     pub fn close_pane(&mut self, index: usize, window: &mut Window, cx: &mut Context<Self>) {
-        if self.panes.len() <= 1 || index >= self.panes.len() {
-            return;
+        if self.group.remove_pane(index, window, cx) {
+            // Dropping the subscription deregisters the removed pane's event
+            // handler; removing at the same index keeps the Vecs aligned.
+            drop(self.pane_subscriptions.remove(index));
+            cx.notify();
         }
-        self.panes.remove(index);
-        // Dropping the subscription deregisters the removed pane's event handler.
-        drop(self.pane_subscriptions.remove(index));
-        if self.active >= self.panes.len() {
-            self.active = self.panes.len() - 1;
-        }
-        self.focus_active(window, cx);
-        cx.notify();
     }
 
     /// Makes `index` the active pane and moves keyboard focus to it.
     pub fn set_active(&mut self, index: usize, window: &mut Window, cx: &mut Context<Self>) {
-        if index >= self.panes.len() || index == self.active {
-            return;
+        if self.group.set_active(index, window, cx) {
+            cx.notify();
         }
-        self.active = index;
-        self.focus_active(window, cx);
-        cx.notify();
     }
 
     fn focus_next(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        if self.panes.len() < 2 {
-            return;
+        if self.group.focus_next(window, cx) {
+            cx.notify();
         }
-        self.set_active((self.active + 1) % self.panes.len(), window, cx);
     }
 
     fn focus_prev(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        if self.panes.len() < 2 {
-            return;
+        if self.group.focus_prev(window, cx) {
+            cx.notify();
         }
-        let count = self.panes.len();
-        self.set_active((self.active + count - 1) % count, window, cx);
-    }
-
-    fn active_pane(&self) -> &Entity<ExplorerPane> {
-        // `active` is kept in bounds by every mutator; fall back to the first
-        // pane rather than panicking should that invariant ever be violated.
-        self.panes.get(self.active).unwrap_or(&self.panes[0])
-    }
-
-    fn focus_active(&self, window: &mut Window, cx: &mut Context<Self>) {
-        let handle = self.active_pane().read(cx).focus_handle.clone();
-        handle.focus(window);
     }
 
     /// Applies the `[ui]` config section to every pane (§5 of `config.md`).
     pub fn apply_config_ui(&mut self, ui: &Ui, cx: &mut Context<Self>) {
         self.ui = ui.clone();
-        for pane in self.panes.clone() {
+        for pane in self.group.panes().to_vec() {
             pane.update(cx, |pane, cx| pane.apply_config_ui(ui, cx));
         }
     }
@@ -264,15 +253,15 @@ impl ExplorerPage {
     pub fn apply_config_explorer(&mut self, explorer: &ExplorerConfig, cx: &mut Context<Self>) {
         // Only adopt the configured orientation while unsplit, so a config reload
         // does not silently flip a split the user arranged via the shortcuts.
-        if self.panes.len() < 2 {
-            self.direction = explorer.split_direction;
+        if self.group.pane_count() < 2 {
+            self.group.set_direction(explorer.split_direction);
         }
         let enabling = explorer.synced_panes && !self.synced_panes;
         self.synced_panes = explorer.synced_panes;
         if enabling {
-            let path = self.active_pane().read(cx).cwd.clone();
-            let active_id = self.active_pane().entity_id();
-            for pane in self.panes.clone() {
+            let path = self.group.active_pane().read(cx).cwd.clone();
+            let active_id = self.group.active_pane().entity_id();
+            for pane in self.group.panes().to_vec() {
                 if pane.entity_id() != active_id {
                     let path = path.clone();
                     pane.update(cx, |pane, cx| pane.navigate_to_synced(path, cx));
@@ -285,136 +274,17 @@ impl ExplorerPage {
     /// Footer status for the active pane (a config error in `RootView` still
     /// takes precedence over this).
     pub fn status_for_footer(&self, cx: &App) -> Option<(String, bool)> {
-        self.active_pane().read(cx).status_for_footer()
-    }
-
-    fn render_pane(&mut self, index: usize, cx: &mut Context<Self>) -> AnyElement {
-        let pane = self.panes[index].clone();
-        let split = self.panes.len() > 1;
-        let is_active = split && index == self.active;
-        div()
-            .flex()
-            .flex_col()
-            .size_full()
-            .min_w(px(0.0))
-            .min_h(px(0.0))
-            .when(is_active, |this| {
-                this.border_t_2().border_color(rgb(theme::ACCENT))
-            })
-            .when(split && !is_active, |this| {
-                this.border_t_2().border_color(rgb(theme::BG))
-            })
-            // Clicking anywhere in a pane makes it the active one.
-            .on_mouse_down(
-                MouseButton::Left,
-                cx.listener(move |this, _event, window, cx| this.set_active(index, window, cx)),
-            )
-            .child(self.render_tab_bar(index, split, cx))
-            .child(div().flex_1().min_h(px(0.0)).overflow_hidden().child(pane))
-            .into_any_element()
-    }
-
-    // The pane-local tab bar: foundation for per-pane tabs (§3.3, full tabs in
-    // #62). For now it shows the current directory as a single tab plus the
-    // pane-close button, which only appears once a split exists.
-    fn render_tab_bar(
-        &self,
-        index: usize,
-        split: bool,
-        cx: &mut Context<Self>,
-    ) -> impl IntoElement {
-        let cwd = self.panes[index].read(cx).cwd.clone();
-        let label = std::path::Path::new(&cwd)
-            .file_name()
-            .map(|name| name.to_string_lossy().to_string())
-            .unwrap_or(cwd);
-        let is_active = split && index == self.active;
-
-        div()
-            .flex()
-            .flex_row()
-            .items_center()
-            .h(px(32.0))
-            .w_full()
-            .px(px(6.0))
-            .gap(px(4.0))
-            .bg(rgb(theme::TOOLBAR_BG))
-            .border_b_1()
-            .border_color(rgb(theme::BORDER))
-            .child(
-                div()
-                    .flex()
-                    .items_center()
-                    .h(px(24.0))
-                    .px(px(10.0))
-                    .rounded(px(6.0))
-                    .text_sm()
-                    .when(is_active, |this| {
-                        this.bg(rgb(theme::TOOLBAR_ACTIVE_BG))
-                            .text_color(rgb(theme::TOOLBAR_ACTIVE_TEXT))
-                    })
-                    .when(!is_active, |this| this.text_color(rgb(theme::TOOLBAR_TEXT)))
-                    .child(label),
-            )
-            // Placeholder for the new-tab affordance fleshed out in #62.
-            .child(
-                div()
-                    .flex()
-                    .items_center()
-                    .justify_center()
-                    .size(px(20.0))
-                    .rounded(px(4.0))
-                    .child(
-                        Icon::new(IconName::Plus)
-                            .size_4()
-                            .text_color(rgb(theme::MUTED)),
-                    ),
-            )
-            .child(div().flex_grow())
-            .when(split, |this| {
-                this.child(
-                    div()
-                        .id(("close-pane", index))
-                        .flex()
-                        .items_center()
-                        .justify_center()
-                        .size(px(22.0))
-                        .rounded(px(4.0))
-                        .cursor_pointer()
-                        .hover(|style| style.bg(rgb(theme::TOOLBAR_HOVER)))
-                        .on_click(cx.listener(move |this, _event, window, cx| {
-                            this.close_pane(index, window, cx);
-                        }))
-                        .child(
-                            Icon::new(IconName::Close)
-                                .size_4()
-                                .text_color(rgb(theme::TOOLBAR_TEXT)),
-                        ),
-                )
-            })
+        self.group.active_pane().read(cx).status_for_footer()
     }
 }
 
 impl Render for ExplorerPage {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let body = if self.panes.len() > 1 {
-            let first = self.render_pane(0, cx);
-            let second = self.render_pane(1, cx);
-            let group = match self.direction {
-                SplitDirection::Vertical => {
-                    h_resizable("explorer-panes", self.pane_resizable.clone())
-                }
-                SplitDirection::Horizontal => {
-                    v_resizable("explorer-panes", self.pane_resizable.clone())
-                }
-            };
-            group
-                .child(resizable_panel().child(first))
-                .child(resizable_panel().child(second))
-                .into_any_element()
-        } else {
-            self.render_pane(0, cx)
-        };
+        let body = self.group.render(
+            cx,
+            |this, index, window, cx| this.set_active(index, window, cx),
+            |this, index, window, cx| this.close_pane(index, window, cx),
+        );
 
         div()
             .size_full()
@@ -454,15 +324,15 @@ impl crate::Page for ExplorerPage {
 #[cfg(test)]
 impl ExplorerPage {
     pub(crate) fn pane_count(&self) -> usize {
-        self.panes.len()
+        self.group.pane_count()
     }
 
     pub(crate) fn active_index(&self) -> usize {
-        self.active
+        self.group.active()
     }
 
     pub(crate) fn direction(&self) -> SplitDirection {
-        self.direction
+        self.group.direction()
     }
 
     pub(crate) fn is_synced(&self) -> bool {
@@ -470,10 +340,21 @@ impl ExplorerPage {
     }
 
     pub(crate) fn pane(&self, index: usize) -> Entity<ExplorerPane> {
-        self.panes[index].clone()
+        self.group
+            .pane(index)
+            .expect("test requested an out-of-range pane")
     }
 
     pub(crate) fn pane_cwd(&self, index: usize, cx: &App) -> Option<String> {
-        self.panes.get(index).map(|pane| pane.read(cx).cwd.clone())
+        self.group
+            .panes()
+            .get(index)
+            .map(|pane| pane.read(cx).cwd.clone())
+    }
+
+    /// Number of live per-pane subscriptions; used to assert the subscription Vec
+    /// stays aligned with the pane Vec across splits/closes.
+    pub(crate) fn subscription_count(&self) -> usize {
+        self.pane_subscriptions.len()
     }
 }

--- a/crates/nohrs-pages/src/explorer/state.rs
+++ b/crates/nohrs-pages/src/explorer/state.rs
@@ -87,6 +87,8 @@ pub struct ExplorerPane {
     pub last_click_info: Option<LastClickInfo>,
     /// Whether the listing is shown as a list or a grid.
     pub view_mode: ViewMode,
+    /// Whether the left quick-access sidebar is shown (toggled with `Cmd/Ctrl+B`).
+    pub sidebar_visible: bool,
 
     // Search
     /// The full-text search service, when available.
@@ -133,6 +135,15 @@ impl Focusable for ExplorerPane {
 }
 
 impl EventEmitter<PaneEvent> for ExplorerPane {}
+
+impl crate::pane_group::PaneItem for ExplorerPane {
+    fn tab_title(&self, _cx: &gpui::App) -> String {
+        std::path::Path::new(&self.cwd)
+            .file_name()
+            .map(|name| name.to_string_lossy().to_string())
+            .unwrap_or_else(|| self.cwd.clone())
+    }
+}
 
 impl ExplorerPane {
     /// Builds a self-contained pane, creating the window-bound sub-entities
@@ -190,6 +201,9 @@ impl ExplorerPane {
             focus_requested: false,
             last_click_info: None,
             view_mode: ViewMode::List,
+            // Hidden by default; the root pane is revealed by `ExplorerPage::new`,
+            // split-created panes stay collapsed (issue #164, §2).
+            sidebar_visible: false,
 
             // Search
             search_service,
@@ -219,6 +233,13 @@ impl ExplorerPane {
 
     pub(crate) fn clear_status(&mut self) {
         self.status_message = None;
+    }
+
+    /// Toggles the left quick-access sidebar (issue #164, §2). Mirrors the
+    /// `toggle_search` open/close pattern.
+    pub(crate) fn toggle_sidebar(&mut self, cx: &mut Context<Self>) {
+        self.sidebar_visible = !self.sidebar_visible;
+        cx.notify();
     }
 
     /// Returns the current status text and whether it represents an error, for

--- a/crates/nohrs-pages/src/explorer/tests.rs
+++ b/crates/nohrs-pages/src/explorer/tests.rs
@@ -572,3 +572,95 @@ async fn split_pane_inherits_applied_ui_config(cx: &mut TestAppContext) {
         })
         .unwrap();
 }
+
+#[gpui::test]
+async fn root_pane_shows_sidebar_but_split_pane_hides_it(cx: &mut TestAppContext) {
+    let window = new_explorer_page(cx);
+    window
+        .update(cx, |page, window, cx| {
+            assert!(
+                page.pane(0).read(cx).sidebar_visible,
+                "the root pane shows its sidebar by default (§2)"
+            );
+
+            page.split(SplitDirection::Vertical, window, cx);
+            assert!(
+                !page.pane(1).read(cx).sidebar_visible,
+                "a pane opened by a split starts with the sidebar collapsed"
+            );
+            assert!(
+                page.pane(0).read(cx).sidebar_visible,
+                "splitting does not disturb the original pane's sidebar"
+            );
+        })
+        .unwrap();
+}
+
+#[gpui::test]
+async fn toggle_sidebar_is_independent_per_pane(cx: &mut TestAppContext) {
+    let window = new_explorer_page(cx);
+    window
+        .update(cx, |page, window, cx| {
+            page.split(SplitDirection::Vertical, window, cx);
+            let pane0 = page.pane(0); // sidebar visible (root)
+            let pane1 = page.pane(1); // sidebar hidden (split)
+
+            pane1.update(cx, |pane, cx| pane.toggle_sidebar(cx));
+            assert!(pane1.read(cx).sidebar_visible, "pane 1 toggled on");
+            assert!(
+                pane0.read(cx).sidebar_visible,
+                "toggling pane 1 leaves pane 0 untouched"
+            );
+
+            pane0.update(cx, |pane, cx| pane.toggle_sidebar(cx));
+            assert!(!pane0.read(cx).sidebar_visible, "pane 0 toggled off");
+            assert!(pane1.read(cx).sidebar_visible, "pane 1 unchanged");
+        })
+        .unwrap();
+}
+
+#[gpui::test]
+async fn close_pane_keeps_subscriptions_aligned(cx: &mut TestAppContext) {
+    let dir = tempfile::tempdir().unwrap();
+    let shared = dir.path().join("shared");
+    std::fs::create_dir(&shared).unwrap();
+    let shared = shared.to_string_lossy().to_string();
+
+    let window = new_explorer_page(cx);
+    window
+        .update(cx, |page, window, cx| {
+            page.split(SplitDirection::Vertical, window, cx);
+            assert_eq!(page.pane_count(), 2);
+            assert_eq!(page.subscription_count(), 2, "one subscription per pane");
+
+            // Closing index 0 must drop the subscription at the same index so the
+            // Vec stays aligned with the surviving pane.
+            page.close_pane(0, window, cx);
+            assert_eq!(page.pane_count(), 1);
+            assert_eq!(page.subscription_count(), 1);
+
+            // Reuse the container: split again and enable sync. If the
+            // subscription Vec had desynced, the mirror below would target the
+            // wrong pane (or none).
+            page.split(SplitDirection::Vertical, window, cx);
+            assert_eq!(page.subscription_count(), 2);
+            let synced = config::Explorer {
+                split_direction: SplitDirection::Vertical,
+                synced_panes: true,
+            };
+            page.apply_config_explorer(&synced, cx);
+            page.pane(0)
+                .update(cx, |pane, cx| pane.change_dir(shared.clone(), window, cx));
+        })
+        .unwrap();
+    cx.run_until_parked();
+    window
+        .read_with(cx, |page, cx| {
+            assert_eq!(
+                page.pane_cwd(1, cx).as_deref(),
+                Some(shared.as_str()),
+                "the sibling still mirrors after a close/split cycle"
+            );
+        })
+        .unwrap();
+}

--- a/crates/nohrs-pages/src/explorer/view.rs
+++ b/crates/nohrs-pages/src/explorer/view.rs
@@ -1,4 +1,5 @@
 use crate::explorer::ExplorerPane;
+use gpui::prelude::FluentBuilder;
 use gpui::*;
 use nohrs_ui::theme::theme;
 
@@ -33,12 +34,17 @@ pub fn render(
         .track_focus(&page.focus_handle)
         .on_key_down(cx.listener(|this, event: &gpui::KeyDownEvent, window, cx| {
             let key_lc = event.keystroke.key.to_lowercase();
+            let with_modifier =
+                event.keystroke.modifiers.platform || event.keystroke.modifiers.control;
             let is_f = key_lc == "f" || event.keystroke.key == "KeyF";
-            let toggle_with_modifier =
-                is_f && (event.keystroke.modifiers.platform || event.keystroke.modifiers.control);
+            let is_b = key_lc == "b" || event.keystroke.key == "KeyB";
             let close_with_escape = key_lc == "escape" && this.search_visible;
-            if toggle_with_modifier || close_with_escape {
+            if (is_f && with_modifier) || close_with_escape {
                 this.toggle_search(window, cx);
+                cx.stop_propagation();
+            } else if is_b && with_modifier {
+                // Cmd/Ctrl+B toggles the left quick-access sidebar (issue #164).
+                this.toggle_sidebar(cx);
                 cx.stop_propagation();
             }
         }))
@@ -64,17 +70,24 @@ pub fn render(
             div().flex().flex_row().flex_grow().min_h(px(0.0)).child(
                 gpui_component::resizable::h_resizable("file-explorer", page.resizable.clone())
                     .child(
+                        // Keep the panel in the resizable's child list even when
+                        // hidden (toggle via `.visible`), so the persisted panel
+                        // sizes/indices stay stable; dropping the child outright
+                        // would make the listing inherit the sidebar's slot.
                         gpui_component::resizable::resizable_panel()
                             .size(px(180.0))
                             .size_range(px(180.0)..px(360.0))
-                            .child(
-                                div()
-                                    .size_full()
-                                    .overflow_hidden()
-                                    .border_r_1()
-                                    .border_color(rgb(theme::BORDER))
-                                    .child(sidebar::render(page, window, cx)),
-                            ),
+                            .visible(page.sidebar_visible)
+                            .when(page.sidebar_visible, |panel| {
+                                panel.child(
+                                    div()
+                                        .size_full()
+                                        .overflow_hidden()
+                                        .border_r_1()
+                                        .border_color(rgb(theme::BORDER))
+                                        .child(sidebar::render(page, window, cx)),
+                                )
+                            }),
                     )
                     .child(
                         gpui_component::resizable::resizable_panel().child(

--- a/crates/nohrs-pages/src/nohrs_pages.rs
+++ b/crates/nohrs-pages/src/nohrs_pages.rs
@@ -10,6 +10,8 @@ pub mod explorer;
 pub mod extensions;
 /// The git page.
 pub mod git;
+/// A reusable 2-way split/tab container shared across pages.
+pub mod pane_group;
 /// The application root view that hosts the sidebar and active page.
 pub mod root;
 /// The S3 page.

--- a/crates/nohrs-pages/src/pane_group.rs
+++ b/crates/nohrs-pages/src/pane_group.rs
@@ -36,6 +36,10 @@ pub trait PaneItem: Render + Focusable + 'static {
 /// trait should not know about.
 type BuildPane<T> = Box<dyn Fn(&mut Window, &mut App) -> Entity<T>>;
 
+/// Maximum panes a group holds. The split is 2-way today (P2 cap); full N-way
+/// tabs are tracked in #62.
+const MAX_PANES: usize = 2;
+
 /// A 2-way split container over independently-rendered panes of type `T`.
 pub struct PaneGroup<T: PaneItem> {
     // Invariant: always non-empty and at most two entries (2-way cap).
@@ -69,13 +73,17 @@ impl<T: PaneItem> PaneGroup<T> {
         (group, first)
     }
 
-    /// Builds a pane and appends it. Returns its index and entity so the embedder
-    /// can subscribe to it and apply per-pane configuration. Does not change the
+    /// Builds a pane and appends it, enforcing the 2-way cap. Returns its index
+    /// and entity (or `None` when already at [`MAX_PANES`]) so the embedder can
+    /// subscribe to it and apply per-pane configuration. Does not change the
     /// active pane or notify; that is the embedder's responsibility.
-    pub fn add_pane(&mut self, window: &mut Window, cx: &mut App) -> (usize, Entity<T>) {
+    pub fn add_pane(&mut self, window: &mut Window, cx: &mut App) -> Option<(usize, Entity<T>)> {
+        if self.panes.len() >= MAX_PANES {
+            return None;
+        }
         let pane = (self.build_pane)(window, cx);
         self.panes.push(pane.clone());
-        (self.panes.len() - 1, pane)
+        Some((self.panes.len() - 1, pane))
     }
 
     /// Removes the pane at `index`, keeping at least one open. Returns whether a
@@ -307,6 +315,9 @@ impl<T: PaneItem> PaneGroup<T> {
                         .rounded(px(4.0))
                         .cursor_pointer()
                         .hover(|style| style.bg(rgb(theme::TOOLBAR_HOVER)))
+                        // Swallow the press so the pane-wide `on_mouse_down`
+                        // doesn't activate the pane we're about to close.
+                        .on_mouse_down(MouseButton::Left, |_, _window, cx| cx.stop_propagation())
                         .on_click(cx.listener(move |this, _event, window, cx| {
                             on_close(this, index, window, cx)
                         }))

--- a/crates/nohrs-pages/src/pane_group.rs
+++ b/crates/nohrs-pages/src/pane_group.rs
@@ -1,0 +1,321 @@
+//! A reusable 2-way split/tab container, decoupled from the explorer.
+//!
+//! [`PaneGroup<T>`] owns the split/tab/active/direction/resize/render machinery
+//! that used to live inside `ExplorerPage`, parameterized over any content type
+//! `T` that implements [`PaneItem`]. The explorer adopts it today; a future page
+//! (or plugin page) implements [`PaneItem`] and gets the same split behaviour for
+//! free.
+//!
+//! The group is plain data owned by an embedding view entity, not an entity
+//! itself: its mutators take `&mut App`/`&mut Window` and the embedder calls
+//! `cx.notify()` after mutating it. Content-specific concerns the group must stay
+//! ignorant of (navigation sync, config replay, per-pane subscriptions) live in
+//! the embedder, which drives create/remove through the group's primitives.
+
+use gpui::prelude::FluentBuilder;
+use gpui::*;
+use gpui_component::resizable::{h_resizable, resizable_panel, v_resizable, ResizableState};
+use gpui_component::{Icon, IconName};
+use nohrs_core::config::SplitDirection;
+use nohrs_ui::theme::theme;
+
+/// Content that a [`PaneGroup`] can host as a pane/tab. Implemented by the views
+/// shown inside a pane (today only `ExplorerPane`).
+pub trait PaneItem: Render + Focusable + 'static {
+    /// Short label shown on the pane's tab (e.g. the current directory name).
+    fn tab_title(&self, cx: &App) -> String;
+
+    /// Optional icon shown before the tab title. Defaults to none.
+    fn tab_icon(&self, _cx: &App) -> Option<IconName> {
+        None
+    }
+}
+
+/// Builds a fresh pane entity. Separate from [`PaneItem`] because construction
+/// needs embedder-owned services (e.g. the explorer's search service) that the
+/// trait should not know about.
+type BuildPane<T> = Box<dyn Fn(&mut Window, &mut App) -> Entity<T>>;
+
+/// A 2-way split container over independently-rendered panes of type `T`.
+pub struct PaneGroup<T: PaneItem> {
+    // Invariant: always non-empty and at most two entries (2-way cap).
+    panes: Vec<Entity<T>>,
+    /// Index of the pane keyboard input and shortcuts act on.
+    active: usize,
+    /// Orientation a split uses; toggled by the split shortcuts.
+    direction: SplitDirection,
+    /// Resizable state for the divider between the two panes.
+    pane_resizable: Entity<ResizableState>,
+    build_pane: BuildPane<T>,
+}
+
+impl<T: PaneItem> PaneGroup<T> {
+    /// Builds a group with a single pane. Returns the first pane so the embedder
+    /// can wire it up (subscribe, replay config, set initial state).
+    pub fn new(
+        build_pane: BuildPane<T>,
+        pane_resizable: Entity<ResizableState>,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> (Self, Entity<T>) {
+        let first = build_pane(window, cx);
+        let group = Self {
+            panes: vec![first.clone()],
+            active: 0,
+            direction: SplitDirection::default(),
+            pane_resizable,
+            build_pane,
+        };
+        (group, first)
+    }
+
+    /// Builds a pane and appends it. Returns its index and entity so the embedder
+    /// can subscribe to it and apply per-pane configuration. Does not change the
+    /// active pane or notify; that is the embedder's responsibility.
+    pub fn add_pane(&mut self, window: &mut Window, cx: &mut App) -> (usize, Entity<T>) {
+        let pane = (self.build_pane)(window, cx);
+        self.panes.push(pane.clone());
+        (self.panes.len() - 1, pane)
+    }
+
+    /// Removes the pane at `index`, keeping at least one open. Returns whether a
+    /// pane was actually removed so the embedder can drop its aligned per-pane
+    /// state (e.g. a subscription) at the same index. Rebinds the active pane and
+    /// moves focus to it.
+    pub fn remove_pane(&mut self, index: usize, window: &mut Window, cx: &mut App) -> bool {
+        if self.panes.len() <= 1 || index >= self.panes.len() {
+            return false;
+        }
+        self.panes.remove(index);
+        if self.active >= self.panes.len() {
+            self.active = self.panes.len() - 1;
+        }
+        self.focus_active(window, cx);
+        true
+    }
+
+    /// Sets the orientation a split renders with.
+    pub fn set_direction(&mut self, direction: SplitDirection) {
+        self.direction = direction;
+    }
+
+    /// Makes `index` the active pane and focuses it. Returns whether the active
+    /// pane changed (out-of-range or unchanged indices are ignored).
+    pub fn set_active(&mut self, index: usize, window: &mut Window, cx: &mut App) -> bool {
+        if index >= self.panes.len() || index == self.active {
+            return false;
+        }
+        self.active = index;
+        self.focus_active(window, cx);
+        true
+    }
+
+    /// Moves focus to the next pane, wrapping around. Returns whether it moved.
+    pub fn focus_next(&mut self, window: &mut Window, cx: &mut App) -> bool {
+        if self.panes.len() < 2 {
+            return false;
+        }
+        self.set_active((self.active + 1) % self.panes.len(), window, cx)
+    }
+
+    /// Moves focus to the previous pane, wrapping around. Returns whether it moved.
+    pub fn focus_prev(&mut self, window: &mut Window, cx: &mut App) -> bool {
+        if self.panes.len() < 2 {
+            return false;
+        }
+        let count = self.panes.len();
+        self.set_active((self.active + count - 1) % count, window, cx)
+    }
+
+    /// Focuses the active pane. Falls back to the first pane rather than
+    /// panicking should the `active` invariant ever be violated.
+    pub fn focus_active(&self, window: &mut Window, cx: &mut App) {
+        let handle = self.active_pane().read(cx).focus_handle(cx);
+        handle.focus(window);
+    }
+
+    /// The currently active pane, falling back to the first to avoid panicking.
+    pub fn active_pane(&self) -> &Entity<T> {
+        self.panes.get(self.active).unwrap_or(&self.panes[0])
+    }
+
+    /// All panes, in display order.
+    pub fn panes(&self) -> &[Entity<T>] {
+        &self.panes
+    }
+
+    /// Number of open panes (1 or 2).
+    pub fn pane_count(&self) -> usize {
+        self.panes.len()
+    }
+
+    /// Index of the active pane.
+    pub fn active(&self) -> usize {
+        self.active
+    }
+
+    /// Current split orientation.
+    pub fn direction(&self) -> SplitDirection {
+        self.direction
+    }
+
+    /// The pane at `index`, if it exists.
+    pub fn pane(&self, index: usize) -> Option<Entity<T>> {
+        self.panes.get(index).cloned()
+    }
+
+    /// Renders the split. `on_activate(index)` fires when a pane is clicked;
+    /// `on_close(index)` fires when its close button is clicked. The hooks run
+    /// against the embedding view `V` so it can keep its own state in sync.
+    pub fn render<V, FA, FC>(
+        &self,
+        cx: &mut Context<V>,
+        on_activate: FA,
+        on_close: FC,
+    ) -> AnyElement
+    where
+        V: 'static,
+        FA: Fn(&mut V, usize, &mut Window, &mut Context<V>) + Clone + 'static,
+        FC: Fn(&mut V, usize, &mut Window, &mut Context<V>) + Clone + 'static,
+    {
+        if self.panes.len() > 1 {
+            let first = self.render_pane(0, cx, on_activate.clone(), on_close.clone());
+            let second = self.render_pane(1, cx, on_activate, on_close);
+            let group = match self.direction {
+                SplitDirection::Vertical => h_resizable("pane-group", self.pane_resizable.clone()),
+                SplitDirection::Horizontal => {
+                    v_resizable("pane-group", self.pane_resizable.clone())
+                }
+            };
+            group
+                .child(resizable_panel().child(first))
+                .child(resizable_panel().child(second))
+                .into_any_element()
+        } else {
+            self.render_pane(0, cx, on_activate, on_close)
+        }
+    }
+
+    fn render_pane<V, FA, FC>(
+        &self,
+        index: usize,
+        cx: &mut Context<V>,
+        on_activate: FA,
+        on_close: FC,
+    ) -> AnyElement
+    where
+        V: 'static,
+        FA: Fn(&mut V, usize, &mut Window, &mut Context<V>) + Clone + 'static,
+        FC: Fn(&mut V, usize, &mut Window, &mut Context<V>) + Clone + 'static,
+    {
+        let pane = self.panes[index].clone();
+        let split = self.panes.len() > 1;
+        let is_active = split && index == self.active;
+        div()
+            .flex()
+            .flex_col()
+            .size_full()
+            .min_w(px(0.0))
+            .min_h(px(0.0))
+            .when(is_active, |this| {
+                this.border_t_2().border_color(rgb(theme::ACCENT))
+            })
+            .when(split && !is_active, |this| {
+                this.border_t_2().border_color(rgb(theme::BG))
+            })
+            // Clicking anywhere in a pane makes it the active one.
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(move |this, _event, window, cx| on_activate(this, index, window, cx)),
+            )
+            .child(self.render_tab_bar(index, split, cx, on_close))
+            .child(div().flex_1().min_h(px(0.0)).overflow_hidden().child(pane))
+            .into_any_element()
+    }
+
+    // The pane-local tab bar: shows the content's tab title as a single tab (full
+    // multi-tab support is tracked in #62) plus the pane-close button, which only
+    // appears once a split exists.
+    fn render_tab_bar<V, FC>(
+        &self,
+        index: usize,
+        split: bool,
+        cx: &mut Context<V>,
+        on_close: FC,
+    ) -> impl IntoElement
+    where
+        V: 'static,
+        FC: Fn(&mut V, usize, &mut Window, &mut Context<V>) + Clone + 'static,
+    {
+        let (title, icon) = {
+            let item = self.panes[index].read(cx);
+            (item.tab_title(cx), item.tab_icon(cx))
+        };
+        let is_active = split && index == self.active;
+
+        div()
+            .flex()
+            .flex_row()
+            .items_center()
+            .h(px(32.0))
+            .w_full()
+            .px(px(6.0))
+            .gap(px(4.0))
+            .bg(rgb(theme::TOOLBAR_BG))
+            .border_b_1()
+            .border_color(rgb(theme::BORDER))
+            .child(
+                div()
+                    .flex()
+                    .items_center()
+                    .gap(px(6.0))
+                    .h(px(24.0))
+                    .px(px(10.0))
+                    .rounded(px(6.0))
+                    .text_sm()
+                    .when(is_active, |this| {
+                        this.bg(rgb(theme::TOOLBAR_ACTIVE_BG))
+                            .text_color(rgb(theme::TOOLBAR_ACTIVE_TEXT))
+                    })
+                    .when(!is_active, |this| this.text_color(rgb(theme::TOOLBAR_TEXT)))
+                    .when_some(icon, |this, icon| this.child(Icon::new(icon).size_4()))
+                    .child(title),
+            )
+            // Placeholder for the new-tab affordance fleshed out in #62.
+            .child(
+                div()
+                    .flex()
+                    .items_center()
+                    .justify_center()
+                    .size(px(20.0))
+                    .rounded(px(4.0))
+                    .child(
+                        Icon::new(IconName::Plus)
+                            .size_4()
+                            .text_color(rgb(theme::MUTED)),
+                    ),
+            )
+            .child(div().flex_grow())
+            .when(split, |this| {
+                this.child(
+                    div()
+                        .id(("close-pane", index))
+                        .flex()
+                        .items_center()
+                        .justify_center()
+                        .size(px(22.0))
+                        .rounded(px(4.0))
+                        .cursor_pointer()
+                        .hover(|style| style.bg(rgb(theme::TOOLBAR_HOVER)))
+                        .on_click(cx.listener(move |this, _event, window, cx| {
+                            on_close(this, index, window, cx)
+                        }))
+                        .child(
+                            Icon::new(IconName::Close)
+                                .size_4()
+                                .text_color(rgb(theme::TOOLBAR_TEXT)),
+                        ),
+                )
+            })
+    }
+}


### PR DESCRIPTION
Implements issue #164. Two changes, built on the 2-way split view from #163.

> [!NOTE]
> This PR **stacks on #163** (`feature/explorer-split-view`), which is not yet merged, so the base is that branch rather than `develop`. The diff here is only the #164 work. Once #163 merges I'll rebase onto `develop` and retarget.

## 1. Generalize the split/tab container (foundation + explorer)

The split/tab/resize machinery was hard-wired into `ExplorerPage`. It now lives in a reusable, content-agnostic `PaneGroup<T: PaneItem>` (`crates/nohrs-pages/src/pane_group.rs`):

- Any view implementing the new `PaneItem` trait (tab title/icon + focus) gets 2-way split, pane focus/close, the tab bar, and divider resize for free.
- `ExplorerPane` adopts it today; a future built-in page or **plugin page** (e.g. an in-app text editor) plugs in without touching the container.
- `ExplorerPage` keeps only the explorer-specific layer on top — navigation sync across panes and `[ui]` config replay — with a per-pane subscription `Vec` funneled through `add_explorer_pane`/`close_pane` so it stays index-aligned with the panes.

This is the foundation only: the other root pages and the (still P4-stub) plugin host are intentionally **not** migrated. Scope was confirmed with the issue author.

## 2. Collapsible left sidebar (`Cmd/Ctrl+B`)

The explorer's left quick-access sidebar (Home/Favorites/folder shortcuts) is now per-pane collapsible:

- The **root** pane shows it; a pane opened by a **split** starts collapsed.
- Each pane toggles independently with `Cmd/Ctrl+B`.
- Toggled via `ResizablePanel::visible` (not by dropping the child), so the persisted resizable panel sizes stay stable.

## Verification

Local gate: `cargo fmt`, `cargo clippy --all-targets -D warnings`, `cargo build -p nohrs`, `cargo test` all clean (46 `nohrs-pages` tests, incl. 4 new: sidebar default-per-pane, independent toggle, and a subscription-alignment regression across a close/split cycle).

Verified live in the GUI (headless Xvfb):

Single pane — sidebar visible (root default), then collapsed with `Ctrl+B`:

![initial](https://raw.githubusercontent.com/noh-rs/nohrs/pr-assets/screenshots/panes-sidebar/3871676-19121/01-initial.png)
![collapsed](https://raw.githubusercontent.com/noh-rs/nohrs/pr-assets/screenshots/panes-sidebar/3871676-19121/02-sidebar-collapsed.png)

Vertical split — left (root) pane keeps its sidebar, right (new) pane defaults to collapsed:

![split-vertical](https://raw.githubusercontent.com/noh-rs/nohrs/pr-assets/screenshots/panes-sidebar/3871676-19121/03-split-vertical.png)

Each pane toggles its sidebar independently; horizontal re-orient (`Ctrl+Shift+\`):

![both-sidebars](https://raw.githubusercontent.com/noh-rs/nohrs/pr-assets/screenshots/panes-sidebar/3871676-19121/04-both-sidebars.png)
![split-horizontal](https://raw.githubusercontent.com/noh-rs/nohrs/pr-assets/screenshots/panes-sidebar/3871676-19121/05-split-horizontal.png)

Resizing by dragging the split divider:

![divider-drag](https://raw.githubusercontent.com/noh-rs/nohrs/pr-assets/screenshots/panes-sidebar/3871676-19121/divider-drag.gif)

Release Notes:

- Added a collapsible explorer sidebar (Cmd/Ctrl+B) and generalized the split/tab container so other pages can reuse it

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generalized the split/tab/resize container into a reusable `PaneGroup` and added a per-pane collapsible explorer sidebar toggled with Cmd/Ctrl+B. Implements Linear #164 and adds small pane UI fixes.

- **New Features**
  - Collapsible left sidebar in the explorer.
    - Root pane shows it by default; split-created panes start collapsed.
    - Toggle per pane with Cmd/Ctrl+B.
    - Uses resizable panel visibility so saved sizes stay stable.

- **Refactors**
  - Extracted split/tab/focus/resize logic into a generic `PaneGroup<T: PaneItem>`.
  - `ExplorerPane` implements `PaneItem`; `ExplorerPage` now handles config replay and navigation sync only.
  - Per-pane subscriptions stay index-aligned across add/remove.
  - Enforced the 2-way cap in `PaneGroup::add_pane` and stopped the close button’s mouse-down from activating the pane before closing.

<sup>Written for commit fecd582799e7dab9eb5ebee76a265e4d6d59cbdc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/noh-rs/nohrs/pull/165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

