### PR TITLE
Migrate workspace to Rust 2024 edition and raise MSRV to 1.85

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ default-members = [
 
 [workspace.package]
 version      = "0.0.1"
-edition      = "2021"
-rust-version = "1.83"
+edition      = "2024"
+rust-version = "1.85"
 license      = "MIT"
 repository   = "https://github.com/noh-rs/nohrs"
 homepage     = "https://nohrs.app"

--- a/crates/nohrs-core/src/config.rs
+++ b/crates/nohrs-core/src/config.rs
@@ -18,10 +18,10 @@ pub mod watcher;
 
 pub use loader::{backup, ensure_exists, needs_migration, reset, write_default};
 pub use settings::{
-    json_schema_string, load_from_path, report_diagnostics, Config, ConfigOverride, Diagnostic,
-    DiagnosticLevel, Diagnostics, DiagnosticsStore, Indexing, IndexingExclude, IndexingMode,
-    Keybindings, Launcher, Plugins, Search, SearchBackend, SortOrder, Theme, ThemeMode, Ui,
-    CURRENT_SCHEMA_VERSION, SCHEMA_URL,
+    CURRENT_SCHEMA_VERSION, Config, ConfigOverride, Diagnostic, DiagnosticLevel, Diagnostics,
+    DiagnosticsStore, Indexing, IndexingExclude, IndexingMode, Keybindings, Launcher, Plugins,
+    SCHEMA_URL, Search, SearchBackend, SortOrder, Theme, ThemeMode, Ui, json_schema_string,
+    load_from_path, report_diagnostics,
 };
 pub use watcher::ConfigWatcher;
 

--- a/crates/nohrs-core/src/config.rs
+++ b/crates/nohrs-core/src/config.rs
@@ -74,3 +74,22 @@ pub const SEARCH_MAX_LINE_LEN: usize = 1000;
 
 /// Upper bound on matches collected from a single file during a content search.
 pub const SEARCH_MAX_MATCHES_PER_FILE: usize = 1000;
+
+/// Process-wide serialization for tests that mutate the environment.
+#[cfg(test)]
+pub(crate) mod test_env {
+    use std::sync::{Mutex, MutexGuard, PoisonError};
+
+    // `std::env::set_var`/`remove_var` mutate process-global state that any
+    // thread's `getenv` can observe, so every env-mutating test in this crate —
+    // across all `config` submodules, which compile into one test binary — must
+    // serialize through a single lock, not a per-module one. Recover from a
+    // poisoned lock (a panic in another env test) so the offending test's own
+    // assertion surfaces instead of an opaque poison panic in later env tests.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Acquire the shared environment lock for the duration of an env-mutating test.
+    pub(crate) fn env_lock() -> MutexGuard<'static, ()> {
+        ENV_LOCK.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+}

--- a/crates/nohrs-core/src/config/loader.rs
+++ b/crates/nohrs-core/src/config/loader.rs
@@ -7,7 +7,7 @@
 //! peek-version → backup → overwrite shape is in place so future bumps slot in
 //! without reworking callers (config.md §7).
 
-use super::settings::{Config, CURRENT_SCHEMA_VERSION};
+use super::settings::{CURRENT_SCHEMA_VERSION, Config};
 use std::io;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -117,9 +117,11 @@ mod tests {
             std::fs::read_to_string(&backup_path).unwrap(),
             "schema_version = 1\nmangled"
         );
-        assert!(std::fs::read_to_string(&path)
-            .unwrap()
-            .starts_with("#:schema"));
+        assert!(
+            std::fs::read_to_string(&path)
+                .unwrap()
+                .starts_with("#:schema")
+        );
     }
 
     #[test]
@@ -172,9 +174,11 @@ mod tests {
         let path = dir.path().join("config.toml");
         let backup_path = reset(&path).unwrap();
         assert!(backup_path.is_none());
-        assert!(std::fs::read_to_string(&path)
-            .unwrap()
-            .starts_with("#:schema"));
+        assert!(
+            std::fs::read_to_string(&path)
+                .unwrap()
+                .starts_with("#:schema")
+        );
     }
 
     #[test]

--- a/crates/nohrs-core/src/config/paths.rs
+++ b/crates/nohrs-core/src/config/paths.rs
@@ -65,7 +65,9 @@ pub fn config_file() -> PathBuf {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
+// Rust 2024 made `std::env::{set_var, remove_var}` unsafe; these tests must
+// mutate the process environment to exercise XDG path resolution.
+#[allow(clippy::unwrap_used, unsafe_code)]
 mod tests {
     use super::*;
 
@@ -92,18 +94,22 @@ mod tests {
     #[test]
     fn absolute_xdg_var_is_honoured() {
         let _guard = env_lock();
-        std::env::set_var("XDG_CONFIG_HOME", "/tmp/xdg-test-abs");
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::set_var("XDG_CONFIG_HOME", "/tmp/xdg-test-abs") };
         let dir = config_dir();
-        std::env::remove_var("XDG_CONFIG_HOME");
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::remove_var("XDG_CONFIG_HOME") };
         assert_eq!(dir, PathBuf::from("/tmp/xdg-test-abs/nohrs"));
     }
 
     #[test]
     fn relative_xdg_var_is_ignored() {
         let _guard = env_lock();
-        std::env::set_var("XDG_CONFIG_HOME", "relative/path");
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::set_var("XDG_CONFIG_HOME", "relative/path") };
         let home = config_home();
-        std::env::remove_var("XDG_CONFIG_HOME");
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::remove_var("XDG_CONFIG_HOME") };
         // A relative value is ignored per the XDG spec, so we fall back to a home
         // (or cwd) based path, never the relative value itself.
         assert!(!home.ends_with("relative/path"));
@@ -112,12 +118,16 @@ mod tests {
     #[test]
     fn each_home_honours_its_own_xdg_var() {
         let _guard = env_lock();
-        std::env::set_var("XDG_CONFIG_HOME", "/tmp/cfg");
-        std::env::set_var("XDG_DATA_HOME", "/tmp/data");
-        std::env::set_var("XDG_CACHE_HOME", "/tmp/cache");
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::set_var("XDG_CONFIG_HOME", "/tmp/cfg") };
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::set_var("XDG_DATA_HOME", "/tmp/data") };
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::set_var("XDG_CACHE_HOME", "/tmp/cache") };
         let (config, data, cache) = (config_home(), data_home(), cache_home());
         for key in ["XDG_CONFIG_HOME", "XDG_DATA_HOME", "XDG_CACHE_HOME"] {
-            std::env::remove_var(key);
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            unsafe { std::env::remove_var(key) };
         }
         assert_eq!(config, PathBuf::from("/tmp/cfg"));
         assert_eq!(data, PathBuf::from("/tmp/data"));

--- a/crates/nohrs-core/src/config/paths.rs
+++ b/crates/nohrs-core/src/config/paths.rs
@@ -70,18 +70,7 @@ pub fn config_file() -> PathBuf {
 #[allow(clippy::unwrap_used, unsafe_code)]
 mod tests {
     use super::*;
-
-    // `XDG_*` env tests mutate process-global state; serialize them so parallel
-    // test threads do not observe each other's vars. Recover from a poisoned
-    // lock (a panic in another env test) so the offending test's own assertion
-    // surfaces instead of an opaque poison panic in every later env test.
-    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
-        ENV_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-    }
+    use crate::config::test_env::env_lock;
 
     #[test]
     fn config_file_lives_under_config_home() {

--- a/crates/nohrs-core/src/config/settings.rs
+++ b/crates/nohrs-core/src/config/settings.rs
@@ -993,6 +993,7 @@ pub fn report_diagnostics(diagnostics: &[Diagnostic]) -> Option<String> {
 #[allow(clippy::unwrap_used, clippy::disallowed_methods, unsafe_code)]
 mod tests {
     use super::*;
+    use crate::config::test_env::env_lock;
 
     fn errors(diagnostics: &[Diagnostic]) -> Vec<&str> {
         diagnostics
@@ -1370,18 +1371,6 @@ mod tests {
         assert!(json.contains("schema_version"));
         let parsed: Config = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed, config);
-    }
-
-    // `NOHRS_*` env tests mutate process-global state; serialize them so parallel
-    // test threads do not observe each other's vars. Recover from a poisoned
-    // lock so a panicking env test surfaces its own assertion rather than an
-    // opaque poison panic in every later env test.
-    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
-        ENV_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
     }
 
     #[test]

--- a/crates/nohrs-core/src/config/settings.rs
+++ b/crates/nohrs-core/src/config/settings.rs
@@ -988,7 +988,9 @@ pub fn report_diagnostics(diagnostics: &[Diagnostic]) -> Option<String> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::disallowed_methods)]
+// Rust 2024 made `std::env::set_var` unsafe; these tests must mutate the
+// process environment to exercise env-var config overrides.
+#[allow(clippy::unwrap_used, clippy::disallowed_methods, unsafe_code)]
 mod tests {
     use super::*;
 
@@ -1385,11 +1387,16 @@ mod tests {
     #[test]
     fn from_env_reads_valid_vars() {
         let _guard = env_lock();
-        std::env::set_var("NOHRS_THEME", "dark");
-        std::env::set_var("NOHRS_ACCENT", "violet");
-        std::env::set_var("NOHRS_DEFAULT_SORT", "size");
-        std::env::set_var("NOHRS_SHOW_HIDDEN", "on");
-        std::env::set_var("NOHRS_ICON_PACK", "nerd");
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::set_var("NOHRS_THEME", "dark") };
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::set_var("NOHRS_ACCENT", "violet") };
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::set_var("NOHRS_DEFAULT_SORT", "size") };
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::set_var("NOHRS_SHOW_HIDDEN", "on") };
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::set_var("NOHRS_ICON_PACK", "nerd") };
         let over = ConfigOverride::from_env();
         for key in [
             "NOHRS_THEME",
@@ -1398,7 +1405,8 @@ mod tests {
             "NOHRS_SHOW_HIDDEN",
             "NOHRS_ICON_PACK",
         ] {
-            std::env::remove_var(key);
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            unsafe { std::env::remove_var(key) };
         }
         assert_eq!(over.theme_mode, Some(ThemeMode::Dark));
         assert_eq!(over.theme_accent.as_deref(), Some("violet"));
@@ -1410,11 +1418,15 @@ mod tests {
     #[test]
     fn from_env_skips_invalid_values() {
         let _guard = env_lock();
-        std::env::set_var("NOHRS_THEME", "neon");
-        std::env::set_var("NOHRS_SHOW_HIDDEN", "maybe");
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::set_var("NOHRS_THEME", "neon") };
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::set_var("NOHRS_SHOW_HIDDEN", "maybe") };
         let over = ConfigOverride::from_env();
-        std::env::remove_var("NOHRS_THEME");
-        std::env::remove_var("NOHRS_SHOW_HIDDEN");
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::remove_var("NOHRS_THEME") };
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::remove_var("NOHRS_SHOW_HIDDEN") };
         assert_eq!(over.theme_mode, None);
         assert_eq!(over.ui_show_hidden, None);
     }

--- a/crates/nohrs-core/src/telemetry/logging.rs
+++ b/crates/nohrs-core/src/telemetry/logging.rs
@@ -1,5 +1,5 @@
 use super::LogErr;
-use tracing_subscriber::{fmt, EnvFilter};
+use tracing_subscriber::{EnvFilter, fmt};
 
 /// Install the global `tracing` subscriber, writing logs to stderr and honoring
 /// `RUST_LOG` (defaulting to `info`). A no-op if a subscriber is already set.

--- a/crates/nohrs-pages/src/explorer/entries.rs
+++ b/crates/nohrs-pages/src/explorer/entries.rs
@@ -19,11 +19,7 @@ pub fn sort_entries(entries: &mut [FileEntryDto], key: SortKey, asc: bool) {
                         ext_a.cmp(&ext_b)
                     }
                 };
-                if asc {
-                    order
-                } else {
-                    order.reverse()
-                }
+                if asc { order } else { order.reverse() }
             }
             kind_order => kind_order,
         }

--- a/crates/nohrs-pages/src/explorer/list_setup.rs
+++ b/crates/nohrs-pages/src/explorer/list_setup.rs
@@ -4,8 +4,8 @@ use nohrs_ui::components::file_list::FileListDelegate;
 use gpui::{AppContext, Context, Window};
 use gpui_component::list::{List, ListEvent};
 
-use super::types::ResizingColumn;
 use super::ExplorerPage;
+use super::types::ResizingColumn;
 
 impl ExplorerPage {
     pub(crate) fn ensure_list_initialized(&mut self, window: &mut Window, cx: &mut Context<Self>) {

--- a/crates/nohrs-pages/src/explorer/navigation.rs
+++ b/crates/nohrs-pages/src/explorer/navigation.rs
@@ -1,11 +1,11 @@
 use nohrs_core::config;
-use nohrs_services::fs::listing::{list_dir_sync, FileEntryDto, ListParams};
+use nohrs_services::fs::listing::{FileEntryDto, ListParams, list_dir_sync};
 
 use gpui::{Context, Window};
 
+use super::ExplorerPage;
 use super::entries;
 use super::types::StatusLevel;
-use super::ExplorerPage;
 
 impl ExplorerPage {
     pub(crate) fn ensure_loaded(&mut self) {

--- a/crates/nohrs-pages/src/explorer/preview.rs
+++ b/crates/nohrs-pages/src/explorer/preview.rs
@@ -2,8 +2,8 @@ use nohrs_core::config;
 
 use gpui::{AppContext, AsyncWindowContext, Context, Window};
 
-use super::view::preview::editor::PreviewEditor;
 use super::ExplorerPage;
+use super::view::preview::editor::PreviewEditor;
 
 /// Result of reading a file for preview off the UI thread.
 enum PreviewOutcome {

--- a/crates/nohrs-pages/src/explorer/search.rs
+++ b/crates/nohrs-pages/src/explorer/search.rs
@@ -1,5 +1,5 @@
-use super::types::{SearchFileResult, SearchMatch, StatusLevel};
 use super::ExplorerPage;
+use super::types::{SearchFileResult, SearchMatch, StatusLevel};
 use gpui::{AppContext, AsyncApp, Context, Window};
 use nohrs_services::fs::listing::FileEntryDto;
 use nohrs_services::search::SearchResult;

--- a/crates/nohrs-pages/src/explorer/state.rs
+++ b/crates/nohrs-pages/src/explorer/state.rs
@@ -4,11 +4,11 @@ use nohrs_services::search::{SearchScope, SearchService};
 use nohrs_services::syntax::SyntaxService;
 use nohrs_ui::components::file_list::FileListDelegate;
 
-use gpui::{px, size, Context, Entity, FocusHandle, Focusable};
+use gpui::{Context, Entity, FocusHandle, Focusable, px, size};
+use gpui_component::VirtualListScrollHandle;
 use gpui_component::input::InputState;
 use gpui_component::list::List;
 use gpui_component::resizable::ResizableState;
-use gpui_component::VirtualListScrollHandle;
 use std::{rc::Rc, sync::Arc, time::Instant};
 
 use super::entries;

--- a/crates/nohrs-pages/src/explorer/tests.rs
+++ b/crates/nohrs-pages/src/explorer/tests.rs
@@ -11,14 +11,14 @@
 
 use std::time::Duration;
 
-use gpui::{point, px, AppContext, TestAppContext, WindowHandle};
+use gpui::{AppContext, TestAppContext, WindowHandle, point, px};
 use gpui_component::input::InputState;
 use gpui_component::resizable::ResizableState;
 use nohrs_core::config;
 use nohrs_services::fs::listing::FileEntryDto;
 
-use super::types::{SortKey, StatusLevel, ViewMode};
 use super::ExplorerPage;
+use super::types::{SortKey, StatusLevel, ViewMode};
 
 /// Build a real `ExplorerPage` inside a test window. The sub-entities
 /// (`ResizableState`, `InputState`) are window-bound, so the page is
@@ -105,18 +105,20 @@ async fn apply_filter_hides_dotfiles_until_enabled(cx: &mut TestAppContext) {
 
             page.show_hidden = false;
             page.apply_filter();
-            assert!(page
-                .filtered_entries
-                .iter()
-                .all(|entry| entry.name != ".hidden"));
+            assert!(
+                page.filtered_entries
+                    .iter()
+                    .all(|entry| entry.name != ".hidden")
+            );
             assert_eq!(page.filtered_entries.len(), 2);
 
             page.show_hidden = true;
             page.apply_filter();
-            assert!(page
-                .filtered_entries
-                .iter()
-                .any(|entry| entry.name == ".hidden"));
+            assert!(
+                page.filtered_entries
+                    .iter()
+                    .any(|entry| entry.name == ".hidden")
+            );
             assert_eq!(page.filtered_entries.len(), 3);
         })
         .unwrap();

--- a/crates/nohrs-pages/src/explorer/view.rs
+++ b/crates/nohrs-pages/src/explorer/view.rs
@@ -16,7 +16,7 @@ pub fn render(
     page: &mut ExplorerPage,
     window: &mut Window,
     cx: &mut Context<ExplorerPage>,
-) -> impl IntoElement {
+) -> impl IntoElement + use<> {
     page.ensure_loaded();
     page.update_editor_search(window, cx);
     if !page.focus_requested {

--- a/crates/nohrs-pages/src/explorer/view/header.rs
+++ b/crates/nohrs-pages/src/explorer/view/header.rs
@@ -12,7 +12,7 @@ pub fn render(
     page: &mut ExplorerPage,
     _window: &mut Window,
     cx: &mut Context<ExplorerPage>,
-) -> impl IntoElement {
+) -> impl IntoElement + use<> {
     let parts = path_parts(&page.cwd);
 
     let (display_parts, is_truncated) = if parts.len() > 5 {
@@ -164,7 +164,7 @@ pub fn render(
 fn render_view_mode_toggle(
     page: &mut ExplorerPage,
     cx: &mut Context<ExplorerPage>,
-) -> impl IntoElement {
+) -> impl IntoElement + use<> {
     div()
         .flex()
         .items_center()
@@ -194,7 +194,7 @@ fn view_mode_button(
     icon: IconName,
     label: &'static str,
     cx: &mut Context<ExplorerPage>,
-) -> impl IntoElement {
+) -> impl IntoElement + use<> {
     let is_active = page.view_mode == mode;
     ListItem::new(id)
         .px(px(8.0))

--- a/crates/nohrs-pages/src/explorer/view/listing/list.rs
+++ b/crates/nohrs-pages/src/explorer/view/listing/list.rs
@@ -1,9 +1,9 @@
 use super::row;
-use crate::explorer::types::SortKey;
 use crate::explorer::ExplorerPage;
+use crate::explorer::types::SortKey;
 use gpui::prelude::*;
 use gpui::*;
-use gpui_component::{v_virtual_list, ListItem};
+use gpui_component::{ListItem, v_virtual_list};
 use nohrs_ui::theme::theme;
 use std::rc::Rc;
 
@@ -47,7 +47,7 @@ fn render_table_with_header(
     col_modified: f32,
     col_action: f32,
     cx: &mut Context<ExplorerPage>,
-) -> impl IntoElement {
+) -> impl IntoElement + use<> {
     let entity = cx.entity().clone();
 
     let mut all_sizes = vec![gpui::size(px(table_width), px(48.0))];
@@ -101,7 +101,7 @@ fn render_header_row(
     col_modified: f32,
     col_action: f32,
     cx: &mut Context<ExplorerPage>,
-) -> impl IntoElement {
+) -> impl IntoElement + use<> {
     div()
         .w(px(table_width))
         .h(px(48.0))
@@ -158,7 +158,7 @@ fn render_resizable_column_header(
     column_index: usize,
     width: f32,
     cx: &mut Context<ExplorerPage>,
-) -> impl IntoElement {
+) -> impl IntoElement + use<> {
     // We need to call page methods like start_column_resize which take &mut self.
     // But `v_virtual_list` closure gives `view` (&mut ExplorerPage), so `page` here could be &mut?
     // In `render_table_with_header` closure, `view` is passed to `render_header_row`.

--- a/crates/nohrs-pages/src/explorer/view/listing/row.rs
+++ b/crates/nohrs-pages/src/explorer/view/listing/row.rs
@@ -13,7 +13,7 @@ pub fn render(
     item: &FileEntryDto,
     ix: usize,
     cx: &mut Context<ExplorerPage>,
-) -> impl IntoElement {
+) -> impl IntoElement + use<> {
     use nohrs_ui::components::file_list::{format_date, get_file_type, human_bytes};
 
     let icon_name = match item.kind.as_str() {

--- a/crates/nohrs-pages/src/explorer/view/listing/search_bar.rs
+++ b/crates/nohrs-pages/src/explorer/view/listing/search_bar.rs
@@ -1,5 +1,5 @@
-use crate::explorer::types::SearchType;
 use crate::explorer::ExplorerPage;
+use crate::explorer::types::SearchType;
 use gpui::prelude::*;
 use gpui::*;
 use gpui_component::input::TextInput;
@@ -8,7 +8,7 @@ use nohrs_services::search::SearchScope;
 use nohrs_ui::theme::theme;
 
 /// Renders the search bar with the query input and search option toggles.
-pub fn render(page: &mut ExplorerPage, cx: &mut Context<ExplorerPage>) -> impl IntoElement {
+pub fn render(page: &mut ExplorerPage, cx: &mut Context<ExplorerPage>) -> impl IntoElement + use<> {
     let current_text = page.search_input.read(cx).text().to_string();
     if current_text != page.search_query {
         page.search_query = current_text;
@@ -210,7 +210,7 @@ fn render_scope_button(
     scope: SearchScope,
     label: &str,
     cx: &mut Context<ExplorerPage>,
-) -> impl IntoElement {
+) -> impl IntoElement + use<> {
     let is_active = page.search_scope == scope;
     div()
         .cursor_pointer()
@@ -236,7 +236,7 @@ fn render_type_button(
     search_type: SearchType,
     label: &str,
     cx: &mut Context<ExplorerPage>,
-) -> impl IntoElement {
+) -> impl IntoElement + use<> {
     let is_active = page.search_type == search_type;
     div()
         .cursor_pointer()

--- a/crates/nohrs-pages/src/explorer/view/preview.rs
+++ b/crates/nohrs-pages/src/explorer/view/preview.rs
@@ -6,7 +6,7 @@ use nohrs_ui::theme::theme;
 // Calculate the maximum line width in characters for horizontal scroll sizing
 /// Renders the preview pane for the selected file, showing a text editor,
 /// image, status message, or an empty placeholder.
-pub fn render(page: &mut ExplorerPage, _window: &mut Window) -> impl IntoElement {
+pub fn render(page: &mut ExplorerPage, _window: &mut Window) -> impl IntoElement + use<> {
     let title = page
         .preview_path
         .as_ref()

--- a/crates/nohrs-pages/src/explorer/view/sidebar.rs
+++ b/crates/nohrs-pages/src/explorer/view/sidebar.rs
@@ -9,7 +9,7 @@ pub fn render(
     page: &mut ExplorerPage,
     _window: &mut Window,
     cx: &mut Context<ExplorerPage>,
-) -> impl IntoElement {
+) -> impl IntoElement + use<> {
     div()
         .size_full()
         .flex()
@@ -45,7 +45,7 @@ pub fn render(
         )
 }
 
-fn sidebar_item(icon: IconName, label: &str, _active: bool) -> impl IntoElement {
+fn sidebar_item(icon: IconName, label: &str, _active: bool) -> impl IntoElement + use<> {
     let label = label.to_string();
     div()
         .w_full()
@@ -61,7 +61,10 @@ fn sidebar_item(icon: IconName, label: &str, _active: bool) -> impl IntoElement 
         .child(div().text_sm().text_color(rgb(theme::FG)).child(label))
 }
 
-fn render_shortcuts(_page: &mut ExplorerPage, cx: &mut Context<ExplorerPage>) -> impl IntoElement {
+fn render_shortcuts(
+    _page: &mut ExplorerPage,
+    cx: &mut Context<ExplorerPage>,
+) -> impl IntoElement + use<> {
     let shortcuts = get_shortcuts();
     let mut shortcuts_el = div().flex().flex_col().gap_1().px(px(8.0));
 

--- a/crates/nohrs-pages/src/extensions.rs
+++ b/crates/nohrs-pages/src/extensions.rs
@@ -1,4 +1,4 @@
-use gpui::{div, prelude::*, px, rgb, AnyElement, Context, Render, Window};
+use gpui::{AnyElement, Context, Render, Window, div, prelude::*, px, rgb};
 use nohrs_ui::theme::theme;
 
 /// The extensions page, a placeholder for a future extension store.

--- a/crates/nohrs-pages/src/git.rs
+++ b/crates/nohrs-pages/src/git.rs
@@ -1,4 +1,4 @@
-use gpui::{div, prelude::*, px, rgb, AnyElement, Context, Render, Window};
+use gpui::{AnyElement, Context, Render, Window, div, prelude::*, px, rgb};
 use nohrs_ui::theme::theme;
 
 /// The git page, a placeholder for future version-control functionality.

--- a/crates/nohrs-pages/src/root.rs
+++ b/crates/nohrs-pages/src/root.rs
@@ -9,11 +9,11 @@
 
 use crate::explorer::ExplorerPage;
 use crate::{
-    extensions::ExtensionsPage, git::GitPage, s3::S3Page, settings::SettingsPage, PageKind,
+    PageKind, extensions::ExtensionsPage, git::GitPage, s3::S3Page, settings::SettingsPage,
 };
 use gpui::{
-    div, prelude::*, px, rgb, AnyElement, App, AsyncWindowContext, Context, Entity, FocusHandle,
-    Focusable, InteractiveElement, Render, WeakEntity, Window,
+    AnyElement, App, AsyncWindowContext, Context, Entity, FocusHandle, Focusable,
+    InteractiveElement, Render, WeakEntity, Window, div, prelude::*, px, rgb,
 };
 use gpui_component::input::InputState;
 use gpui_component::resizable::ResizableState;
@@ -21,14 +21,14 @@ use gpui_component::{Icon, Root, Theme, ThemeMode as GpuiThemeMode};
 use nohrs_core::config::{self, Config, ConfigOverride, ConfigWatcher};
 use nohrs_core::telemetry::LogErr;
 use nohrs_services::search::SearchService;
-use nohrs_ui::components::layout::footer::{footer, FooterProps};
+use nohrs_ui::components::layout::footer::{FooterProps, footer};
 use nohrs_ui::components::layout::unified_toolbar::{
-    unified_toolbar, AccountMenuAction, AccountMenuCommand, UnifiedToolbarProps,
+    AccountMenuAction, AccountMenuCommand, UnifiedToolbarProps, unified_toolbar,
 };
 use nohrs_ui::theme::theme;
 use std::path::PathBuf;
-use std::sync::mpsc;
 use std::sync::Arc;
+use std::sync::mpsc;
 use std::time::Duration;
 use tracing::info;
 
@@ -347,7 +347,7 @@ impl RootView {
         }
     }
 
-    fn render_navigation(&self, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render_navigation(&self, cx: &mut Context<Self>) -> impl IntoElement + use<> {
         let active_page = self.current_page;
 
         div()
@@ -376,7 +376,7 @@ impl RootView {
         page: PageKind,
         active: bool,
         cx: &mut Context<Self>,
-    ) -> impl IntoElement {
+    ) -> impl IntoElement + use<> {
         div()
             .id(("nav-btn", page as usize))
             .w(px(48.0))

--- a/crates/nohrs-pages/src/s3.rs
+++ b/crates/nohrs-pages/src/s3.rs
@@ -1,4 +1,4 @@
-use gpui::{div, prelude::*, px, rgb, AnyElement, Context, Render, Window};
+use gpui::{AnyElement, Context, Render, Window, div, prelude::*, px, rgb};
 use nohrs_ui::theme::theme;
 
 /// The S3 page, a placeholder for future object-storage browsing.

--- a/crates/nohrs-pages/src/settings.rs
+++ b/crates/nohrs-pages/src/settings.rs
@@ -1,4 +1,4 @@
-use gpui::{div, prelude::*, px, rgb, AnyElement, Context, Render, Window};
+use gpui::{AnyElement, Context, Render, Window, div, prelude::*, px, rgb};
 use nohrs_ui::theme::theme;
 
 /// The settings page, a placeholder for future application configuration.

--- a/crates/nohrs-services/src/fs/listing.rs
+++ b/crates/nohrs-services/src/fs/listing.rs
@@ -178,12 +178,14 @@ mod tests {
 
     #[test]
     fn nonexistent_path_is_an_error() {
-        assert!(list_dir_sync(ListParams {
-            path: "/no/such/dir/here",
-            limit: 10,
-            cursor: None,
-        })
-        .is_err());
+        assert!(
+            list_dir_sync(ListParams {
+                path: "/no/such/dir/here",
+                limit: 10,
+                cursor: None,
+            })
+            .is_err()
+        );
     }
 
     #[test]

--- a/crates/nohrs-services/src/search/indexer.rs
+++ b/crates/nohrs-services/src/search/indexer.rs
@@ -2,8 +2,8 @@ use anyhow::{Context, Result};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
-use tantivy::schema::{Field, Schema, Term, Value, FAST, STORED, STRING, TEXT};
 use tantivy::TantivyDocument;
+use tantivy::schema::{FAST, Field, STORED, STRING, Schema, TEXT, Term, Value};
 use tantivy::{Index, IndexWriter}; // Import trait for add_text etc? No, TantivyDocument implements it.
 
 /// Owns the tantivy index and its writer, and performs full and incremental indexing.

--- a/crates/nohrs-services/src/search/ripgrep.rs
+++ b/crates/nohrs-services/src/search/ripgrep.rs
@@ -1,5 +1,5 @@
-use super::backend::SearchBackend;
 use super::SearchResult;
+use super::backend::SearchBackend;
 use anyhow::{Context, Result};
 use grep::regex::RegexMatcher;
 use grep::searcher::{Searcher, Sink, SinkMatch};

--- a/crates/nohrs-services/src/search/spotlight.rs
+++ b/crates/nohrs-services/src/search/spotlight.rs
@@ -1,5 +1,5 @@
-use super::backend::SearchBackend;
 use super::SearchResult;
+use super::backend::SearchBackend;
 use anyhow::{Context, Result};
 use nohrs_core::config::{SEARCH_MAX_LINE_LEN, SEARCH_MAX_MATCHES_PER_FILE};
 use std::fs::File;

--- a/crates/nohrs-services/src/search/watcher.rs
+++ b/crates/nohrs-services/src/search/watcher.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use notify::RecursiveMode;
-use notify_debouncer_mini::{new_debouncer, DebounceEventResult, Debouncer};
+use notify_debouncer_mini::{DebounceEventResult, Debouncer, new_debouncer};
 use std::path::PathBuf;
 use std::time::Duration;
 // `notify` / `notify-debouncer-mini` are runtime-agnostic (they drive their own

--- a/crates/nohrs-store/src/sqlite.rs
+++ b/crates/nohrs-store/src/sqlite.rs
@@ -5,11 +5,11 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
 use std::time::Duration;
 
-use rusqlite::{params, Connection, OptionalExtension, Row};
+use rusqlite::{Connection, OptionalExtension, Row, params};
 
 use crate::{
-    now_ns, FileId, FileRecord, FileUpsert, HistoryEntry, HistoryKind, HistoryStore, MetadataQuery,
-    MetadataStore, Result, StoreLogConfig,
+    FileId, FileRecord, FileUpsert, HistoryEntry, HistoryKind, HistoryStore, MetadataQuery,
+    MetadataStore, Result, StoreLogConfig, now_ns,
 };
 
 /// Forward-only migrations, applied in order and recorded in `_migrations`.
@@ -373,10 +373,12 @@ mod tests {
             .unwrap();
         assert_eq!(record.indexed_at, Some(500));
         store.delete_file(Path::new("/home/user/a.txt")).unwrap();
-        assert!(store
-            .get_file(Path::new("/home/user/a.txt"))
-            .unwrap()
-            .is_none());
+        assert!(
+            store
+                .get_file(Path::new("/home/user/a.txt"))
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[test]
@@ -417,10 +419,12 @@ mod tests {
         let id = store
             .upsert_file(&sample("/home/user/a.txt", 1, 100))
             .unwrap();
-        assert!(store
-            .get_file(Path::new("/home/user/a.txt"))
-            .unwrap()
-            .is_some());
+        assert!(
+            store
+                .get_file(Path::new("/home/user/a.txt"))
+                .unwrap()
+                .is_some()
+        );
         store.mark_indexed(id, 1).unwrap();
     }
 
@@ -435,9 +439,11 @@ mod tests {
                 .unwrap();
         }
         let reopened = SqliteStore::open(&path, &StoreLogConfig::default()).unwrap();
-        assert!(reopened
-            .get_file(Path::new("/home/user/a.txt"))
-            .unwrap()
-            .is_some());
+        assert!(
+            reopened
+                .get_file(Path::new("/home/user/a.txt"))
+                .unwrap()
+                .is_some()
+        );
     }
 }

--- a/crates/nohrs-ui/src/components/file_list.rs
+++ b/crates/nohrs-ui/src/components/file_list.rs
@@ -1,5 +1,5 @@
 use crate::theme::theme;
-use gpui::{div, px, rgb, ParentElement, Styled, Window};
+use gpui::{ParentElement, Styled, Window, div, px, rgb};
 use gpui_component::list::{List, ListDelegate, ListItem};
 use gpui_component::{Icon, IconName, IndexPath};
 use nohrs_models::file_entry::FileEntryDto;
@@ -220,8 +220,8 @@ pub fn human_bytes(size: u64) -> String {
 
 /// Format a Unix timestamp (seconds) as a `year/month/day` date, or `-` if invalid.
 pub fn format_date(timestamp: &u64) -> String {
-    use time::macros::format_description;
     use time::OffsetDateTime;
+    use time::macros::format_description;
 
     let format = format_description!("[year]/[month]/[day]");
     match OffsetDateTime::from_unix_timestamp(*timestamp as i64) {
@@ -251,10 +251,10 @@ pub fn get_file_type(name: &str, kind: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{format_date, get_file_type, human_bytes, FileListDelegate};
+    use super::{FileListDelegate, format_date, get_file_type, human_bytes};
     use gpui::TestAppContext;
-    use gpui_component::list::{List, ListDelegate};
     use gpui_component::IndexPath;
+    use gpui_component::list::{List, ListDelegate};
     use nohrs_models::file_entry::FileEntryDto;
     use proptest::prelude::*;
     use std::sync::{Arc, Mutex};

--- a/crates/nohrs-ui/src/components/layout/footer.rs
+++ b/crates/nohrs-ui/src/components/layout/footer.rs
@@ -1,5 +1,5 @@
 use crate::theme::theme;
-use gpui::{div, prelude::*, px, rgb, Context, IntoElement};
+use gpui::{Context, IntoElement, div, prelude::*, px, rgb};
 use gpui_component::{Icon, IconName};
 
 /// Properties controlling the contents of the footer status bar.
@@ -43,7 +43,10 @@ impl Default for FooterProps {
 }
 
 /// A VSCode-like footer (status bar)
-pub fn footer<V: gpui::Render>(props: FooterProps, cx: &mut Context<V>) -> impl IntoElement {
+pub fn footer<V: gpui::Render>(
+    props: FooterProps,
+    cx: &mut Context<V>,
+) -> impl IntoElement + use<V> {
     div()
         .h(px(28.0))
         .w_full()
@@ -206,7 +209,7 @@ fn truncate_path(path: &str, max_len: usize) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{footer, truncate_path, FooterProps};
+    use super::{FooterProps, footer, truncate_path};
     use gpui::{IntoElement, Render, TestAppContext, Window};
 
     #[test]

--- a/crates/nohrs-ui/src/components/layout/unified_toolbar.rs
+++ b/crates/nohrs-ui/src/components/layout/unified_toolbar.rs
@@ -1,11 +1,11 @@
 use crate::theme::theme;
 use gpui::{
-    div, prelude::*, px, rgb, Action, Context, IntoElement, Pixels, Render, WindowControlArea,
+    Action, Context, IntoElement, Pixels, Render, WindowControlArea, div, prelude::*, px, rgb,
 };
 use gpui_component::{
+    Icon, IconName, Sizable, Size,
     button::{Button, ButtonRounded, ButtonVariant, ButtonVariants},
     popup_menu::PopupMenuExt,
-    Icon, IconName, Sizable, Size,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -37,7 +37,7 @@ impl Default for UnifiedToolbarProps {
 pub fn unified_toolbar<V: Render>(
     props: UnifiedToolbarProps,
     _cx: &mut Context<V>,
-) -> impl IntoElement {
+) -> impl IntoElement + use<V> {
     let UnifiedToolbarProps {
         account_name,
         account_plan,
@@ -261,7 +261,7 @@ impl Action for AccountMenuAction {
 
 #[cfg(test)]
 mod tests {
-    use super::{unified_toolbar, AccountMenuCommand, UnifiedToolbarProps};
+    use super::{AccountMenuCommand, UnifiedToolbarProps, unified_toolbar};
     use gpui::{IntoElement, Render, TestAppContext, Window};
     use serde_json::json;
 

--- a/crates/nohrs-ui/src/components/pane.rs
+++ b/crates/nohrs-ui/src/components/pane.rs
@@ -1,5 +1,5 @@
 use crate::theme::theme;
-use gpui::{div, prelude::*, px, rgb, IntoElement};
+use gpui::{IntoElement, div, prelude::*, px, rgb};
 
 /// Non-functional tab bar (placeholder)
 pub fn tab_bar() -> impl IntoElement {
@@ -55,7 +55,7 @@ pub fn split_container<L: IntoElement, R: IntoElement>(left: L, right: R) -> imp
 #[cfg(test)]
 mod tests {
     use super::{split_container, tab_bar};
-    use gpui::{div, point, px, size, ParentElement, TestAppContext};
+    use gpui::{ParentElement, TestAppContext, div, point, px, size};
 
     #[gpui::test]
     async fn placeholders_lay_out_without_panicking(cx: &mut TestAppContext) {

--- a/crates/nohrs-ui/src/window/traffic_lights.rs
+++ b/crates/nohrs-ui/src/window/traffic_lights.rs
@@ -1,4 +1,4 @@
-use gpui::{point, px, Pixels, Point, TitlebarOptions, WindowOptions};
+use gpui::{Pixels, Point, TitlebarOptions, WindowOptions, point, px};
 
 const DEFAULT_HORIZONTAL_OFFSET: Pixels = px(12.0);
 const DEFAULT_BUTTON_SIZE: Pixels = px(16.0);

--- a/crates/nohrs/src/app.rs
+++ b/crates/nohrs/src/app.rs
@@ -7,9 +7,9 @@
 //! P3) will be opened from here too, as a symmetric second pillar.
 
 use crate::cli::Cli;
-use gpui::{px, size, App, AppContext, Application, Bounds};
-use gpui_component::resizable::ResizableState;
+use gpui::{App, AppContext, Application, Bounds, px, size};
 use gpui_component::Root;
+use gpui_component::resizable::ResizableState;
 use nohrs_core::config::{self, ConfigOverride};
 use nohrs_core::telemetry::logging::init_logging;
 use nohrs_pages::RootView;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,8 +56,8 @@ exclude = ["web"]
 
 [workspace.package]
 version      = "0.0.1"
-edition      = "2021"
-rust-version = "1.83"
+edition      = "2024"
+rust-version = "1.85"
 license      = "MIT"
 repository   = "https://github.com/noh-rs/nohrs"
 homepage     = "https://nohrs.app"

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -136,7 +136,7 @@ disallowed-methods = [
 ### `rustfmt.toml`
 
 ```toml
-edition = "2021"
+edition = "2024"
 imports_granularity = "Crate"
 group_imports = "StdExternalCrate"
 reorder_imports = true

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -5,7 +5,7 @@
 # `cargo fmt --check` on stable enforces only `edition` / `reorder_imports`. They
 # are kept here so a nightly `cargo fmt` reorganizes imports consistently and so
 # the intended policy is documented in one place.
-edition = "2021"
+edition = "2024"
 imports_granularity = "Crate"
 group_imports = "StdExternalCrate"
 reorder_imports = true


### PR DESCRIPTION
The workspace declared `edition = "2021"` and `rust-version = "1.83"`, but the GUI dependency tree already requires newer Rust: `gpui` 0.2.2 is itself `edition = "2024"`, which needs rustc ≥ 1.85. So the declared MSRV of 1.83 only held for the headless `default-members` subset and was unbuildable for the full workspace. This aligns the policy with reality and moves our own crates onto the 2024 edition.

## Changes

- `Cargo.toml` (`workspace.package`): `edition` → `2024`, `rust-version` → `1.85` (the edition-2024 floor). All crates inherit these.
- `rustfmt.toml` / docs: bump `edition` to `2024` so stable `cargo fmt` import ordering matches the crate edition; refresh the snippets in `docs/architecture.md` and `docs/testing.md`.
- `cargo fix --edition` migration:
  - Rust 2024 makes `std::env::{set_var, remove_var}` `unsafe`. The calls only exist in two `nohrs-core` config test modules; they are wrapped in `unsafe {}` and the modules carry a scoped `#[allow(unsafe_code)]` with a comment explaining why (the workspace lint is `unsafe_code = deny`).
  - Several `-> impl IntoElement` signatures gained `+ use<>` precise-capturing bounds to preserve 2021 capture semantics.
- The remaining diff is import reordering from the 2024 rustfmt style edition.

## Verification

- `cargo check --workspace` (GUI crates included) — passes
- `cargo clippy --workspace --all-targets -- -D warnings` — clean, `unsafe_code = deny` still enforced
- `cargo test` (headless default-members) — 71 passed
- `cargo fmt --all --check` — clean

No user-visible behavior changes; the touched `view`/`ui` files differ only in import ordering and capture bounds.

## Follow-up (out of scope)

The config tests mutate process env via `set_var`, which 2024 flags as unsafe because it races with parallel test threads. This is preserved as-is here; serializing those tests or injecting env lookups would be a cleaner long-term fix.

Release Notes:

- N/A

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrate the workspace to Rust 2024 edition and raise MSRV to 1.85 to align with `gpui` 0.2.2. No behavior changes; this makes the full workspace build requirements explicit and stabilizes env-mutating tests.

- **Refactors**
  - Set `edition = "2024"` and `rust-version = "1.85"` in `Cargo.toml`; updated `rustfmt.toml` and docs.
  - Applied `cargo fix --edition`: wrapped test uses of `std::env::{set_var, remove_var}` in `unsafe` with scoped `#[allow(unsafe_code)]`; added a shared `cfg(test)` `test_env::env_lock()` in `nohrs-core::config` and routed `paths.rs`/`settings.rs` tests through it to serialize env mutations across modules.
  - Added `+ use<>` precise-capture bounds to UI render functions returning `-> impl IntoElement`.
  - Remaining diffs are import reorders from 2024 rustfmt.

- **Migration**
  - Toolchain: use rustc 1.85+ (e.g., `rustup toolchain install 1.85`).
  - Formatting: `cargo fmt` now enforces 2024 import ordering; expect minor churn.
  - No runtime or API changes required.

<sup>Written for commit db8e408aa1a107cb76a9d970ce1f72935cfa0225. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/noh-rs/nohrs/pull/181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded project to Rust edition 2024 and minimum Rust version 1.85; docs and formatting updated accordingly.
* **Tests**
  * Improved test isolation for environment-mutating tests to make test runs more robust under the newer toolchain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->