### PR TITLE
pull-request: Propose a blog issue when a change is blog-worthy

### DIFF
--- a/.claude/skills/pull-request/SKILL.md
+++ b/.claude/skills/pull-request/SKILL.md
@@ -15,6 +15,8 @@ metadata:
 
 End-to-end flow for turning the current change into a pull request that passes
 this repo's automated quality gate, fixing review feedback in a loop until green.
+When green, it also flags changes worth a blog post and offers to file a blog
+issue (Phase 6).
 
 The quality gate here is **not** classic GitHub Actions (there are none yet). It
 is:
@@ -174,6 +176,67 @@ Phase 5 for what to do if still blocked).
   or access you need from them. Don't keep pushing speculative fixes — repeated
   no-op pushes spam the reviewers and burn CI.
 
+## Phase 6 — Blog-worthy? (propose, don't auto-write)
+
+Once the PR is green and reported (Phase 5 "Green"), judge whether the change
+holds a lesson worth a blog post — then **propose** it. Don't write the article
+and don't file anything without the user's go-ahead. Skip this entirely on the
+escalate path (a still-blocked PR isn't ready to write up).
+
+**The bar (propose only if it clears it).** This repo's blog is for design
+stories and instructive findings (see #154, #157), not changelog entries.
+Propose when the PR contains one of:
+
+- A non-obvious **design decision / architectural shift** with real tradeoffs
+  (e.g. #154 — removing tokio for consistency, not speed).
+- A **subtle bug** whose root cause generalizes — teaches something beyond this
+  codebase.
+- A **surprising discovery** about a tool, library, or platform behavior (GPUI
+  quirks, build/runtime gotchas).
+
+Do **not** propose for routine feature adds, mechanical refactors, dependency
+bumps, docs-only changes, or trivial fixes. One proposal max — if the user
+declines, drop it (don't nag on later pushes).
+
+**If it clears the bar:** give the user a 1–2 line pitch (the angle/thesis, not
+"added X") and ask if they want a blog issue filed. The blog engine (#99) isn't
+built yet, so blog topics live as GitHub issues following the #154/#157
+convention.
+
+**On approval**, file the issue while the diff is fresh — the `path:line`
+references are the most valuable part to capture now:
+
+```bash
+gh issue create \
+  --title "Blog: <topic>" \
+  --label "type:docs,area:docs,area:web" \
+  --body "$(cat <<'EOF'
+関連: PR #<this-pr> / #99 (blog エンジン) / <related issues>
+
+## 目標
+<the design story / lesson — what other developers learn, not "got faster">
+
+## 記事の角度（draft）
+- <thesis / angle>
+
+## アウトライン（draft）
+- [ ] <section>
+- [ ] <section>
+
+## 引用したい実コード（PR #<this-pr>）
+- `crates/.../foo.rs:NN` — <why this line matters>
+
+## 完了条件
+- <topic> の記事が blog で公開される
+
+## 参照
+- <docs/ADR links>
+EOF
+)"
+```
+
+Match the existing issues' Japanese section headings. Title may be Japanese.
+
 ---
 
 ## Reference
@@ -188,6 +251,7 @@ Phase 5 for what to do if still blocked).
 | Gate report | `.claude/skills/pull-request/scripts/review-status.sh [PR#]` |
 | Publish screenshots | `.claude/skills/pull-request/scripts/attach-screenshots.sh <slug> <png...>` |
 | PR review threads (raw) | `gh api repos/{owner}/{repo}/pulls/{n}/comments` |
+| Blog issue convention | `gh issue list --label type:docs` (template: #154, #157) |
 
 **AI reviewer bots** treated as the gate: `coderabbitai[bot]`, `cubic-dev-ai[bot]`.
 Override with the `PR_REVIEW_BOTS` env var (space-separated) if the set changes.


### PR DESCRIPTION
Add a "Phase 6 — Blog-worthy?" step to the `pull-request` skill so that, once a PR is green, the agent judges whether the change holds a lesson worth a blog post and — only if it clears a high bar — **proposes** filing a blog issue.

The repo's blog engine (#99) isn't built yet, so blog topics currently live as GitHub issues following the #154/#157 convention (`Blog:` title, `type:docs,area:docs,area:web` labels, 目標/角度/アウトライン/引用したい実コード/参照 sections). Phase 6 captures the `file:line` references while the diff is fresh, which is the most valuable part to record for later write-up.

Guardrails:
- Proposal only — never auto-writes the article, and files nothing without the user's go-ahead.
- High bar: design decisions/architectural shifts, instructive bugs, or surprising tool/platform discoveries. Stays silent for routine features, mechanical refactors, dependency bumps, docs-only, and trivial fixes.
- Green path only — skipped on the escalate path. One proposal max, no nagging.

Also adds a one-line pointer in the skill intro and a `Blog issue convention` row to the Reference table.

## Verification

N/A — this changes only the `pull-request` skill definition (a prompt/markdown doc); no Rust or UI code is touched, so the cargo gate and UI verification do not apply.

Release Notes:

- N/A

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Phase 6 to the `pull-request` skill: once a PR is green, it judges if the change is blog-worthy and, if so, proposes creating a blog issue following the #154/#157 convention. No product code changes; this updates the skill doc only.

- **New Features**
  - Proposes (never auto-files) a blog issue for high-signal changes: design/architecture decisions, instructive bugs, or surprising tool/platform discoveries.
  - Skips routine work (features, mechanical refactors, dependency bumps, docs-only, trivial fixes); one proposal max; skipped on the escalate path.
  - Captures `path:line` references while the diff is fresh and provides a `gh issue create` template with the existing Japanese sections.
  - Adds a brief pointer in the skill intro and a “Blog issue convention” row in the Reference table.

<sup>Written for commit a217bed2a72d570aee6dbeb526e4e405ddb02dc6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/noh-rs/nohrs/pull/182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced pull-request workflow documentation with Phase 6, including guidance for proposing blog content when changes meet specific design, bug, or discovery criteria, along with instructions for creating and tracking related issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->