### PR TITLE
explorer: Add file operations service and multi-select model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4122,6 +4122,7 @@ dependencies = [
  "tempfile",
  "time",
  "tracing",
+ "trash",
 ]
 
 [[package]]
@@ -7142,6 +7143,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "trash"
+version = "5.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7602e0c7d66ec2d92a8c917219fbc7894039efa2063b9064260110828a356f46"
+dependencies = [
+ "chrono",
+ "libc",
+ "log",
+ "objc2",
+ "objc2-foundation",
+ "once_cell",
+ "percent-encoding",
+ "scopeguard",
+ "urlencoding",
+ "windows 0.56.0",
+]
+
+[[package]]
 name = "tree-sitter"
 version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7369,6 +7388,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "usvg"
@@ -7807,6 +7832,16 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de69df01bdf1ead2f4ac895dc77c9351aefff65b2f3db429a343f9cbf05e132"
+dependencies = [
+ "windows-core 0.56.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
@@ -7848,6 +7883,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4698e52ed2d08f8658ab0c39512a7c00ee5fe2688c65f8c0a4f06750d729f2a6"
+dependencies = [
+ "windows-implement 0.56.0",
+ "windows-interface 0.56.0",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -7901,6 +7948,17 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-implement"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
@@ -7915,6 +7973,17 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/nohrs-pages/src/explorer/list_setup.rs
+++ b/crates/nohrs-pages/src/explorer/list_setup.rs
@@ -18,7 +18,7 @@ impl ExplorerPane {
                 window,
                 |this, _list, event: &ListEvent, window, cx| match event {
                     ListEvent::Select(ix) => {
-                        this.selected_index = Some(ix.row);
+                        this.select_single(ix.row);
                         if let Some(item) = this.filtered_entries.get(ix.row).cloned() {
                             if item.kind == "file" {
                                 this.open_preview(item.path, window, cx);
@@ -36,7 +36,7 @@ impl ExplorerPane {
                             }
                         }
                         this.last_click_info = None;
-                        this.selected_index = Some(ix.row);
+                        this.select_single(ix.row);
                         if let Some(item) = this.filtered_entries.get(ix.row).cloned() {
                             this.activate_entry(item, window, cx);
                         }

--- a/crates/nohrs-pages/src/explorer/page.rs
+++ b/crates/nohrs-pages/src/explorer/page.rs
@@ -504,6 +504,18 @@ impl ExplorerPage {
         self.group.active_pane().read(cx).status_for_footer()
     }
 
+    /// Selection and listing counts for the active tab, as `(selected, total)`,
+    /// for the footer's "N selected" / "N items" indicators.
+    pub fn selection_counts(&self, cx: &App) -> (usize, usize) {
+        let pane = self.group.active_pane().read(cx);
+        (pane.selection.len(), pane.filtered_entries.len())
+    }
+
+    /// Absolute path of the active tab's current directory, for the footer.
+    pub fn current_path(&self, cx: &App) -> String {
+        self.group.active_pane().read(cx).cwd.clone()
+    }
+
     // Captures the current panes/tabs into a persistable snapshot (§4).
     fn session_snapshot(&self, cx: &App) -> SessionSnapshot {
         let panes = (0..self.group.pane_count())

--- a/crates/nohrs-pages/src/explorer/search.rs
+++ b/crates/nohrs-pages/src/explorer/search.rs
@@ -67,6 +67,9 @@ impl ExplorerPane {
                         if this.search_generation != generation {
                             return;
                         }
+                        // The result set replaces `filtered_entries`, so drop any
+                        // selection whose indices referred to the old listing.
+                        this.clear_selection();
                         match processed {
                             Ok((grouped, entries)) => {
                                 this.filtered_entries = entries;

--- a/crates/nohrs-pages/src/explorer/state.rs
+++ b/crates/nohrs-pages/src/explorer/state.rs
@@ -59,8 +59,12 @@ pub struct ExplorerPane {
     pub preview_path: Option<String>,
     /// Text content of the previewed file, when it is textual.
     pub preview_text: Option<String>,
-    /// Index of the selected row within `filtered_entries`.
-    pub selected_index: Option<usize>,
+    /// Indices (into `filtered_entries`) of all currently selected rows.
+    pub selection: std::collections::BTreeSet<usize>,
+    /// Anchor row for Shift range selection, or `None` when nothing is anchored.
+    pub selection_anchor: Option<usize>,
+    /// The active/primary row that drives the preview and keyboard navigation.
+    pub active_index: Option<usize>,
     /// Scroll handle for the virtualized listing.
     pub virtual_scroll_handle: VirtualListScrollHandle,
     /// Per-row sizes for the virtualized listing.
@@ -188,7 +192,9 @@ impl ExplorerPane {
             subs: Vec::new(),
             preview_path: None,
             preview_text: None,
-            selected_index: None,
+            selection: std::collections::BTreeSet::new(),
+            selection_anchor: None,
+            active_index: None,
             virtual_scroll_handle: VirtualListScrollHandle::new(),
             item_sizes: Rc::new(Vec::new()),
             col_name_width: config::COL_NAME_WIDTH,
@@ -287,6 +293,95 @@ impl ExplorerPane {
         });
     }
 
+    /// Returns whether the row at `ix` (an index into `filtered_entries`) is
+    /// part of the current selection.
+    pub fn is_selected(&self, ix: usize) -> bool {
+        self.selection.contains(&ix)
+    }
+
+    /// Replaces the selection with the single row `ix`, making it both the
+    /// anchor and the active row (a plain click or arrow-key move).
+    pub(crate) fn select_single(&mut self, ix: usize) {
+        self.selection.clear();
+        self.selection.insert(ix);
+        self.selection_anchor = Some(ix);
+        self.active_index = Some(ix);
+    }
+
+    /// Toggles row `ix` in the selection (Cmd/Ctrl+click) and re-anchors there.
+    pub(crate) fn toggle_select(&mut self, ix: usize) {
+        if !self.selection.remove(&ix) {
+            self.selection.insert(ix);
+        }
+        self.selection_anchor = Some(ix);
+        self.active_index = Some(ix);
+    }
+
+    /// Selects the contiguous range between the current anchor and `ix`
+    /// (Shift+click / Shift+arrow). Falls back to a single selection when there
+    /// is no anchor yet.
+    pub(crate) fn select_range_to(&mut self, ix: usize) {
+        let anchor = match self.selection_anchor {
+            Some(anchor) => anchor,
+            None => {
+                self.select_single(ix);
+                return;
+            }
+        };
+        let (low, high) = if anchor <= ix {
+            (anchor, ix)
+        } else {
+            (ix, anchor)
+        };
+        self.selection = (low..=high).collect();
+        self.active_index = Some(ix);
+    }
+
+    /// Selects every visible row.
+    pub(crate) fn select_all(&mut self) {
+        let len = self.filtered_entries.len();
+        self.selection = (0..len).collect();
+        self.selection_anchor = if len > 0 { Some(0) } else { None };
+        self.active_index = len.checked_sub(1);
+    }
+
+    /// Clears the selection, anchor, and active row.
+    pub(crate) fn clear_selection(&mut self) {
+        self.selection.clear();
+        self.selection_anchor = None;
+        self.active_index = None;
+    }
+
+    /// Moves the active row by `delta` rows, clamped to the visible range. With
+    /// `extend` (Shift held) the selection grows from the anchor; otherwise the
+    /// moved-to row becomes the sole selection. Selecting from an empty state
+    /// lands on the first row.
+    pub(crate) fn move_active(&mut self, delta: isize, extend: bool) {
+        let len = self.filtered_entries.len();
+        if len == 0 {
+            return;
+        }
+        let next = match self.active_index {
+            Some(current) => (current as isize + delta).clamp(0, len as isize - 1) as usize,
+            None => 0,
+        };
+        if extend {
+            self.select_range_to(next);
+        } else {
+            self.select_single(next);
+        }
+    }
+
+    /// Paths of the currently selected rows, in row order. Used by file
+    /// operations and drag-and-drop.
+    pub fn selected_paths(&self) -> Vec<String> {
+        self.selection
+            .iter()
+            .filter_map(|&ix| self.filtered_entries.get(ix))
+            .map(|entry| entry.path.clone())
+            .collect()
+    }
+
     pub(crate) fn update_item_sizes(&mut self) {
         let total_width = self.total_table_width();
 
@@ -333,6 +428,11 @@ impl ExplorerPane {
             self.update_item_sizes();
             return;
         }
+
+        // Rebuilding `filtered_entries` invalidates the row indices the
+        // selection is expressed in, so reset it rather than risk selecting
+        // unrelated rows after a sort/filter/reload.
+        self.clear_selection();
 
         let show_hidden = self.show_hidden;
         let visible = self

--- a/crates/nohrs-pages/src/explorer/state.rs
+++ b/crates/nohrs-pages/src/explorer/state.rs
@@ -422,17 +422,17 @@ impl ExplorerPane {
     }
 
     pub(crate) fn apply_filter(&mut self) {
+        // Rebuilding the visible row set (here or via the search path) invalidates
+        // the row indices the selection is expressed in, so reset it rather than
+        // risk acting on unrelated rows after a sort/filter/reload/search.
+        self.clear_selection();
+
         // When explicit search results are displayed, `filtered_entries` is owned
         // by the search path; only refresh row sizes here.
         if self.search_results.is_some() {
             self.update_item_sizes();
             return;
         }
-
-        // Rebuilding `filtered_entries` invalidates the row indices the
-        // selection is expressed in, so reset it rather than risk selecting
-        // unrelated rows after a sort/filter/reload.
-        self.clear_selection();
 
         let show_hidden = self.show_hidden;
         let visible = self

--- a/crates/nohrs-pages/src/explorer/tests.rs
+++ b/crates/nohrs-pages/src/explorer/tests.rs
@@ -866,3 +866,100 @@ async fn restore_disabled_ignores_saved_session(cx: &mut TestAppContext) {
         })
         .unwrap();
 }
+
+#[gpui::test]
+async fn selection_single_toggle_range_and_paths(cx: &mut TestAppContext) {
+    let window = new_explorer(cx);
+    window
+        .update(cx, |page, _window, _cx| {
+            page.filtered_entries = vec![
+                file("a", "file", 1),
+                file("b", "file", 2),
+                file("c", "file", 3),
+                file("d", "file", 4),
+            ];
+
+            // Single selection re-anchors and becomes active.
+            page.select_single(1);
+            assert!(page.is_selected(1));
+            assert_eq!(page.selection.len(), 1);
+            assert_eq!(page.active_index, Some(1));
+
+            // Shift range spans from the anchor (row 1) to row 3 inclusive.
+            page.select_range_to(3);
+            assert_eq!(
+                page.selection.iter().copied().collect::<Vec<_>>(),
+                vec![1, 2, 3]
+            );
+            assert_eq!(page.active_index, Some(3));
+
+            // Cmd/Ctrl toggle removes one without clearing the rest and adds
+            // another, re-anchoring at the toggled row.
+            page.toggle_select(2);
+            assert!(!page.is_selected(2) && page.is_selected(1) && page.is_selected(3));
+            page.toggle_select(0);
+            assert!(page.is_selected(0));
+
+            // `selected_paths` follows row order (rows 0, 1, 3).
+            assert_eq!(page.selected_paths(), vec!["/tmp/a", "/tmp/b", "/tmp/d"]);
+        })
+        .unwrap();
+}
+
+#[gpui::test]
+async fn selection_all_clear_and_arrow_navigation(cx: &mut TestAppContext) {
+    let window = new_explorer(cx);
+    window
+        .update(cx, |page, _window, _cx| {
+            page.filtered_entries = vec![
+                file("a", "file", 1),
+                file("b", "file", 2),
+                file("c", "file", 3),
+            ];
+
+            page.select_all();
+            assert_eq!(page.selection.len(), 3);
+            assert_eq!(page.active_index, Some(2));
+
+            page.clear_selection();
+            assert!(page.selection.is_empty());
+            assert_eq!(page.active_index, None);
+            assert_eq!(page.selection_anchor, None);
+
+            // Arrow-down from an empty selection lands on the first row.
+            page.move_active(1, false);
+            assert_eq!(page.active_index, Some(0));
+            page.move_active(1, false);
+            assert_eq!(page.active_index, Some(1));
+
+            // Shift+down extends the range from the anchor; up is clamped at 0.
+            page.move_active(1, true);
+            assert_eq!(
+                page.selection.iter().copied().collect::<Vec<_>>(),
+                vec![1, 2]
+            );
+            page.select_single(0);
+            page.move_active(-1, false);
+            assert_eq!(page.active_index, Some(0));
+        })
+        .unwrap();
+}
+
+#[gpui::test]
+async fn apply_filter_resets_stale_selection(cx: &mut TestAppContext) {
+    let window = new_explorer(cx);
+    window
+        .update(cx, |page, _window, _cx| {
+            page.entries = vec![file("a", "file", 1), file("b", "file", 2)];
+            page.apply_filter();
+            page.select_all();
+            assert!(!page.selection.is_empty());
+
+            // Re-filtering rebuilds the row set, so the selection must reset to
+            // avoid pointing at stale indices.
+            page.apply_filter();
+            assert!(page.selection.is_empty());
+            assert_eq!(page.active_index, None);
+        })
+        .unwrap();
+}

--- a/crates/nohrs-pages/src/explorer/view.rs
+++ b/crates/nohrs-pages/src/explorer/view.rs
@@ -34,13 +34,38 @@ pub fn render(
         .track_focus(&page.focus_handle)
         .on_key_down(cx.listener(|this, event: &gpui::KeyDownEvent, window, cx| {
             let key_lc = event.keystroke.key.to_lowercase();
-            let with_modifier =
-                event.keystroke.modifiers.platform || event.keystroke.modifiers.control;
+            let modifiers = event.keystroke.modifiers;
+            let with_modifier = modifiers.platform || modifiers.control;
             let is_f = key_lc == "f" || event.keystroke.key == "KeyF";
             let close_with_escape = key_lc == "escape" && this.search_visible;
             if (is_f && with_modifier) || close_with_escape {
                 this.toggle_search(window, cx);
                 cx.stop_propagation();
+                return;
+            }
+            // Selection model (§5). Escape while searching is handled above, so
+            // here it only clears the selection.
+            match key_lc.as_str() {
+                "a" if with_modifier => {
+                    this.select_all();
+                    cx.stop_propagation();
+                    cx.notify();
+                }
+                "escape" => {
+                    this.clear_selection();
+                    cx.notify();
+                }
+                "up" => {
+                    this.move_active(-1, modifiers.shift);
+                    cx.stop_propagation();
+                    cx.notify();
+                }
+                "down" => {
+                    this.move_active(1, modifiers.shift);
+                    cx.stop_propagation();
+                    cx.notify();
+                }
+                _ => {}
             }
         }))
         .on_mouse_move(

--- a/crates/nohrs-pages/src/explorer/view.rs
+++ b/crates/nohrs-pages/src/explorer/view.rs
@@ -51,8 +51,13 @@ pub fn render(
                     cx.stop_propagation();
                     cx.notify();
                 }
-                "escape" => {
+                // Search-close Escape is handled by the branch above (which
+                // returns early), so here Escape only clears a selection — and
+                // only consumes the event when there was one to clear, leaving
+                // an empty-selection Escape free to bubble.
+                "escape" if !this.selection.is_empty() => {
                     this.clear_selection();
+                    cx.stop_propagation();
                     cx.notify();
                 }
                 "up" => {

--- a/crates/nohrs-pages/src/explorer/view/listing/grid.rs
+++ b/crates/nohrs-pages/src/explorer/view/listing/grid.rs
@@ -21,7 +21,7 @@ pub fn render(
         .min_h(px(0.0));
 
     for (ix, item) in items.into_iter().enumerate() {
-        let selected = page.selected_index == Some(ix);
+        let selected = page.is_selected(ix);
         grid = grid.child(render_grid_item(page, item, ix, selected, window, cx));
     }
 
@@ -91,13 +91,21 @@ fn render_grid_item(
             gpui::MouseButton::Left,
             cx.listener(move |this, event: &gpui::MouseDownEvent, window, cx| {
                 this.record_click(ix, event.click_count);
-                this.selected_index = Some(ix);
+                let modifiers = event.modifiers;
+                if modifiers.shift {
+                    this.select_range_to(ix);
+                } else if modifiers.platform || modifiers.control {
+                    this.toggle_select(ix);
+                } else {
+                    this.select_single(ix);
+                }
                 if preview_item.kind == "file" {
                     this.open_preview(preview_item.path.clone(), window, cx);
                 }
                 if event.click_count >= 2 {
                     this.activate_entry(activation_item.clone(), window, cx);
                 }
+                cx.notify();
             }),
         )
         .child(

--- a/crates/nohrs-pages/src/explorer/view/listing/row.rs
+++ b/crates/nohrs-pages/src/explorer/view/listing/row.rs
@@ -26,7 +26,9 @@ pub fn render(
         _ => rgb(theme::GRAY_600),
     };
 
-    let bg_color = if ix % 2 == 0 {
+    let bg_color = if page.is_selected(ix) {
+        theme::ACCENT_LIGHT
+    } else if ix % 2 == 0 {
         theme::BG
     } else {
         theme::GRAY_50
@@ -115,13 +117,21 @@ pub fn render(
                         if let gpui::ClickEvent::Mouse(mouse) = event {
                             if mouse.up.button == gpui::MouseButton::Left {
                                 this.record_click(ix, mouse.up.click_count);
-                                this.selected_index = Some(ix);
+                                let modifiers = mouse.up.modifiers;
+                                if modifiers.shift {
+                                    this.select_range_to(ix);
+                                } else if modifiers.platform || modifiers.control {
+                                    this.toggle_select(ix);
+                                } else {
+                                    this.select_single(ix);
+                                }
                                 if item_for_preview.kind == "file" {
                                     this.open_preview(item_for_preview.path.clone(), window, cx);
                                 }
                                 if mouse.up.click_count >= 2 {
                                     this.activate_entry(item_for_activate.clone(), window, cx);
                                 }
+                                cx.notify();
                             }
                         }
                     }),

--- a/crates/nohrs-pages/src/root.rs
+++ b/crates/nohrs-pages/src/root.rs
@@ -313,8 +313,7 @@ impl Render for RootView {
                             None => (None, false),
                         },
                     };
-                    let (selected_count, total_count) =
-                        self.explorer.read(cx).selection_counts(cx);
+                    let (selected_count, total_count) = self.explorer.read(cx).selection_counts(cx);
                     let current_path = self.explorer.read(cx).current_path(cx);
                     let props = FooterProps {
                         selected_count,

--- a/crates/nohrs-pages/src/root.rs
+++ b/crates/nohrs-pages/src/root.rs
@@ -313,7 +313,13 @@ impl Render for RootView {
                             None => (None, false),
                         },
                     };
+                    let (selected_count, total_count) =
+                        self.explorer.read(cx).selection_counts(cx);
+                    let current_path = self.explorer.read(cx).current_path(cx);
                     let props = FooterProps {
+                        selected_count,
+                        total_count,
+                        current_path,
                         indexing_progress: self.indexing_progress,
                         status_message,
                         status_is_error,

--- a/crates/nohrs-services/Cargo.toml
+++ b/crates/nohrs-services/Cargo.toml
@@ -33,6 +33,7 @@ grep = "0.4"
 dirs = "6.0"
 notify = "8"
 notify-debouncer-mini = "0.7"
+trash = "5"
 gpui = { version = "0.2", optional = true }
 syntect = { version = "5", default-features = false, features = ["default-fancy"], optional = true }
 

--- a/crates/nohrs-services/src/fs.rs
+++ b/crates/nohrs-services/src/fs.rs
@@ -1,4 +1,7 @@
-//! Directory listing with stable, case-insensitive ordering and cursor paging.
+//! Directory listing with stable, case-insensitive ordering and cursor paging,
+//! plus synchronous file mutation operations (copy/move/rename/delete/trash).
 
 /// Synchronous directory listing.
 pub mod listing;
+/// Synchronous file mutation operations with cross-volume and conflict handling.
+pub mod ops;

--- a/crates/nohrs-services/src/fs.rs
+++ b/crates/nohrs-services/src/fs.rs
@@ -1,5 +1,5 @@
 //! Directory listing with stable, case-insensitive ordering and cursor paging,
-//! plus synchronous file mutation operations (copy/move/rename/delete/trash).
+//! plus synchronous file mutation operations (see [`ops`]).
 
 /// Synchronous directory listing.
 pub mod listing;

--- a/crates/nohrs-services/src/fs/ops.rs
+++ b/crates/nohrs-services/src/fs/ops.rs
@@ -1,0 +1,323 @@
+//! Filesystem mutation operations: copy, move, rename, create, trash, and
+//! permanent delete, with cross-volume awareness and conflict-name resolution.
+//!
+//! These functions are synchronous filesystem IO. Callers that must stay
+//! responsive during large operations should run them on a background executor
+//! (mirroring how `search` offloads work via `cx.background_spawn`). The UI
+//! layer is expected to route all mutations through this module rather than
+//! calling `std::fs` directly (see `docs/explorer-essentials.md` §8).
+
+use nohrs_core::errors::{Error, Result};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// How a [`move_path`] operation was carried out.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MoveKind {
+    /// The move stayed on a single filesystem and used `rename(2)`.
+    Rename,
+    /// Source and destination were on different filesystems, so the move was
+    /// performed as a recursive copy followed by deleting the source.
+    CrossVolume,
+}
+
+/// How a name collision at the destination should be resolved when copying or
+/// moving. The resolution itself is applied by the caller; this module only
+/// provides the building blocks ([`would_conflict`], [`unique_name`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConflictResolution {
+    /// Keep both items by writing to a non-colliding name (see [`unique_name`]).
+    Rename,
+    /// Replace the existing destination.
+    Overwrite,
+    /// Leave the destination untouched and skip this item.
+    Skip,
+}
+
+/// Returns whether `dst` already exists, the condition that triggers conflict
+/// resolution before a copy or move.
+pub fn would_conflict(dst: &Path) -> bool {
+    dst.exists()
+}
+
+/// Returns `true` when `src` and `dst_dir` reside on different filesystems, in
+/// which case a move cannot use `rename(2)` and must copy then delete.
+///
+/// On non-Unix platforms device ids are not consulted, so this conservatively
+/// returns `false`; [`move_path`] still detects the cross-device error from
+/// `rename` and falls back to copy + delete regardless.
+pub fn is_cross_volume(src: &Path, dst_dir: &Path) -> Result<bool> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        let src_dev = fs::metadata(src)?.dev();
+        let dst_dev = fs::metadata(dst_dir)?.dev();
+        Ok(src_dev != dst_dev)
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (src, dst_dir);
+        Ok(false)
+    }
+}
+
+/// Produces a file name within `dir` that does not collide with an existing
+/// entry, deriving it from `name` by inserting ` (N)` before the extension
+/// (`report.pdf` becomes `report (2).pdf`), trying `N = 2, 3, ...` until a free
+/// name is found. Returns `name` unchanged when there is no collision.
+pub fn unique_name(dir: &Path, name: &str) -> String {
+    if !dir.join(name).exists() {
+        return name.to_string();
+    }
+    let path = Path::new(name);
+    let extension = path.extension().and_then(|ext| ext.to_str());
+    // `file_stem` is `None` only for empty names; fall back to the full name so
+    // we never panic and always make progress.
+    let stem = path.file_stem().and_then(|s| s.to_str()).unwrap_or(name);
+    let mut counter: u32 = 2;
+    loop {
+        let candidate = match extension {
+            Some(extension) => format!("{stem} ({counter}).{extension}"),
+            None => format!("{stem} ({counter})"),
+        };
+        if !dir.join(&candidate).exists() {
+            return candidate;
+        }
+        counter += 1;
+    }
+}
+
+/// Recursively copies `src` (a file or directory) to `dst`, where `dst` is the
+/// full destination path rather than its parent directory. Missing parent
+/// directories are created; an existing destination file is overwritten.
+pub fn copy_path(src: &Path, dst: &Path) -> Result<()> {
+    let metadata = fs::symlink_metadata(src)?;
+    if metadata.is_dir() {
+        copy_dir_all(src, dst)
+    } else {
+        if let Some(parent) = dst.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::copy(src, dst)?;
+        Ok(())
+    }
+}
+
+// Recursively copies the contents of directory `src` into `dst`, creating
+// `dst` and any intermediate directories. Symlinks are copied via `fs::copy`
+// (following the link) rather than recursed into, to avoid cycles.
+fn copy_dir_all(src: &Path, dst: &Path) -> Result<()> {
+    fs::create_dir_all(dst)?;
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        let from = entry.path();
+        let to = dst.join(entry.file_name());
+        if file_type.is_dir() {
+            copy_dir_all(&from, &to)?;
+        } else {
+            fs::copy(&from, &to)?;
+        }
+    }
+    Ok(())
+}
+
+/// Moves `src` to `dst`. Uses `rename(2)` when both reside on the same
+/// filesystem; otherwise (a cross-volume move) copies `src` recursively to
+/// `dst` and then removes the source, reporting which path was taken.
+pub fn move_path(src: &Path, dst: &Path) -> Result<MoveKind> {
+    match fs::rename(src, dst) {
+        Ok(()) => Ok(MoveKind::Rename),
+        Err(error) if is_cross_device(&error) => {
+            copy_path(src, dst)?;
+            delete_permanent(src)?;
+            Ok(MoveKind::CrossVolume)
+        }
+        Err(error) => Err(Error::Io(error)),
+    }
+}
+
+// Whether an IO error from `rename` indicates the source and destination are on
+// different devices, the signal to fall back to copy + delete.
+#[cfg(unix)]
+fn is_cross_device(error: &std::io::Error) -> bool {
+    // EXDEV ("Invalid cross-device link") is 18 on Linux and macOS.
+    error.raw_os_error() == Some(18)
+}
+
+#[cfg(windows)]
+fn is_cross_device(error: &std::io::Error) -> bool {
+    // ERROR_NOT_SAME_DEVICE.
+    error.raw_os_error() == Some(17)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn is_cross_device(_error: &std::io::Error) -> bool {
+    false
+}
+
+/// Renames `src` to `new_name` within its current directory, returning the new
+/// full path. `new_name` must be a bare file name, not a path with separators.
+pub fn rename_in_place(src: &Path, new_name: &str) -> Result<PathBuf> {
+    let parent = src.parent().ok_or_else(|| {
+        Error::Other(format!(
+            "cannot rename path without a parent: {}",
+            src.display()
+        ))
+    })?;
+    let dst = parent.join(new_name);
+    fs::rename(src, &dst)?;
+    Ok(dst)
+}
+
+/// Creates a new directory named `name` inside `parent`, returning its full
+/// path. Fails if a file or directory of that name already exists.
+pub fn create_dir(parent: &Path, name: &str) -> Result<PathBuf> {
+    let dst = parent.join(name);
+    fs::create_dir(&dst)?;
+    Ok(dst)
+}
+
+/// Moves `path` to the operating system's trash/recycle bin.
+pub fn trash_path(path: &Path) -> Result<()> {
+    trash::delete(path).map_err(|error| Error::Other(format!("failed to move to trash: {error}")))
+}
+
+/// Permanently deletes `path`, whether it is a file, symlink, or directory
+/// tree. This cannot be undone.
+pub fn delete_permanent(path: &Path) -> Result<()> {
+    let metadata = fs::symlink_metadata(path)?;
+    if metadata.is_dir() {
+        fs::remove_dir_all(path)?;
+    } else {
+        fs::remove_file(path)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::disallowed_methods)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn unique_name_returns_input_when_no_collision() {
+        let dir = tempdir().unwrap();
+        assert_eq!(unique_name(dir.path(), "report.pdf"), "report.pdf");
+    }
+
+    #[test]
+    fn unique_name_inserts_counter_before_extension() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("report.pdf"), "a").unwrap();
+        assert_eq!(unique_name(dir.path(), "report.pdf"), "report (2).pdf");
+
+        fs::write(dir.path().join("report (2).pdf"), "b").unwrap();
+        assert_eq!(unique_name(dir.path(), "report.pdf"), "report (3).pdf");
+    }
+
+    #[test]
+    fn unique_name_handles_extensionless_names() {
+        let dir = tempdir().unwrap();
+        fs::create_dir(dir.path().join("folder")).unwrap();
+        assert_eq!(unique_name(dir.path(), "folder"), "folder (2)");
+    }
+
+    #[test]
+    fn would_conflict_reflects_existence() {
+        let dir = tempdir().unwrap();
+        let target = dir.path().join("x");
+        assert!(!would_conflict(&target));
+        fs::write(&target, "x").unwrap();
+        assert!(would_conflict(&target));
+    }
+
+    #[test]
+    fn copy_path_copies_a_file() {
+        let dir = tempdir().unwrap();
+        let src = dir.path().join("a.txt");
+        let dst = dir.path().join("b.txt");
+        fs::write(&src, "hello").unwrap();
+        copy_path(&src, &dst).unwrap();
+        assert_eq!(fs::read_to_string(&dst).unwrap(), "hello");
+        assert!(src.exists(), "source is preserved on copy");
+    }
+
+    #[test]
+    fn copy_path_copies_a_directory_tree() {
+        let dir = tempdir().unwrap();
+        let src = dir.path().join("src");
+        fs::create_dir(&src).unwrap();
+        fs::write(src.join("top.txt"), "top").unwrap();
+        fs::create_dir(src.join("nested")).unwrap();
+        fs::write(src.join("nested").join("deep.txt"), "deep").unwrap();
+
+        let dst = dir.path().join("dst");
+        copy_path(&src, &dst).unwrap();
+
+        assert_eq!(fs::read_to_string(dst.join("top.txt")).unwrap(), "top");
+        assert_eq!(
+            fs::read_to_string(dst.join("nested").join("deep.txt")).unwrap(),
+            "deep"
+        );
+    }
+
+    #[test]
+    fn move_path_within_volume_renames_and_removes_source() {
+        let dir = tempdir().unwrap();
+        let src = dir.path().join("a.txt");
+        let dst = dir.path().join("sub").join("a.txt");
+        fs::create_dir(dir.path().join("sub")).unwrap();
+        fs::write(&src, "payload").unwrap();
+
+        let kind = move_path(&src, &dst).unwrap();
+        assert_eq!(kind, MoveKind::Rename);
+        assert!(!src.exists());
+        assert_eq!(fs::read_to_string(&dst).unwrap(), "payload");
+    }
+
+    #[test]
+    fn rename_in_place_changes_name_keeps_dir() {
+        let dir = tempdir().unwrap();
+        let src = dir.path().join("old.txt");
+        fs::write(&src, "x").unwrap();
+
+        let dst = rename_in_place(&src, "new.txt").unwrap();
+        assert_eq!(dst, dir.path().join("new.txt"));
+        assert!(!src.exists());
+        assert!(dst.exists());
+    }
+
+    #[test]
+    fn create_dir_makes_a_new_directory() {
+        let dir = tempdir().unwrap();
+        let created = create_dir(dir.path(), "fresh").unwrap();
+        assert_eq!(created, dir.path().join("fresh"));
+        assert!(created.is_dir());
+    }
+
+    #[test]
+    fn delete_permanent_removes_file_and_tree() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("f.txt");
+        fs::write(&file, "x").unwrap();
+        delete_permanent(&file).unwrap();
+        assert!(!file.exists());
+
+        let tree = dir.path().join("tree");
+        fs::create_dir(&tree).unwrap();
+        fs::write(tree.join("inner.txt"), "y").unwrap();
+        delete_permanent(&tree).unwrap();
+        assert!(!tree.exists());
+    }
+
+    #[test]
+    fn is_cross_volume_false_within_same_dir() {
+        let dir = tempdir().unwrap();
+        let src = dir.path().join("a.txt");
+        fs::write(&src, "x").unwrap();
+        assert!(!is_cross_volume(&src, dir.path()).unwrap());
+    }
+}

--- a/crates/nohrs-services/src/fs/ops.rs
+++ b/crates/nohrs-services/src/fs/ops.rs
@@ -9,7 +9,7 @@
 
 use nohrs_core::errors::{Error, Result};
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 /// How a [`move_path`] operation was carried out.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -34,10 +34,39 @@ pub enum ConflictResolution {
     Skip,
 }
 
-/// Returns whether `dst` already exists, the condition that triggers conflict
-/// resolution before a copy or move.
+/// Returns whether `dst` is already occupied, the condition that triggers
+/// conflict resolution before a copy or move.
+///
+/// Unlike [`Path::exists`], this probes the entry itself rather than following
+/// symlinks, so a dangling symlink at `dst` still counts as occupied. An
+/// ambiguous error (e.g. a permission failure while stat-ing) is treated
+/// conservatively as occupied so the caller surfaces the conflict path rather
+/// than silently overwriting.
 pub fn would_conflict(dst: &Path) -> bool {
-    dst.exists()
+    path_occupied(dst)
+}
+
+// Whether a filesystem entry exists at `path`, detecting the entry itself
+// (including a broken symlink) rather than following links. Ambiguous errors
+// are reported as occupied; only a definitive "not found" is reported as free.
+fn path_occupied(path: &Path) -> bool {
+    match fs::symlink_metadata(path) {
+        Ok(_) => true,
+        Err(error) => error.kind() != std::io::ErrorKind::NotFound,
+    }
+}
+
+// Validates that `name` is a single, normal path component — not empty, not `.`
+// or `..`, and free of path separators — so child-name inputs cannot escape the
+// target directory when joined.
+fn ensure_plain_name(name: &str) -> Result<()> {
+    let mut components = Path::new(name).components();
+    match (components.next(), components.next()) {
+        (Some(Component::Normal(component)), None) if component == std::ffi::OsStr::new(name) => {
+            Ok(())
+        }
+        _ => Err(Error::Other(format!("invalid file name: {name:?}"))),
+    }
 }
 
 /// Returns `true` when `src` and `dst_dir` reside on different filesystems, in
@@ -50,7 +79,10 @@ pub fn is_cross_volume(src: &Path, dst_dir: &Path) -> Result<bool> {
     #[cfg(unix)]
     {
         use std::os::unix::fs::MetadataExt;
-        let src_dev = fs::metadata(src)?.dev();
+        // `rename(2)` acts on the source directory entry itself, so use the
+        // entry's own device (don't follow a symlink). The destination is the
+        // directory the entry lands in, so its resolved device is what matters.
+        let src_dev = fs::symlink_metadata(src)?.dev();
         let dst_dev = fs::metadata(dst_dir)?.dev();
         Ok(src_dev != dst_dev)
     }
@@ -66,7 +98,7 @@ pub fn is_cross_volume(src: &Path, dst_dir: &Path) -> Result<bool> {
 /// (`report.pdf` becomes `report (2).pdf`), trying `N = 2, 3, ...` until a free
 /// name is found. Returns `name` unchanged when there is no collision.
 pub fn unique_name(dir: &Path, name: &str) -> String {
-    if !dir.join(name).exists() {
+    if !path_occupied(&dir.join(name)) {
         return name.to_string();
     }
     let path = Path::new(name);
@@ -80,7 +112,7 @@ pub fn unique_name(dir: &Path, name: &str) -> String {
             Some(extension) => format!("{stem} ({counter}).{extension}"),
             None => format!("{stem} ({counter})"),
         };
-        if !dir.join(&candidate).exists() {
+        if !path_occupied(&dir.join(&candidate)) {
             return candidate;
         }
         counter += 1;
@@ -159,6 +191,7 @@ fn is_cross_device(_error: &std::io::Error) -> bool {
 /// Renames `src` to `new_name` within its current directory, returning the new
 /// full path. `new_name` must be a bare file name, not a path with separators.
 pub fn rename_in_place(src: &Path, new_name: &str) -> Result<PathBuf> {
+    ensure_plain_name(new_name)?;
     let parent = src.parent().ok_or_else(|| {
         Error::Other(format!(
             "cannot rename path without a parent: {}",
@@ -173,6 +206,7 @@ pub fn rename_in_place(src: &Path, new_name: &str) -> Result<PathBuf> {
 /// Creates a new directory named `name` inside `parent`, returning its full
 /// path. Fails if a file or directory of that name already exists.
 pub fn create_dir(parent: &Path, name: &str) -> Result<PathBuf> {
+    ensure_plain_name(name)?;
     let dst = parent.join(name);
     fs::create_dir(&dst)?;
     Ok(dst)
@@ -311,6 +345,38 @@ mod tests {
         fs::write(tree.join("inner.txt"), "y").unwrap();
         delete_permanent(&tree).unwrap();
         assert!(!tree.exists());
+    }
+
+    #[test]
+    fn would_conflict_detects_a_dangling_symlink() {
+        let dir = tempdir().unwrap();
+        let link = dir.path().join("broken");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(dir.path().join("missing-target"), &link).unwrap();
+        #[cfg(not(unix))]
+        std::fs::write(&link, "x").unwrap();
+        // `Path::exists()` would report `false` for a dangling symlink; the
+        // entry is nonetheless occupied.
+        assert!(would_conflict(&link));
+    }
+
+    #[test]
+    fn rename_and_create_reject_path_traversal_names() {
+        let dir = tempdir().unwrap();
+        let src = dir.path().join("f.txt");
+        fs::write(&src, "x").unwrap();
+        for bad in ["../escape", "a/b", ".", "..", ""] {
+            assert!(
+                rename_in_place(&src, bad).is_err(),
+                "rename allowed {bad:?}"
+            );
+            assert!(
+                create_dir(dir.path(), bad).is_err(),
+                "create allowed {bad:?}"
+            );
+        }
+        // A plain name is still accepted.
+        assert!(create_dir(dir.path(), "ok-dir").is_ok());
     }
 
     #[test]


### PR DESCRIPTION
Foundation for the explorer file-operations epic (#60) and the dependent
drag-and-drop work (#59). Implements sub-issue #184 (parent #60).

`#59` (DnD) and most of `#60` depend on two pieces that did not exist yet:
a filesystem mutation service and a multi-selection model. This PR adds both
so later PRs (copy/paste + conflict dialog, delete/trash, rename, progress UI,
undo, context menu, and DnD) are thin layers on top.

## What changed

**`nohrs-services::fs::ops` (new)** — synchronous file mutations, the single
choke point the UI calls instead of `std::fs` (docs/explorer-essentials.md §8):

- `copy_path` (recursive), `move_path` (rename on the same volume, automatic
  copy+delete across volumes), `rename_in_place`, `create_dir`, `trash_path`
  (new `trash` dep), `delete_permanent`.
- `is_cross_volume` (device-id comparison) plus `unique_name` (`report.pdf`
  -> `report (2).pdf`) and `would_conflict`/`ConflictResolution` for the
  conflict handling a later PR will surface as a dialog.
- 11 unit tests covering each operation and the conflict-name logic.

**Multi-select model (§5)** on `ExplorerPane`:

- Replaces the single `selected_index` with a selection set + anchor + active
  row, with helpers (`select_single`/`toggle_select`/`select_range_to`/
  `select_all`/`clear_selection`/`move_active`/`selected_paths`).
- Wired into list and grid clicks (plain / Shift = range / Cmd·Ctrl = toggle)
  and the keyboard (Cmd/Ctrl+A, Esc, Up/Down, Shift+arrow to extend).
- List/grid rows highlight the selection; `apply_filter` resets it so stale
  indices can't point at unrelated rows after a sort/filter/reload.
- Footer now reflects the active pane's `N selected` / `N items` and path.

Out of scope (tracked as sub-issues of #60): clipboard/paste + conflict dialog
(#185), delete/trash (#186), rename/new folder (#187), progress UI (#188), undo
(#189), context menu (#190).

## Verification

- `cargo test -p nohrs-services` (fs ops, 11 tests) and `cargo test -p nohrs-pages`
  (selection model: single/toggle/range/select-all/clear/arrow-nav + stale-reset)
  pass; `cargo clippy --all-targets` is clean.
- GUI verified headlessly (software Vulkan / Xvnc). Mouse events do not register
  under this Xvnc (`no xinput mouse pointers`), so selection was exercised via the
  keyboard, which drives the same selection helpers as the click handlers.

Range selection + footer counts (`3 selected · 23 items`):

![range selection and footer counts](https://raw.githubusercontent.com/noh-rs/nohrs/pr-assets/screenshots/explorer-multi-select/191126-6354/sel_footer.png)

Select-all (Cmd/Ctrl+A):

![select all](https://raw.githubusercontent.com/noh-rs/nohrs/pr-assets/screenshots/explorer-multi-select/191126-6354/sel_all.png)

Release Notes:

- Added multi-file selection in the explorer (click, Shift-click, Cmd/Ctrl-click, Cmd/Ctrl+A, and arrow keys), with selected/total counts in the status bar.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a synchronous file-operations service and a multi-select model to the Explorer. Implements sub-issue #184 and unblocks the file-ops epic (#60) and drag-and-drop (#59).

- **New Features**
  - `nohrs-services::fs::ops`: copy/move (rename with cross-volume copy+delete fallback)/rename-in-place/create-dir/trash/delete; conflict helpers (`unique_name`, `would_conflict`), and `is_cross_volume`. Conflict detection treats dangling symlinks as occupied, and `rename_in_place`/`create_dir` reject path-traversal names.
  - Explorer multi-select: selection set + anchor + active row with click, Shift-click, Cmd/Ctrl-click, Cmd/Ctrl+A, Esc, and arrow keys; list/grid selection highlighting; footer shows “N selected · N items” and current path. Selection resets on re-filter and when search results rebuild the listing; Escape is only consumed when it clears a selection.

- **Dependencies**
  - Added `trash` to support moving items to the OS trash.

<sup>Written for commit 3ec4dfbed6919f7d421b7669522e679af2b3e32f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/noh-rs/nohrs/pull/191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-row selection (Shift range, Ctrl/Cmd toggle) and selection-aware grid/row interactions
  * Footer shows selected count, total count, and current directory
  * File ops: copy, move (cross-volume aware), rename, trash, and permanent delete

* **Bug Fixes**
  * Selection is cleared when listings/filter/search change to avoid stale indices

* **Tests**
  * Selection behavior and file-op unit tests added/expanded
<!-- end of auto-generated comment: release notes by coderabbit.ai -->