### PR TITLE
Make ui-run.sh wait for a rendered frame instead of a log line

### DIFF
--- a/docs/agent-ui-verification.md
+++ b/docs/agent-ui-verification.md
@@ -109,10 +109,16 @@ for you.
 - **With no window manager the window stays black forever.** Nothing damages the window after it
   is mapped, so gpui presents no further frame — waiting does not help (still all-black after 45s
   on `Xvfb`, `xwininfo` reporting `Map State: IsViewable` the whole time). A one-pixel resize and
-  back forces the redraw. `ui-run.sh launch` does this and then polls the framebuffer until it is
-  no longer a single flat color; if you start the binary by hand, do the nudge yourself:
-  `xdotool windowsize $WIN 1279 779; xdotool sleep 1; xdotool windowsize $WIN 1280 780`.
-  Once a frame is out, ordinary interaction repaints normally.
+  back forces the redraw. `ui-run.sh launch` does this and then polls the window's own pixels
+  until they are no longer a single flat color. Once a frame is out, ordinary interaction
+  repaints normally. If you start the binary by hand, do the nudge yourself — read the size back
+  rather than hardcoding one, since the window is not the same size as the screen:
+  ```bash
+  DISP=$(./script/ui-run.sh display); WIN=$(./script/ui-run.sh win)
+  eval "$(DISPLAY=$DISP xdotool getwindowgeometry --shell "$WIN")"   # sets WIDTH / HEIGHT
+  DISPLAY=$DISP xdotool windowsize "$WIN" $((WIDTH - 1)) $((HEIGHT - 1)) \
+    sleep 1 windowsize "$WIN" "$WIDTH" "$HEIGHT"
+  ```
 - **Do not wait for the `Refreshing every` log line.** gpui only logs it when the RandR mode
   reports a non-zero dot clock. `Xvfb` reports zero, gpui silently falls back to 16ms, and the line
   never appears — so waiting on it just times out. `ui-run.sh` watches the pixels instead.

--- a/docs/agent-ui-verification.md
+++ b/docs/agent-ui-verification.md
@@ -21,18 +21,28 @@ navigation) and want evidence it actually works, not just that it compiles.
 ## One-time prerequisites
 
 ```bash
-# Build-link symlinks so the GUI links without root (creates ~/.local/devlibs):
-./script/ui-run.sh setup
+# Toolchain: rust-toolchain.toml tracks `stable`, but an installed stable older than the
+# one `rusqlite` / `libsqlite3-sys` need fails with "use of unstable library feature
+# `cfg_select`" while compiling their build scripts. Update before blaming the workspace:
+rustup update stable
 
 # Tools (need root once; ask the user to run if sudo needs a password):
 sudo apt-get install -y xdotool                 # input synthesis (click/type/keys)
+sudo apt-get install -y x11-apps                # xwd — screenshot capture, often NOT preinstalled
+sudo apt-get install -y mesa-vulkan-drivers     # llvmpipe ICD; without it there is no Vulkan device
+sudo apt-get install -y libxkbcommon-x11-0      # else `setup` leaves a dangling libxkbcommon-x11.so
+sudo apt-get install -y x11-utils               # optional: xwininfo, to inspect window map state
 sudo apt-get install -y ffmpeg                  # optional: screen recording -> mp4
 sudo apt-get install -y xvfb                    # optional: only if there is NO existing X server
-# Runtime Vulkan (llvmpipe) is usually already present: ls /usr/lib/x86_64-linux-gnu/libvulkan_lvp.so
+
+# Build-link symlinks so the GUI links without root (creates ~/.local/devlibs).
+# Run this AFTER the packages above — it symlinks to runtime .so files that must exist:
+./script/ui-run.sh setup
+ls -lL ~/.local/devlibs                         # every entry must resolve; a dangling one = missing package
 ```
 
-`xwd` (screenshot capture) is normally preinstalled. PNG conversion uses `script/xwd2png.py`
-(stdlib only — no ImageMagick/ffmpeg required for stills).
+Verify the software Vulkan driver landed: `ls /usr/share/vulkan/icd.d/lvp_icd*.json`.
+PNG conversion uses `script/xwd2png.py` (stdlib only — no ImageMagick/ffmpeg required for stills).
 
 ## The loop
 
@@ -40,7 +50,8 @@ sudo apt-get install -y xvfb                    # optional: only if there is NO 
 # 1. Implement your change, then build (note the RUSTFLAGS linker path from `setup`):
 RUSTFLAGS="-L $HOME/.local/devlibs" cargo build -p nohrs
 
-# 2. Launch + wait for first real frame. Prints the window id you'll target.
+# 2. Launch + wait for first real frame (it forces the redraw; see Gotchas).
+#    Prints the window id you'll target.
 ./script/ui-run.sh launch
 #   -> WINDOW=16777217 DISPLAY=:108 PID=...
 
@@ -48,9 +59,8 @@ RUSTFLAGS="-L $HOME/.local/devlibs" cargo build -p nohrs
 ./script/ui-run.sh shot /tmp/step0.png      # then Read /tmp/step0.png
 
 # 4. Drive the UI. Coordinates are absolute screen pixels (match the full-screen PNG).
-DISP=$(./script/ui-run.sh display); WIN=$(./script/ui-run.sh win)
-DISPLAY=$DISP xdotool windowactivate "$WIN" \
-  mousemove 450 666 sleep 0.4 click 1 sleep 1.5      # e.g. select a file row
+DISP=$(./script/ui-run.sh display)
+DISPLAY=$DISP xdotool mousemove 450 666 sleep 0.4 click 1 sleep 1.5   # e.g. select a file row
 ./script/ui-run.sh shot /tmp/step1.png      # then Read /tmp/step1.png to confirm the effect
 
 # 5. Repeat step 4 for each action. When done:
@@ -69,7 +79,7 @@ populated, view toggled, breadcrumb advanced, ...). Compare against your baselin
 | Type text | `xdotool type "query"` |
 | Press a key / chord | `xdotool key Return` / `xdotool key ctrl+f` |
 | Pace between steps | `xdotool sleep 1.2` (built-in; do **not** rely on the `sleep` binary) |
-| Focus the window first | `xdotool windowactivate $WIN` |
+| Focus before typing | `xdotool mousemove 640 400` — put the pointer over the window |
 
 Reference coordinates (root view, maximized 1280x800; re-shoot to recheck after layout changes):
 file rows step ~32px from y≈186 (first row) downward; List/Grid toggle ≈ (1122,92)/(1185,92);
@@ -82,7 +92,7 @@ DISP=$(./script/ui-run.sh display)
 ffmpeg -y -f x11grab -draw_mouse 1 -framerate 20 -video_size 1280x800 -i "$DISP" \
   -c:v libx264 -pix_fmt yuv420p -movflags +faststart /tmp/demo.mp4 >/tmp/ffmpeg.log 2>&1 &
 FF=$!
-DISPLAY=$DISP xdotool windowactivate "$(./script/ui-run.sh win)" sleep 1 \
+DISPLAY=$DISP xdotool mousemove 640 400 sleep 1 \
   <your action chain with sleeps> sleep 1
 kill -INT $FF; wait $FF        # finalize the mp4 cleanly
 ```
@@ -96,8 +106,19 @@ for you.
   it (exit ~143/144). Use `pkill -x nohrs` (exact process name). `ui-run.sh stop` does this.
 - **Find the window by PID, not name.** The app does not set `WM_NAME`, so `xdotool search --name`
   fails. Use `--pid` (handled by `ui-run.sh win`).
-- **Black window right after launch is normal.** llvmpipe draws the first frame late; wait for the
-  `Refreshing every` log line (the helper does) before screenshotting or clicking.
+- **With no window manager the window stays black forever.** Nothing damages the window after it
+  is mapped, so gpui presents no further frame — waiting does not help (still all-black after 45s
+  on `Xvfb`, `xwininfo` reporting `Map State: IsViewable` the whole time). A one-pixel resize and
+  back forces the redraw. `ui-run.sh launch` does this and then polls the framebuffer until it is
+  no longer a single flat color; if you start the binary by hand, do the nudge yourself:
+  `xdotool windowsize $WIN 1279 779; xdotool sleep 1; xdotool windowsize $WIN 1280 780`.
+  Once a frame is out, ordinary interaction repaints normally.
+- **Do not wait for the `Refreshing every` log line.** gpui only logs it when the RandR mode
+  reports a non-zero dot clock. `Xvfb` reports zero, gpui silently falls back to 16ms, and the line
+  never appears — so waiting on it just times out. `ui-run.sh` watches the pixels instead.
+- **`xdotool windowactivate` fails without a window manager** ("claims not to support
+  `_NET_ACTIVE_WINDOW`"). Not needed: X focus follows the pointer here, so `mousemove` over the
+  window is enough for keys to land (verified with `ctrl+t` opening a tab).
 - **Avoid the `sleep` binary in driver scripts.** Some agent shells block long foreground sleeps.
   Use `xdotool sleep N` or `perl -e 'select(undef,undef,undef,N)'`.
 - **Coordinates are brittle.** After any layout-affecting change, take a fresh baseline shot and

--- a/script/ui-run.sh
+++ b/script/ui-run.sh
@@ -21,6 +21,7 @@ LOG="${NOHRS_LOG:-/tmp/nohrs.log}"
 DEVLIBS="$HOME/.local/devlibs"
 LIBDIR="${LIBDIR:-/usr/lib/x86_64-linux-gnu}"
 TMP="${TMPDIR:-/tmp}"
+STARTUP_POLLS=20       # x 0.5s: how long to give the process to appear at all
 WINDOW_POLLS=120       # x 0.5s: how long to wait for the X window to be created
 REDRAW_ATTEMPTS=20     # x ~2.5s: how long to keep nudging before giving up on a frame
 UNIFORM_EXIT=3         # xwd2png.py --fail-if-uniform: captured frame is one flat color
@@ -144,6 +145,12 @@ launch() {
       # backgrounding `setsid` and the binary appearing under its own name.
       report_failure "nohrs exited during startup"
       return 1
+    elif [ "$attempt" -ge "$STARTUP_POLLS" ]; then
+      # Never appeared under its own name at all, so it died before or during
+      # exec. The rest of the window budget is for a slow first window on a live
+      # process; spending it here would just delay the report.
+      report_failure "nohrs did not start"
+      return 1
     fi
     pause 0.5
   done
@@ -179,13 +186,19 @@ shot() {
   # xdotool with; the blank check below still has to look at the window alone.
   capture "$out" "$disp" root || return 1
   local window; window="$(win_id)"
-  if [ -n "$window" ]; then
-    window_frame_status "$disp" "$window"
-    if [ $? -eq "$UNIFORM_EXIT" ]; then
+  [ -n "$window" ] || { echo "nohrs is running but has no window: $out cannot show it" >&2; return 1; }
+  window_frame_status "$disp" "$window"
+  local status=$?
+  case "$status" in
+    0) ;;
+    # Written and usable, but say what is in it: the caller asked for a shot of
+    # the app and got a picture of an unpainted window.
+    "$UNIFORM_EXIT")
       echo "warning: the nohrs window in $out is one flat color -- it has not presented a frame." >&2
       echo "         re-run './script/ui-run.sh launch' to force the redraw." >&2
-    fi
-  fi
+      ;;
+    *) echo "could not inspect the nohrs window (exit $status): $out may not show it" >&2; return 1 ;;
+  esac
 }
 
 case "${1:-}" in

--- a/script/ui-run.sh
+++ b/script/ui-run.sh
@@ -20,6 +20,15 @@ BIN="$ROOT/target/debug/nohrs"
 LOG="${NOHRS_LOG:-/tmp/nohrs.log}"
 DEVLIBS="$HOME/.local/devlibs"
 LIBDIR="${LIBDIR:-/usr/lib/x86_64-linux-gnu}"
+TMP="${TMPDIR:-/tmp}"
+WINDOW_POLLS=120       # x 0.5s: how long to wait for the X window to be created
+REDRAW_ATTEMPTS=20     # x ~2.5s: how long to keep nudging before giving up on a frame
+UNIFORM_EXIT=3         # xwd2png.py --fail-if-uniform: captured frame is one flat color
+
+pause() {
+  # The 'sleep' binary is blocked in some agent shells; this is not.
+  perl -e 'select(undef, undef, undef, $ARGV[0])' "$1"
+}
 
 setup() {
   mkdir -p "$DEVLIBS"
@@ -51,30 +60,79 @@ win_id() {
   DISPLAY="$(resolve_display)" xdotool search --pid "$pid" 2>/dev/null | head -1
 }
 
+# Force a redraw. Under a bare X server (no window manager) nothing ever damages the
+# window after it is mapped, so gpui presents no further frame and the surface stays
+# black indefinitely -- waiting does not help. A one-pixel resize and back does.
+nudge() {
+  local disp="$1" window="$2" geometry width height
+  geometry="$(DISPLAY="$disp" xdotool getwindowgeometry --shell "$window")" || return 1
+  width="$(sed -n 's/^WIDTH=//p' <<< "$geometry")"
+  height="$(sed -n 's/^HEIGHT=//p' <<< "$geometry")"
+  case "$width$height" in
+    *[!0-9]* | "") echo "could not read geometry of window $window" >&2; return 1 ;;
+  esac
+  DISPLAY="$disp" xdotool windowsize "$window" "$((width - 1))" "$((height - 1))" || return 1
+  pause 1
+  DISPLAY="$disp" xdotool windowsize "$window" "$width" "$height" || return 1
+}
+
+capture() {   # capture <out.png> <display> [xwd2png.py flags...]
+  local out="$1" disp="$2"; shift 2
+  local dump; dump="$(mktemp "$TMP/ui-shot.XXXXXX.xwd")" || return 1
+  DISPLAY="$disp" xwd -root -silent -out "$dump" || { rm -f "$dump"; echo "xwd failed" >&2; return 1; }
+  python3 "$ROOT/script/xwd2png.py" "$dump" "$out" "$@"
+  local status=$?
+  rm -f "$dump"
+  return "$status"
+}
+
 launch() {
   local disp; disp="$(resolve_display)" || return 1
   [ -x "$BIN" ] || { echo "binary not built: $BIN" >&2; return 1; }
   pkill -x nohrs 2>/dev/null   # never use 'pkill -f' here: it matches this script's own path.
   : > "$LOG"
   DISPLAY="$disp" setsid "$BIN" > "$LOG" 2>&1 < /dev/null &
-  # Software (llvmpipe) rendering: the window is black until the first real frame.
-  # Wait for the steady-state render marker (poll, don't busy-spin), then let UI/fonts settle.
-  timeout 30 bash -c "until grep -q 'Refreshing every' '$LOG' 2>/dev/null; do sleep 0.2; done" \
-    || { echo "render marker not seen; tail of $LOG:" >&2; tail -5 "$LOG" >&2; return 1; }
-  perl -e 'select(undef,undef,undef,4)'   # 'sleep' may be blocked in some agent shells; this is not.
-  local w; w="$(win_id)"
-  [ -n "$w" ] || { echo "window id not found; tail of $LOG:" >&2; tail -5 "$LOG" >&2; return 1; }
-  echo "WINDOW=$w DISPLAY=$disp PID=$(pgrep -x nohrs | head -1)"
+
+  local window="" attempt
+  for attempt in $(seq 1 "$WINDOW_POLLS"); do
+    pgrep -x nohrs >/dev/null \
+      || { echo "nohrs exited during startup; tail of $LOG:" >&2; tail -5 "$LOG" >&2; return 1; }
+    window="$(win_id)"
+    [ -n "$window" ] && break
+    pause 0.5
+  done
+  [ -n "$window" ] || { echo "window id not found; tail of $LOG:" >&2; tail -5 "$LOG" >&2; return 1; }
+
+  # Software (llvmpipe) rendering plus the no-damage problem above: the only reliable
+  # readiness signal is the framebuffer itself no longer being a single flat color.
+  local probe="$TMP/ui-launch-probe.$$.png"
+  for attempt in $(seq 1 "$REDRAW_ATTEMPTS"); do
+    nudge "$disp" "$window" || { rm -f "$probe"; return 1; }
+    pause 1.5
+    if capture "$probe" "$disp" --fail-if-uniform >/dev/null 2>&1; then
+      rm -f "$probe"
+      echo "WINDOW=$window DISPLAY=$disp PID=$(pgrep -x nohrs | head -1)"
+      return 0
+    fi
+  done
+  rm -f "$probe"
+  echo "window still blank after $REDRAW_ATTEMPTS redraw attempts; tail of $LOG:" >&2
+  tail -5 "$LOG" >&2
+  return 1
 }
 
 shot() {
   local out="${1:?usage: ui-run.sh shot <out.png>}"
   local disp; disp="$(resolve_display)" || return 1
   pgrep -x nohrs >/dev/null || launch >/dev/null || return 1
-  local xwd="/tmp/ui-shot.$$.xwd"
-  DISPLAY="$disp" xwd -root -silent -out "$xwd" || { echo "xwd failed" >&2; return 1; }
-  python3 "$ROOT/script/xwd2png.py" "$xwd" "$out" || { rm -f "$xwd"; echo "xwd2png failed" >&2; return 1; }
-  rm -f "$xwd"
+  capture "$out" "$disp" --fail-if-uniform
+  local status=$?
+  if [ "$status" -eq "$UNIFORM_EXIT" ]; then
+    echo "warning: $out is one flat color -- the window has not presented a frame." >&2
+    echo "         re-run './script/ui-run.sh launch' to force the redraw." >&2
+    return 0
+  fi
+  return "$status"
 }
 
 case "${1:-}" in

--- a/script/ui-run.sh
+++ b/script/ui-run.sh
@@ -76,13 +76,30 @@ nudge() {
   DISPLAY="$disp" xdotool windowsize "$window" "$width" "$height" || return 1
 }
 
-capture() {   # capture <out.png> <display> [xwd2png.py flags...]
-  local out="$1" disp="$2"; shift 2
+capture() {   # capture <out.png> <display> <root|window-id> [xwd2png.py flags...]
+  local out="$1" disp="$2" target="$3"; shift 3
+  local -a selector
+  if [ "$target" = root ]; then selector=(-root); else selector=(-id "$target"); fi
   local dump; dump="$(mktemp "$TMP/ui-shot.XXXXXX.xwd")" || return 1
-  DISPLAY="$disp" xwd -root -silent -out "$dump" || { rm -f "$dump"; echo "xwd failed" >&2; return 1; }
+  DISPLAY="$disp" xwd "${selector[@]}" -silent -out "$dump" \
+    || { rm -f "$dump"; echo "xwd failed" >&2; return 1; }
   python3 "$ROOT/script/xwd2png.py" "$dump" "$out" "$@"
   local status=$?
   rm -f "$dump"
+  return "$status"
+}
+
+# Exit status of a --fail-if-uniform capture of the app's OWN window: 0 = it has
+# presented a real frame, UNIFORM_EXIT = still one flat color, anything else = the
+# capture itself failed. Probing the root window instead would be wrong on any
+# display that has a desktop or other windows on it: those pixels alone make the
+# capture non-uniform, so a blank nohrs window would read as rendered.
+window_frame_status() {
+  local disp="$1" window="$2"
+  local probe="$TMP/ui-frame-probe.$$.png"
+  capture "$probe" "$disp" "$window" --fail-if-uniform >/dev/null 2>&1
+  local status=$?
+  rm -f "$probe"
   return "$status"
 }
 
@@ -93,29 +110,33 @@ launch() {
   : > "$LOG"
   DISPLAY="$disp" setsid "$BIN" > "$LOG" 2>&1 < /dev/null &
 
-  local window="" attempt
+  local window="" attempt seen_process=false
   for attempt in $(seq 1 "$WINDOW_POLLS"); do
-    pgrep -x nohrs >/dev/null \
-      || { echo "nohrs exited during startup; tail of $LOG:" >&2; tail -5 "$LOG" >&2; return 1; }
-    window="$(win_id)"
-    [ -n "$window" ] && break
+    if pgrep -x nohrs >/dev/null; then
+      seen_process=true
+      window="$(win_id)"
+      [ -n "$window" ] && break
+    elif [ "$seen_process" = true ]; then
+      # Gone after having been seen: a real crash, not the startup race between
+      # backgrounding `setsid` and the binary appearing under its own name.
+      echo "nohrs exited during startup; tail of $LOG:" >&2
+      tail -5 "$LOG" >&2
+      return 1
+    fi
     pause 0.5
   done
   [ -n "$window" ] || { echo "window id not found; tail of $LOG:" >&2; tail -5 "$LOG" >&2; return 1; }
 
   # Software (llvmpipe) rendering plus the no-damage problem above: the only reliable
-  # readiness signal is the framebuffer itself no longer being a single flat color.
-  local probe="$TMP/ui-launch-probe.$$.png"
+  # readiness signal is the window's own pixels no longer being a single flat color.
   for attempt in $(seq 1 "$REDRAW_ATTEMPTS"); do
-    nudge "$disp" "$window" || { rm -f "$probe"; return 1; }
+    nudge "$disp" "$window" || return 1
     pause 1.5
-    if capture "$probe" "$disp" --fail-if-uniform >/dev/null 2>&1; then
-      rm -f "$probe"
+    if window_frame_status "$disp" "$window"; then
       echo "WINDOW=$window DISPLAY=$disp PID=$(pgrep -x nohrs | head -1)"
       return 0
     fi
   done
-  rm -f "$probe"
   echo "window still blank after $REDRAW_ATTEMPTS redraw attempts; tail of $LOG:" >&2
   tail -5 "$LOG" >&2
   return 1
@@ -125,14 +146,17 @@ shot() {
   local out="${1:?usage: ui-run.sh shot <out.png>}"
   local disp; disp="$(resolve_display)" || return 1
   pgrep -x nohrs >/dev/null || launch >/dev/null || return 1
-  capture "$out" "$disp" --fail-if-uniform
-  local status=$?
-  if [ "$status" -eq "$UNIFORM_EXIT" ]; then
-    echo "warning: $out is one flat color -- the window has not presented a frame." >&2
-    echo "         re-run './script/ui-run.sh launch' to force the redraw." >&2
-    return 0
+  # The PNG is the whole screen, so its pixel coordinates match the ones you drive
+  # xdotool with; the blank check below still has to look at the window alone.
+  capture "$out" "$disp" root || return 1
+  local window; window="$(win_id)"
+  if [ -n "$window" ]; then
+    window_frame_status "$disp" "$window"
+    if [ $? -eq "$UNIFORM_EXIT" ]; then
+      echo "warning: the nohrs window in $out is one flat color -- it has not presented a frame." >&2
+      echo "         re-run './script/ui-run.sh launch' to force the redraw." >&2
+    fi
   fi
-  return "$status"
 }
 
 case "${1:-}" in

--- a/script/ui-run.sh
+++ b/script/ui-run.sh
@@ -30,6 +30,11 @@ pause() {
   perl -e 'select(undef, undef, undef, $ARGV[0])' "$1"
 }
 
+report_failure() {
+  echo "$1; tail of $LOG:" >&2
+  tail -5 "$LOG" >&2
+}
+
 setup() {
   mkdir -p "$DEVLIBS"
   # gpui links these; create unversioned symlinks to the runtime .so (no dev packages / root needed).
@@ -68,9 +73,14 @@ nudge() {
   geometry="$(DISPLAY="$disp" xdotool getwindowgeometry --shell "$window")" || return 1
   width="$(sed -n 's/^WIDTH=//p' <<< "$geometry")"
   height="$(sed -n 's/^HEIGHT=//p' <<< "$geometry")"
-  case "$width$height" in
-    *[!0-9]* | "") echo "could not read geometry of window $window" >&2; return 1 ;;
-  esac
+  # Each dimension on its own, and at least 2 so the shrink below stays positive:
+  # checking the two concatenated would accept a missing or zero WIDTH.
+  case "$width" in ''|*[!0-9]*) width=0 ;; esac
+  case "$height" in ''|*[!0-9]*) height=0 ;; esac
+  if [ "$width" -lt 2 ] || [ "$height" -lt 2 ]; then
+    echo "no usable geometry for window $window (got ${width}x${height})" >&2
+    return 1
+  fi
   DISPLAY="$disp" xdotool windowsize "$window" "$((width - 1))" "$((height - 1))" || return 1
   pause 1
   DISPLAY="$disp" xdotool windowsize "$window" "$width" "$height" || return 1
@@ -96,8 +106,10 @@ capture() {   # capture <out.png> <display> <root|window-id> [xwd2png.py flags..
 # capture non-uniform, so a blank nohrs window would read as rendered.
 window_frame_status() {
   local disp="$1" window="$2"
-  local probe="$TMP/ui-frame-probe.$$.png"
-  capture "$probe" "$disp" "$window" --fail-if-uniform >/dev/null 2>&1
+  local probe; probe="$(mktemp "$TMP/ui-frame-probe.XXXXXX.png")" || return 1
+  # Only stdout is dropped (the "wrote ..." line): on the uniform path nothing is
+  # written to stderr, so letting it through surfaces real capture failures.
+  capture "$probe" "$disp" "$window" --fail-if-uniform >/dev/null
   local status=$?
   rm -f "$probe"
   return "$status"
@@ -106,7 +118,18 @@ window_frame_status() {
 launch() {
   local disp; disp="$(resolve_display)" || return 1
   [ -x "$BIN" ] || { echo "binary not built: $BIN" >&2; return 1; }
-  pkill -x nohrs 2>/dev/null   # never use 'pkill -f' here: it matches this script's own path.
+  # never use 'pkill -f' here: it matches this script's own path.
+  if pkill -x nohrs 2>/dev/null; then
+    # Wait for it to actually go. `pkill` only signals, and the poll below matches
+    # by process name: an outgoing instance still winding down would be picked up
+    # as the new one, handing back its about-to-be-destroyed window id.
+    local dying
+    for dying in $(seq 1 40); do
+      pgrep -x nohrs >/dev/null || break
+      pause 0.25
+    done
+    pgrep -x nohrs >/dev/null && { echo "a previous nohrs will not exit" >&2; return 1; }
+  fi
   : > "$LOG"
   DISPLAY="$disp" setsid "$BIN" > "$LOG" 2>&1 < /dev/null &
 
@@ -119,26 +142,32 @@ launch() {
     elif [ "$seen_process" = true ]; then
       # Gone after having been seen: a real crash, not the startup race between
       # backgrounding `setsid` and the binary appearing under its own name.
-      echo "nohrs exited during startup; tail of $LOG:" >&2
-      tail -5 "$LOG" >&2
+      report_failure "nohrs exited during startup"
       return 1
     fi
     pause 0.5
   done
-  [ -n "$window" ] || { echo "window id not found; tail of $LOG:" >&2; tail -5 "$LOG" >&2; return 1; }
+  [ -n "$window" ] || { report_failure "window id not found"; return 1; }
 
   # Software (llvmpipe) rendering plus the no-damage problem above: the only reliable
   # readiness signal is the window's own pixels no longer being a single flat color.
+  local status
   for attempt in $(seq 1 "$REDRAW_ATTEMPTS"); do
-    nudge "$disp" "$window" || return 1
+    pgrep -x nohrs >/dev/null || { report_failure "nohrs exited while waiting for a frame"; return 1; }
+    nudge "$disp" "$window" || { report_failure "could not resize the window to force a redraw"; return 1; }
     pause 1.5
-    if window_frame_status "$disp" "$window"; then
-      echo "WINDOW=$window DISPLAY=$disp PID=$(pgrep -x nohrs | head -1)"
-      return 0
-    fi
+    window_frame_status "$disp" "$window"
+    status=$?
+    case "$status" in
+      0) echo "WINDOW=$window DISPLAY=$disp PID=$(pgrep -x nohrs | head -1)"; return 0 ;;
+      "$UNIFORM_EXIT") ;;   # still one flat color: nudge again
+      # Anything else is the capture path failing (a dead or hung display, a
+      # destroyed window), not the app being slow to paint. Say so now rather
+      # than burning the remaining attempts and blaming the app at the end.
+      *) report_failure "capturing window $window failed (exit $status)"; return 1 ;;
+    esac
   done
-  echo "window still blank after $REDRAW_ATTEMPTS redraw attempts; tail of $LOG:" >&2
-  tail -5 "$LOG" >&2
+  report_failure "window still blank after $REDRAW_ATTEMPTS redraw attempts"
   return 1
 }
 

--- a/script/xwd2png.py
+++ b/script/xwd2png.py
@@ -7,13 +7,12 @@ ImageMagick / ffmpeg installed. See docs/agent-ui-verification.md.
 Usage: python3 script/xwd2png.py input.xwd output.png [--fail-if-uniform]
 
 `--fail-if-uniform` still writes the PNG but exits with UNIFORM_EXIT when every
-sampled pixel is the same color, which is how a window that has never presented
-a frame looks. `ui-run.sh launch` polls on this to decide when the GUI is up.
+pixel is the same color, which is how a window that has never presented a frame
+looks. `ui-run.sh launch` polls on this to decide when the GUI is up.
 """
 import sys, struct, zlib
 
 UNIFORM_EXIT = 3
-SAMPLE_STEP = 7
 
 
 def read_xwd(path):
@@ -87,21 +86,21 @@ def write_png(path, w, h, raw):
 
 
 def is_uniform(width, height, raw):
-    """Whether every sampled pixel of a scanline buffer has the same color.
+    """Whether every pixel of a scanline buffer has the same color.
 
     `raw` is in PNG scanline layout: one filter byte per row, then RGB triples.
+    Each row is compared whole against a repeat of the first pixel, so every
+    pixel is inspected without a per-pixel Python loop. Sampling instead would
+    let sparse content fall between the sample points and read as uniform,
+    which would strand `ui-run.sh launch` on an already-rendered window.
     """
+    if width == 0 or height == 0:
+        return True
     stride = width * 3 + 1
-    reference = None
-    for y in range(0, height, SAMPLE_STEP):
-        row = raw[y * stride + 1:(y + 1) * stride]
-        for x in range(0, width, SAMPLE_STEP):
-            pixel = row[x * 3:x * 3 + 3]
-            if reference is None:
-                reference = pixel
-            elif pixel != reference:
-                return False
-    return True
+    expected = raw[1:4] * width
+    return all(
+        raw[y * stride + 1:(y + 1) * stride] == expected for y in range(height)
+    )
 
 
 if __name__ == "__main__":

--- a/script/xwd2png.py
+++ b/script/xwd2png.py
@@ -4,9 +4,16 @@
 Used by the agent UI-verification flow so screenshots can be produced without
 ImageMagick / ffmpeg installed. See docs/agent-ui-verification.md.
 
-Usage: python3 script/xwd2png.py input.xwd output.png
+Usage: python3 script/xwd2png.py input.xwd output.png [--fail-if-uniform]
+
+`--fail-if-uniform` still writes the PNG but exits with UNIFORM_EXIT when every
+sampled pixel is the same color, which is how a window that has never presented
+a frame looks. `ui-run.sh launch` polls on this to decide when the GUI is up.
 """
 import sys, struct, zlib
+
+UNIFORM_EXIT = 3
+SAMPLE_STEP = 7
 
 
 def read_xwd(path):
@@ -79,9 +86,37 @@ def write_png(path, w, h, raw):
         f.write(sig + chunk(b"IHDR", ihdr) + chunk(b"IDAT", idat) + chunk(b"IEND", b""))
 
 
+def is_uniform(width, height, raw):
+    """Whether every sampled pixel of a scanline buffer has the same color.
+
+    `raw` is in PNG scanline layout: one filter byte per row, then RGB triples.
+    """
+    stride = width * 3 + 1
+    reference = None
+    for y in range(0, height, SAMPLE_STEP):
+        row = raw[y * stride + 1:(y + 1) * stride]
+        for x in range(0, width, SAMPLE_STEP):
+            pixel = row[x * 3:x * 3 + 3]
+            if reference is None:
+                reference = pixel
+            elif pixel != reference:
+                return False
+    return True
+
+
 if __name__ == "__main__":
-    if len(sys.argv) != 3:
-        sys.exit("usage: xwd2png.py input.xwd output.png")
-    w, h, raw = read_xwd(sys.argv[1])
-    write_png(sys.argv[2], w, h, raw)
-    print(f"wrote {sys.argv[2]} {w}x{h}")
+    arguments = sys.argv[1:]
+    fail_if_uniform = "--fail-if-uniform" in arguments
+    paths = [argument for argument in arguments if not argument.startswith("--")]
+    unknown = [
+        argument
+        for argument in arguments
+        if argument.startswith("--") and argument != "--fail-if-uniform"
+    ]
+    if len(paths) != 2 or unknown:
+        sys.exit("usage: xwd2png.py input.xwd output.png [--fail-if-uniform]")
+    width, height, raw = read_xwd(paths[0])
+    write_png(paths[1], width, height, raw)
+    print(f"wrote {paths[1]} {width}x{height}")
+    if fail_if_uniform and is_uniform(width, height, raw):
+        sys.exit(UNIFORM_EXIT)


### PR DESCRIPTION
## Summary

`./script/ui-run.sh launch` could not succeed under a headless X server, so the agent UI-verification loop in `docs/agent-ui-verification.md` was unusable from a fresh environment. Two independent problems:

1. **The readiness signal never fires.** `launch` waited up to 30s for gpui's `Refreshing every` log line. gpui only emits that line when the RandR mode reports a non-zero dot clock (`mode_refresh_rate`, gpui `x11/client.rs`); `Xvfb` reports zero, gpui silently falls back to 16ms, and the line never appears. `launch` therefore always exited 1 — even though the app was up and healthy.

2. **The frame it was waiting for never arrives either.** With no window manager, nothing damages the window after it is mapped, so gpui presents no further frame and the surface stays black indefinitely. Verified: all pixels `(0,0,0)` after 45s, with `xwininfo` reporting `Map State: IsViewable` the whole time. A one-pixel resize and back forces the redraw.

The existing doc described this as "black window right after launch is normal, wait for the log line" — both halves of that are wrong off a real display server, which is what sent this investigation down the wrong path to begin with.

## Changes

- `script/ui-run.sh`
  - `launch` polls for the window, nudges it, and waits until **the window's own pixels** are no longer a single flat color — the only signal that actually correlates with the GUI being visible. Probing the root instead would count a desktop background as a rendered frame.
  - New `nudge()` forces the redraw with a one-pixel resize and back. Geometry comes from `xdotool --shell` parsed with `sed` (not `eval`), with each dimension validated independently.
  - The redraw loop retries only while the frame is uniform; a dead process, a failed nudge, or a capture error is reported immediately with the log tail rather than burning all 20 attempts and blaming the app.
  - `launch` waits for a previous instance to fully exit before starting — `pkill` only signals, and the poll matches by process name, so a dying instance could hand back its about-to-be-destroyed window id.
  - Both startup-failure shapes fail fast: a process that is seen and then dies reports `nohrs exited during startup`, and one that never appears at all reports `nohrs did not start` after ~11s instead of running out the 60s window budget.
  - New `capture()` shared by `launch` and `shot`. `shot` captures the root (its coordinates must match the ones `xdotool` is driven with) but inspects the window alone: it warns on a flat frame and fails when the window is missing or cannot be captured.
- `script/xwd2png.py`
  - New `--fail-if-uniform`: writes the PNG but exits `3` when **every** pixel is the same color. Each row is compared whole against a repeat of the first pixel, so nothing is sampled past.
- `docs/agent-ui-verification.md`
  - Prerequisites gained `mesa-vulkan-drivers` (without the lavapipe ICD there is no Vulkan device at all), `x11-apps` (`xwd` is not always preinstalled, contrary to the old note), `libxkbcommon-x11-0` (otherwise `ui-run.sh setup` leaves a dangling symlink and linking fails with `unable to find library -lxkbcommon-x11`), and a `rustup update stable` note for the `use of unstable library feature cfg_select` build failure in `rusqlite` / `libsqlite3-sys` on older stable toolchains.
  - `setup` is now documented as running *after* the packages, since it symlinks to runtime `.so` files that must already exist.
  - Gotchas rewritten to match measured behavior; `xdotool windowactivate` examples replaced with `mousemove`, since `windowactivate` fails without a WM ("claims not to support `_NET_ACTIVE_WINDOW`") and is unnecessary — focus follows the pointer.

## Testing

- [x] `cargo fmt --all --check`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo test`

clippy and test were **not** run locally: this diff contains no Rust, and both are full-workspace compiles. CI runs them on this PR regardless (`script/**` is not in the workflow's `paths-ignore`), and both are green on ubuntu and macOS. `typos` was run over the repo and is clean.

Behavior was verified against a real GUI on `Xvfb :99` (1280x800, llvmpipe):

| Check | Before | After |
| --- | --- | --- |
| `launch` from a fresh X server | exit 1 after 30s, every time | `WINDOW=... DISPLAY=... PID=...` in ~4s |
| Frame after launch | all-black, also after 45s of waiting | fully rendered explorer |
| Three back-to-back `launch`es | 2nd reliably `BadWindow` | 3/3 succeed |
| `launch` when the app starts then crashes (`DISPLAY=:77`) | 30s timeout, generic message | `nohrs exited during startup` + panic tail |
| `launch` when the binary never starts | 60s, then the misleading `window id not found` | `nohrs did not start` in 11.5s |
| `shot` on an un-nudged window | silent black PNG | PNG plus a warning naming the fix |
| `shot` with no window / an uninspectable one | exit 0, silent | exit 1 with the reason |
| `nudge` on a bogus window id | n/a | exit 1, no hang |

Two review findings were reproduced before fixing, since both were reachable rather than theoretical:

- **Root vs. window probe.** With an un-nudged (black) window and a patterned root (`xsetroot -mod 4 4`, standing in for a desktop background on Xvnc), the root probe exits `0` ("rendered") while the window probe exits `3` ("still blank"). The bare Xvfb this was developed against has a solid black root, which is why it never showed up here.
- **Sampled uniformity.** A single differing pixel at (3,3) — a coordinate the old step-7 grid never visits — was reported as uniform. The row-compare replacement catches it, and is faster than scanning per pixel: 0.47 ms vs 111 ms on a 1280x800 uniform frame.

Also drove the full documented loop end-to-end — `launch` → `shot` → click a tab → click a file row → `shot` — and read each PNG back: the tab switch and the file preview (syntax-highlighted `Cargo.toml`) both rendered, confirming ordinary interaction repaints normally once the first frame is out. Keyboard input was confirmed separately with `ctrl+t` opening a new tab after only a `mousemove`, which is what the cheatsheet change rests on.

Screenshots are not attached: `attach-screenshots.sh` publishes to the `pr-assets` branch, and this session is only authorized to push to its own branch. Happy to add them on request.

## Suggested .rules additions

Offered per the Rules Hygiene section of `CLAUDE.md` — reviewer's call. Both were hit repeatedly in one session and cost real time:

> - Under a bare X server (no window manager), a gpui window stays black forever after it is mapped — nothing damages it, so no frame is ever presented. Waiting does not help. Force the redraw with a one-pixel resize (`ui-run.sh launch` does this). A black screenshot is not "still starting up".
> - Never gate a headless GUI wait on a gpui log line. `Refreshing every` is only emitted when the RandR mode reports a non-zero dot clock, which `Xvfb` does not. Wait on the framebuffer instead.

Release Notes:

- N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BJQ9hBxBgUTkipA1jt11b