### PR TITLE
nohrs_store: Make the KV key namespace a type, not a convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ are additive changes within a phase. See [`docs/ROADMAP.md`](docs/ROADMAP.md) fo
 
 ### Changed
 
+- Host KV keys are a `KvKey` rather than a `&str`, so the `<namespace>.<name>`
+  convention is enforced instead of merely documented. A literal goes through
+  `KvKey::from_static`, a `const fn`, so a key without a namespace is a build
+  error; keys built at runtime go through `KvKey::new` / `parse` and return a
+  `Result`. `KvStore::list_prefix` becomes `list_namespace`, which appends the
+  separator itself so a listing cannot straddle into a longer namespace
+  (`window` no longer picking up `window_backup.*`). See
+  [`docs/persistence.md`](docs/persistence.md) §3.
 - Split the single `nohrs` crate into a Cargo workspace of six layered crates
   (`nohrs-core`, `nohrs-models`, `nohrs-services`, `nohrs-ui`, `nohrs-pages`, and
   the `nohrs` binary), with a strict downward dependency direction. Shared

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,10 @@ are additive changes within a phase. See [`docs/ROADMAP.md`](docs/ROADMAP.md) fo
 
 - Host KV keys are a `KvKey` rather than a `&str`, so the `<namespace>.<name>`
   convention is enforced instead of merely documented. A literal goes through
-  `KvKey::from_static`, a `const fn`, so a key without a namespace is a build
-  error; keys built at runtime go through `KvKey::new` / `parse` and return a
-  `Result`. `KvStore::list_prefix` becomes `list_namespace`, which appends the
+  the `kv_key!` macro, whose `const { … }` block forces const evaluation, so a
+  key without a namespace is a build error; keys built at runtime go through
+  `KvKey::new` / `parse` and return a `Result`.
+  `KvStore::list_prefix` becomes `list_namespace`, which appends the
   separator itself so a listing cannot straddle into a longer namespace
   (`window` no longer picking up `window_backup.*`). See
   [`docs/persistence.md`](docs/persistence.md) §3.

--- a/crates/nohrs-pages/src/explorer/page.rs
+++ b/crates/nohrs-pages/src/explorer/page.rs
@@ -17,7 +17,7 @@ use gpui_component::resizable::ResizableState;
 use nohrs_core::config::{Explorer as ExplorerConfig, SplitDirection, Ui};
 use nohrs_core::telemetry::LogErr;
 use nohrs_services::search::SearchService;
-use nohrs_store::KvStore;
+use nohrs_store::{KvKey, KvStore};
 use nohrs_ui::theme::theme;
 use serde::{Deserialize, Serialize};
 
@@ -31,7 +31,7 @@ const PANES_CONTEXT: &str = "ExplorerPanes";
 
 // Host-KV key under which the tab session is persisted (`docs/persistence.md`
 // §3: tab/session restore lives in redb `state.redb`).
-const SESSION_KEY: &str = "session.explorer_tabs";
+const SESSION_KEY: KvKey = KvKey::from_static("session.explorer_tabs");
 
 // How long to coalesce rapid mutations (navigation, tab open/close) before
 // writing the session snapshot, so high-frequency changes don't hammer redb's
@@ -216,7 +216,7 @@ impl ExplorerPage {
 
     // Reads and deserializes the persisted session snapshot, if any.
     fn load_session(&self) -> Option<SessionSnapshot> {
-        let bytes = self.store.as_ref()?.get(SESSION_KEY).log_err()??;
+        let bytes = self.store.as_ref()?.get(&SESSION_KEY).log_err()??;
         serde_json::from_slice(&bytes).log_err()
     }
 
@@ -563,7 +563,7 @@ impl ExplorerPage {
                     return;
                 };
                 cx.background_spawn(async move {
-                    store.put(SESSION_KEY, &bytes).log_err();
+                    store.put(&SESSION_KEY, &bytes).log_err();
                 })
                 .await;
             }

--- a/crates/nohrs-pages/src/explorer/page.rs
+++ b/crates/nohrs-pages/src/explorer/page.rs
@@ -17,7 +17,7 @@ use gpui_component::resizable::ResizableState;
 use nohrs_core::config::{Explorer as ExplorerConfig, SplitDirection, Ui};
 use nohrs_core::telemetry::LogErr;
 use nohrs_services::search::SearchService;
-use nohrs_store::{KvKey, KvStore};
+use nohrs_store::{KvKey, KvStore, kv_key};
 use nohrs_ui::theme::theme;
 use serde::{Deserialize, Serialize};
 
@@ -31,7 +31,7 @@ const PANES_CONTEXT: &str = "ExplorerPanes";
 
 // Host-KV key under which the tab session is persisted (`docs/persistence.md`
 // §3: tab/session restore lives in redb `state.redb`).
-const SESSION_KEY: KvKey = KvKey::from_static("session.explorer_tabs");
+const SESSION_KEY: KvKey = kv_key!("session.explorer_tabs");
 
 // How long to coalesce rapid mutations (navigation, tab open/close) before
 // writing the session snapshot, so high-frequency changes don't hammer redb's

--- a/crates/nohrs-store/src/nohrs_store.rs
+++ b/crates/nohrs-store/src/nohrs_store.rs
@@ -41,6 +41,14 @@ pub enum StoreError {
         /// What was wrong with it.
         reason: &'static str,
     },
+    /// A string was not a well-formed KV namespace.
+    #[error("invalid kv namespace {namespace:?}: {reason}")]
+    InvalidNamespace {
+        /// The string that was rejected.
+        namespace: String,
+        /// What was wrong with it.
+        reason: &'static str,
+    },
 }
 
 // redb surfaces a family of error types from its different stages. Funnel each
@@ -297,13 +305,26 @@ impl KvKey {
     /// passed in — `new("a.b", "c")` would answer `"a"` — so the key would not
     /// be listed under the namespace its own caller believed it wrote it to.
     pub fn new(namespace: &str, name: &str) -> Result<Self> {
-        if namespace.contains('.') {
-            return Err(StoreError::InvalidKey {
-                key: format!("{namespace}.{name}"),
-                reason: "the namespace must be a single segment, without a '.'",
-            });
-        }
+        Self::check_namespace(namespace)?;
         Self::parse(format!("{namespace}.{name}"))
+    }
+
+    /// Check that `namespace` names a namespace: one non-empty segment of
+    /// lowercase ASCII, digits or `_`.
+    ///
+    /// Shared by [`KvKey::new`] and every [`KvStore::list_namespace`]
+    /// implementation, so that the two cannot drift. They did: `new` rejected
+    /// `"window.main"` while `list_namespace` accepted it and scanned
+    /// `window.main.`, returning keys whose own [`KvKey::namespace`] is
+    /// `"window"`. One argument, two meanings, on either side of the same API.
+    pub fn check_namespace(namespace: &str) -> Result<()> {
+        if is_valid_segment(namespace) {
+            return Ok(());
+        }
+        Err(StoreError::InvalidNamespace {
+            namespace: namespace.to_string(),
+            reason: "a namespace is one segment of lowercase ASCII, digits and _",
+        })
     }
 
     /// A key from an existing string, checked.
@@ -347,6 +368,17 @@ impl TryFrom<&str> for KvKey {
     }
 }
 
+/// The bytes a segment may contain. Shared by [`is_valid_key`] and
+/// [`is_valid_segment`] so the charset is written once.
+const fn is_segment_byte(byte: u8) -> bool {
+    byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_'
+}
+
+/// Whether `segment` is one non-empty run of [`is_segment_byte`] — no dots.
+fn is_valid_segment(segment: &str) -> bool {
+    !segment.is_empty() && segment.bytes().all(is_segment_byte)
+}
+
 /// Whether `key` is `<segment>.<segment>[.<segment>…]`, each segment non-empty
 /// and made of lowercase ASCII, digits or `_`.
 ///
@@ -366,7 +398,7 @@ const fn is_valid_key(key: &str) -> bool {
             }
             segments += 1;
             segment_len = 0;
-        } else if byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_' {
+        } else if is_segment_byte(byte) {
             segment_len += 1;
         } else {
             return false;
@@ -390,6 +422,10 @@ pub trait KvStore: Send + Sync {
     /// straddle one: `list_prefix("sess")` used to match `session.*` by
     /// accident, and `list_prefix("window")` would also return `window_backup.*`
     /// if such a namespace were ever added.
+    ///
+    /// Errors when `namespace` is not one, per [`KvKey::check_namespace`] — the
+    /// same rule [`KvKey::new`] applies, so that a namespace which cannot be
+    /// written to cannot be listed either.
     fn list_namespace(&self, namespace: &str) -> Result<Vec<(KvKey, Vec<u8>)>>;
     /// Apply `ops` atomically in a single transaction.
     fn batch(&self, ops: Vec<KvOp>) -> Result<()>;
@@ -548,7 +584,8 @@ mod tests {
         assert!(KvKey::parse("window.main.position").is_ok());
         let error = KvKey::new("window.main", "position")
             .expect_err("a dotted namespace is not a namespace");
-        assert!(error.to_string().contains("single segment"), "{error}");
+        assert!(error.to_string().contains("one segment"), "{error}");
+        assert!(error.to_string().contains("window.main"), "{error}");
     }
 
     #[test]

--- a/crates/nohrs-store/src/nohrs_store.rs
+++ b/crates/nohrs-store/src/nohrs_store.rs
@@ -291,7 +291,18 @@ impl KvKey {
     }
 
     /// A key from a namespace and a name, both checked.
+    ///
+    /// The namespace must be a *single* segment. Joining a dotted one would
+    /// build a key whose [`KvKey::namespace`] is not the namespace that was
+    /// passed in — `new("a.b", "c")` would answer `"a"` — so the key would not
+    /// be listed under the namespace its own caller believed it wrote it to.
     pub fn new(namespace: &str, name: &str) -> Result<Self> {
+        if namespace.contains('.') {
+            return Err(StoreError::InvalidKey {
+                key: format!("{namespace}.{name}"),
+                reason: "the namespace must be a single segment, without a '.'",
+            });
+        }
         Self::parse(format!("{namespace}.{name}"))
     }
 
@@ -340,8 +351,8 @@ impl TryFrom<&str> for KvKey {
 /// and made of lowercase ASCII, digits or `_`.
 ///
 /// Written as a hand-rolled loop rather than `split`/`all` because it has to be
-/// a `const fn` for [`KvKey::from_static`] to reject a bad literal at build
-/// time, and iterators are not available there.
+/// a `const fn` for [`kv_key!`] to reject a bad literal at build time, and
+/// iterators are not available there.
 const fn is_valid_key(key: &str) -> bool {
     let bytes = key.as_bytes();
     let mut index = 0;
@@ -529,6 +540,15 @@ mod tests {
         assert!(KvKey::new("session", "").is_err());
         assert!(KvKey::new("", "tabs").is_err());
         assert!(KvKey::new("session", ".tabs").is_err());
+
+        // A dotted namespace joins into a *valid* key, which is why it needs
+        // rejecting on its own: `namespace()` would answer "window", not
+        // "window.main", so the key would not be listed under the namespace its
+        // caller believed it wrote it to.
+        assert!(KvKey::parse("window.main.position").is_ok());
+        let error = KvKey::new("window.main", "position")
+            .expect_err("a dotted namespace is not a namespace");
+        assert!(error.to_string().contains("single segment"), "{error}");
     }
 
     #[test]

--- a/crates/nohrs-store/src/nohrs_store.rs
+++ b/crates/nohrs-store/src/nohrs_store.rs
@@ -225,27 +225,64 @@ pub trait MetadataStore: MetadataQuery {
 /// …)` compiled, round-tripped correctly, and went wrong only later and
 /// elsewhere, as a listing quietly missing rows.
 ///
-/// A literal key is checked at compile time by [`KvKey::from_static`], which is
-/// where nearly all of them come from. [`KvKey::new`] and [`KvKey::parse`] cover
-/// the built-at-runtime rest.
+/// A literal key is checked at compile time by [`kv_key!`], which is where
+/// nearly all of them come from. [`KvKey::new`] and [`KvKey::parse`] cover the
+/// built-at-runtime rest.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct KvKey(std::borrow::Cow<'static, str>);
 
+/// A key from a literal, rejected **at compile time** if malformed.
+///
+/// ```
+/// # use nohrs_store::kv_key;
+/// let key = kv_key!("session.explorer_tabs");
+/// assert_eq!(key.namespace(), "session");
+/// ```
+///
+/// A key without a namespace does not compile:
+///
+/// ```compile_fail
+/// # use nohrs_store::kv_key;
+/// let key = kv_key!("tabs");
+/// ```
+///
+/// Nor does a non-literal, which is what would let the check slip to runtime:
+///
+/// ```compile_fail
+/// # use nohrs_store::kv_key;
+/// let name: &'static str = "tabs";
+/// let key = kv_key!(name);
+/// ```
+///
+/// The `const { … }` block is the load-bearing part. A `const fn` called from an
+/// ordinary expression is *permitted* to run at compile time but is not required
+/// to, so a bare call would turn the assertion into a runtime panic — the exact
+/// thing this exists to prevent, and one the no-panic rule forbids. The block
+/// forces const evaluation at every call site, and `$key:literal` keeps a
+/// runtime-selected `&'static str` from reaching it at all.
+#[macro_export]
+macro_rules! kv_key {
+    ($key:literal) => {
+        const { $crate::KvKey::from_static_checked($key) }
+    };
+}
+
 impl KvKey {
-    /// A key from a literal, rejected **at compile time** if malformed.
+    /// The checked constructor behind [`kv_key!`]. **Call it through the macro.**
     ///
-    /// This is a `const fn`, so `KvKey::from_static("tabs")` is a build error
-    /// rather than a runtime one. Prefer it for the fixed keys a subsystem owns;
-    /// it is the whole reason the convention is now enforceable rather than
-    /// merely written down.
+    /// Public only because [`kv_key!`] expands into other crates. Calling it
+    /// directly from an ordinary expression evaluates the assertion at runtime,
+    /// which turns a build error into a panic; the macro's `const { … }` block is
+    /// what makes the guarantee real.
     ///
     /// # Panics
     ///
-    /// If `key` is not a valid key. In a `const` context — which is where a
-    /// literal belongs — that panic is a compile error and can never reach a
-    /// running program.
+    /// If `key` is not a valid key. Reached through [`kv_key!`] that panic is a
+    /// const-evaluation failure — a compile error — and cannot reach a running
+    /// program.
+    #[doc(hidden)]
     #[must_use]
-    pub const fn from_static(key: &'static str) -> Self {
+    pub const fn from_static_checked(key: &'static str) -> Self {
         assert!(
             is_valid_key(key),
             "a kv key must be <namespace>.<name>, lowercase ASCII, digits and _"
@@ -475,16 +512,10 @@ mod tests {
 
     #[test]
     fn a_key_reports_the_namespace_it_belongs_to() {
-        assert_eq!(
-            KvKey::from_static("session.explorer_tabs").namespace(),
-            "session"
-        );
+        assert_eq!(kv_key!("session.explorer_tabs").namespace(), "session");
         // The namespace is the *first* segment, not everything before the last
         // dot: `list_namespace("window")` has to find this key.
-        assert_eq!(
-            KvKey::from_static("window.main.position").namespace(),
-            "window"
-        );
+        assert_eq!(kv_key!("window.main.position").namespace(), "window");
     }
 
     #[test]

--- a/crates/nohrs-store/src/nohrs_store.rs
+++ b/crates/nohrs-store/src/nohrs_store.rs
@@ -33,6 +33,14 @@ pub enum StoreError {
     /// otherwise bloat every `Result` in this crate (`clippy::result_large_err`).
     #[error("redb error: {0}")]
     Redb(Box<redb::Error>),
+    /// A string was not a well-formed [`KvKey`].
+    #[error("invalid kv key {key:?}: {reason}")]
+    InvalidKey {
+        /// The string that was rejected.
+        key: String,
+        /// What was wrong with it.
+        reason: &'static str,
+    },
 }
 
 // redb surfaces a family of error types from its different stages. Funnel each
@@ -168,14 +176,14 @@ pub enum KvOp {
     /// Insert or overwrite `key` with `value`.
     Put {
         /// The key to write.
-        key: String,
+        key: KvKey,
         /// The value to store.
         value: Vec<u8>,
     },
     /// Remove `key` if present.
     Delete {
         /// The key to remove.
-        key: String,
+        key: KvKey,
     },
 }
 
@@ -205,16 +213,136 @@ pub trait MetadataStore: MetadataQuery {
     fn mark_indexed(&self, id: FileId, indexed_at_ns: i64) -> Result<()>;
 }
 
+/// A host KV key: a namespace, then a name within it.
+///
+/// Keys are dot-separated segments and there are always at least two, so every
+/// key names a namespace — `session.explorer_tabs`, `window.position`. Segments
+/// are lowercase ASCII, digits and `_`.
+///
+/// The namespace is what lets [`KvStore::list_namespace`] hand a subsystem its
+/// own state and nobody else's, and what stops two subsystems both reaching for
+/// a bare `tabs`. That was a documented convention nothing checked: `put("tabs",
+/// …)` compiled, round-tripped correctly, and went wrong only later and
+/// elsewhere, as a listing quietly missing rows.
+///
+/// A literal key is checked at compile time by [`KvKey::from_static`], which is
+/// where nearly all of them come from. [`KvKey::new`] and [`KvKey::parse`] cover
+/// the built-at-runtime rest.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct KvKey(std::borrow::Cow<'static, str>);
+
+impl KvKey {
+    /// A key from a literal, rejected **at compile time** if malformed.
+    ///
+    /// This is a `const fn`, so `KvKey::from_static("tabs")` is a build error
+    /// rather than a runtime one. Prefer it for the fixed keys a subsystem owns;
+    /// it is the whole reason the convention is now enforceable rather than
+    /// merely written down.
+    ///
+    /// # Panics
+    ///
+    /// If `key` is not a valid key. In a `const` context — which is where a
+    /// literal belongs — that panic is a compile error and can never reach a
+    /// running program.
+    #[must_use]
+    pub const fn from_static(key: &'static str) -> Self {
+        assert!(
+            is_valid_key(key),
+            "a kv key must be <namespace>.<name>, lowercase ASCII, digits and _"
+        );
+        Self(std::borrow::Cow::Borrowed(key))
+    }
+
+    /// A key from a namespace and a name, both checked.
+    pub fn new(namespace: &str, name: &str) -> Result<Self> {
+        Self::parse(format!("{namespace}.{name}"))
+    }
+
+    /// A key from an existing string, checked.
+    pub fn parse(key: impl Into<String>) -> Result<Self> {
+        let key: String = key.into();
+        if !is_valid_key(&key) {
+            return Err(StoreError::InvalidKey {
+                key,
+                reason: "expected <namespace>.<name> in lowercase ASCII, digits and _",
+            });
+        }
+        Ok(Self(std::borrow::Cow::Owned(key)))
+    }
+
+    /// The part before the first `.`.
+    #[must_use]
+    pub fn namespace(&self) -> &str {
+        // A valid key always has one, so the fallback is unreachable in practice
+        // and still not a panic.
+        self.0.split('.').next().unwrap_or(&self.0)
+    }
+
+    /// The whole key, as stored.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for KvKey {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl TryFrom<&str> for KvKey {
+    type Error = StoreError;
+
+    fn try_from(key: &str) -> Result<Self> {
+        Self::parse(key)
+    }
+}
+
+/// Whether `key` is `<segment>.<segment>[.<segment>…]`, each segment non-empty
+/// and made of lowercase ASCII, digits or `_`.
+///
+/// Written as a hand-rolled loop rather than `split`/`all` because it has to be
+/// a `const fn` for [`KvKey::from_static`] to reject a bad literal at build
+/// time, and iterators are not available there.
+const fn is_valid_key(key: &str) -> bool {
+    let bytes = key.as_bytes();
+    let mut index = 0;
+    let mut segment_len = 0;
+    let mut segments = 1;
+    while index < bytes.len() {
+        let byte = bytes[index];
+        if byte == b'.' {
+            if segment_len == 0 {
+                return false;
+            }
+            segments += 1;
+            segment_len = 0;
+        } else if byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_' {
+            segment_len += 1;
+        } else {
+            return false;
+        }
+        index += 1;
+    }
+    segment_len > 0 && segments >= 2
+}
+
 /// A simple key/value blob store (host KV, backed by redb).
 pub trait KvStore: Send + Sync {
     /// Fetch the value for `key`, or `None` if absent.
-    fn get(&self, key: &str) -> Result<Option<Vec<u8>>>;
+    fn get(&self, key: &KvKey) -> Result<Option<Vec<u8>>>;
     /// Insert or overwrite `key` with `value`.
-    fn put(&self, key: &str, value: &[u8]) -> Result<()>;
+    fn put(&self, key: &KvKey, value: &[u8]) -> Result<()>;
     /// Remove `key` if present.
-    fn delete(&self, key: &str) -> Result<()>;
-    /// Return every `(key, value)` whose key begins with `prefix`.
-    fn list_prefix(&self, prefix: &str) -> Result<Vec<(String, Vec<u8>)>>;
+    fn delete(&self, key: &KvKey) -> Result<()>;
+    /// Return every `(key, value)` in `namespace`.
+    ///
+    /// Takes the namespace rather than a free prefix so that a listing cannot
+    /// straddle one: `list_prefix("sess")` used to match `session.*` by
+    /// accident, and `list_prefix("window")` would also return `window_backup.*`
+    /// if such a namespace were ever added.
+    fn list_namespace(&self, namespace: &str) -> Result<Vec<(KvKey, Vec<u8>)>>;
     /// Apply `ops` atomically in a single transaction.
     fn batch(&self, ops: Vec<KvOp>) -> Result<()>;
 }
@@ -316,5 +444,80 @@ mod tests {
             assert_eq!(HistoryKind::parse(kind.as_str()), Some(kind));
         }
         assert_eq!(HistoryKind::parse("unknown"), None);
+    }
+
+    #[test]
+    fn a_key_needs_a_namespace_and_a_name() {
+        for key in [
+            "session.explorer_tabs",
+            "window.position",
+            "window.main.position",
+            "plugin.acme_2.state",
+        ] {
+            assert!(KvKey::parse(key).is_ok(), "{key} should be a valid key");
+        }
+        for key in [
+            // The one this exists for: a bare name, which used to compile and
+            // then be missing from every namespace listing.
+            "tabs",
+            "",
+            ".",
+            ".leading",
+            "trailing.",
+            "double..dot",
+            "Upper.case",
+            "has space.x",
+            "dash-ed.x",
+        ] {
+            assert!(KvKey::parse(key).is_err(), "{key} should be rejected");
+        }
+    }
+
+    #[test]
+    fn a_key_reports_the_namespace_it_belongs_to() {
+        assert_eq!(
+            KvKey::from_static("session.explorer_tabs").namespace(),
+            "session"
+        );
+        // The namespace is the *first* segment, not everything before the last
+        // dot: `list_namespace("window")` has to find this key.
+        assert_eq!(
+            KvKey::from_static("window.main.position").namespace(),
+            "window"
+        );
+    }
+
+    #[test]
+    fn new_joins_and_checks_both_halves() {
+        let key = KvKey::new("session", "explorer_tabs").unwrap();
+        assert_eq!(key.as_str(), "session.explorer_tabs");
+        assert_eq!(key.to_string(), "session.explorer_tabs");
+
+        // A name that smuggles in its own separator is still checked as a whole,
+        // so it cannot produce an empty segment.
+        assert!(KvKey::new("session", "").is_err());
+        assert!(KvKey::new("", "tabs").is_err());
+        assert!(KvKey::new("session", ".tabs").is_err());
+    }
+
+    #[test]
+    fn the_compile_time_and_runtime_checks_agree() {
+        // `from_static` is a `const fn` and `parse` is not, so they are two
+        // paths to one rule. A literal that `parse` rejects has to be a build
+        // error, not a key that only `from_static` lets through.
+        for key in ["session.tabs", "window.main.position"] {
+            assert!(is_valid_key(key) && KvKey::parse(key).is_ok(), "{key}");
+        }
+        for key in ["tabs", "trailing.", "Upper.case"] {
+            assert!(!is_valid_key(key) && KvKey::parse(key).is_err(), "{key}");
+        }
+    }
+
+    #[test]
+    fn an_invalid_key_says_what_it_was() {
+        let error = KvKey::parse("tabs").unwrap_err();
+        let rendered = error.to_string();
+        assert!(rendered.contains("tabs"), "{rendered}");
+        assert!(rendered.contains("namespace"), "{rendered}");
     }
 }

--- a/crates/nohrs-store/src/redb_kv.rs
+++ b/crates/nohrs-store/src/redb_kv.rs
@@ -104,11 +104,23 @@ impl KvStore for RedbKvStore {
             if !key.starts_with(&prefix) {
                 break;
             }
-            // Every key was a `KvKey` on the way in, so this only fails if the
-            // file was written by something else; such a row is not ours to
-            // return.
-            let Ok(key) = KvKey::parse(key) else {
-                continue;
+            // Every key written through this API is a `KvKey`, so a row that
+            // does not parse predates the validation (or came from another
+            // writer). It is skipped rather than returned, because the caller
+            // asked for keys and this is not one — but *reported*, since a row
+            // vanishing from a listing with no explanation is the kind of thing
+            // that gets diagnosed as data loss. Failing the whole listing
+            // instead would let one stale row break session restore, which is a
+            // worse trade for the same problem.
+            let key = match KvKey::parse(key) {
+                Ok(key) => key,
+                Err(error) => {
+                    tracing::warn!(
+                        target: "nohrs_store::redb",
+                        "skipping unparseable key in namespace {namespace}: {error}"
+                    );
+                    continue;
+                }
             };
             matches.push((key, value.value().to_vec()));
         }
@@ -176,6 +188,34 @@ mod tests {
         assert_eq!(session.len(), 2);
         assert_eq!(session[0].0.as_str(), "session.active");
         assert_eq!(session[1].0.as_str(), "session.tabs");
+    }
+
+    #[test]
+    fn a_row_that_predates_the_validation_is_skipped_not_returned() {
+        // An older build could write any string. Such a row is not a `KvKey`, so
+        // `list_namespace` cannot hand it back — but the valid rows beside it
+        // must still come through, rather than one stale key failing the whole
+        // listing and taking session restore with it.
+        let store = store();
+        store.put(&kv_key!("session.tabs"), b"mine").unwrap();
+        // Written past the API, the way an older build would have.
+        {
+            let write_txn = store.database.begin_write().unwrap();
+            {
+                let mut table = write_txn.open_table(HOST_KV).unwrap();
+                table.insert("session.Legacy", &b"theirs"[..]).unwrap();
+            }
+            write_txn.commit().unwrap();
+        }
+
+        let listed = store.list_namespace("session").unwrap();
+
+        assert_eq!(listed.len(), 1, "{listed:?}");
+        assert_eq!(listed[0].0.as_str(), "session.tabs");
+        // Still reachable by an exact read, so it is skipped, not destroyed.
+        let read_txn = store.database.begin_read().unwrap();
+        let table = read_txn.open_table(HOST_KV).unwrap();
+        assert!(table.get("session.Legacy").unwrap().is_some());
     }
 
     #[test]

--- a/crates/nohrs-store/src/redb_kv.rs
+++ b/crates/nohrs-store/src/redb_kv.rs
@@ -6,7 +6,7 @@ use std::time::Instant;
 
 use redb::{Database, ReadableDatabase, TableDefinition, TableError};
 
-use crate::{KvOp, KvStore, Result, StoreLogConfig};
+use crate::{KvKey, KvOp, KvStore, Result, StoreLogConfig};
 
 /// The single host KV table. Keys are namespaced strings (e.g.
 /// `"window.position"`, `"session.tabs"`); values are opaque blobs the caller
@@ -47,11 +47,11 @@ impl RedbKvStore {
 }
 
 impl KvStore for RedbKvStore {
-    fn get(&self, key: &str) -> Result<Option<Vec<u8>>> {
+    fn get(&self, key: &KvKey) -> Result<Option<Vec<u8>>> {
         let started = Instant::now();
         let read_txn = self.database.begin_read()?;
         let value = match read_txn.open_table(HOST_KV) {
-            Ok(table) => table.get(key)?.map(|guard| guard.value().to_vec()),
+            Ok(table) => table.get(key.as_str())?.map(|guard| guard.value().to_vec()),
             // No writes have happened yet: an absent table means an absent key.
             Err(TableError::TableDoesNotExist(_)) => None,
             Err(error) => return Err(error.into()),
@@ -60,32 +60,36 @@ impl KvStore for RedbKvStore {
         Ok(value)
     }
 
-    fn put(&self, key: &str, value: &[u8]) -> Result<()> {
+    fn put(&self, key: &KvKey, value: &[u8]) -> Result<()> {
         let started = Instant::now();
         let write_txn = self.database.begin_write()?;
         {
             let mut table = write_txn.open_table(HOST_KV)?;
-            table.insert(key, value)?;
+            table.insert(key.as_str(), value)?;
         }
         write_txn.commit()?;
         self.trace("put", started);
         Ok(())
     }
 
-    fn delete(&self, key: &str) -> Result<()> {
+    fn delete(&self, key: &KvKey) -> Result<()> {
         let started = Instant::now();
         let write_txn = self.database.begin_write()?;
         {
             let mut table = write_txn.open_table(HOST_KV)?;
-            table.remove(key)?;
+            table.remove(key.as_str())?;
         }
         write_txn.commit()?;
         self.trace("delete", started);
         Ok(())
     }
 
-    fn list_prefix(&self, prefix: &str) -> Result<Vec<(String, Vec<u8>)>> {
+    fn list_namespace(&self, namespace: &str) -> Result<Vec<(KvKey, Vec<u8>)>> {
         let started = Instant::now();
+        // The trailing dot is what confines the scan to the namespace itself:
+        // scanning from `window` alone would also walk into a `window_backup`
+        // namespace, since `window_backup.x` sorts after `window`.
+        let prefix = format!("{namespace}.");
         let read_txn = self.database.begin_read()?;
         let table = match read_txn.open_table(HOST_KV) {
             Ok(table) => table,
@@ -94,15 +98,21 @@ impl KvStore for RedbKvStore {
         };
         let mut matches = Vec::new();
         // Keys are ordered, so once one stops matching the prefix none after it can.
-        for entry in table.range(prefix..)? {
+        for entry in table.range(prefix.as_str()..)? {
             let (key, value) = entry?;
             let key = key.value();
-            if !key.starts_with(prefix) {
+            if !key.starts_with(&prefix) {
                 break;
             }
-            matches.push((key.to_string(), value.value().to_vec()));
+            // Every key was a `KvKey` on the way in, so this only fails if the
+            // file was written by something else; such a row is not ours to
+            // return.
+            let Ok(key) = KvKey::parse(key) else {
+                continue;
+            };
+            matches.push((key, value.value().to_vec()));
         }
-        self.trace("list_prefix", started);
+        self.trace("list_namespace", started);
         Ok(matches)
     }
 
@@ -137,60 +147,88 @@ mod tests {
         RedbKvStore::open_in_memory(&StoreLogConfig::default()).unwrap()
     }
 
+    /// Shorthand for a compile-time-checked key in these tests.
+    macro_rules! key {
+        ($key:literal) => {
+            KvKey::from_static($key)
+        };
+    }
+
     #[test]
     fn get_missing_key_before_any_write() {
         let store = store();
-        assert_eq!(store.get("absent").unwrap(), None);
-        assert!(store.list_prefix("any").unwrap().is_empty());
+        assert_eq!(store.get(&key!("window.absent")).unwrap(), None);
+        assert!(store.list_namespace("window").unwrap().is_empty());
     }
 
     #[test]
     fn put_get_delete_round_trip() {
         let store = store();
-        store.put("window.position", b"1,2,3,4").unwrap();
-        assert_eq!(
-            store.get("window.position").unwrap().as_deref(),
-            Some(&b"1,2,3,4"[..])
-        );
-        store.delete("window.position").unwrap();
-        assert_eq!(store.get("window.position").unwrap(), None);
+        let key = key!("window.position");
+        store.put(&key, b"1,2,3,4").unwrap();
+        assert_eq!(store.get(&key).unwrap().as_deref(), Some(&b"1,2,3,4"[..]));
+        store.delete(&key).unwrap();
+        assert_eq!(store.get(&key).unwrap(), None);
     }
 
     #[test]
-    fn list_prefix_returns_only_matching_keys() {
+    fn list_namespace_returns_only_that_namespace() {
         let store = store();
-        store.put("session.tabs", b"a").unwrap();
-        store.put("session.active", b"b").unwrap();
-        store.put("window.position", b"c").unwrap();
-        let mut session = store.list_prefix("session.").unwrap();
+        store.put(&key!("session.tabs"), b"a").unwrap();
+        store.put(&key!("session.active"), b"b").unwrap();
+        store.put(&key!("window.position"), b"c").unwrap();
+        let mut session = store.list_namespace("session").unwrap();
         session.sort();
         assert_eq!(session.len(), 2);
-        assert_eq!(session[0].0, "session.active");
-        assert_eq!(session[1].0, "session.tabs");
+        assert_eq!(session[0].0.as_str(), "session.active");
+        assert_eq!(session[1].0.as_str(), "session.tabs");
+    }
+
+    #[test]
+    fn a_namespace_listing_does_not_straddle_into_a_longer_one() {
+        // `range("window"..)` would walk into `window_backup.*`, since it sorts
+        // after `window`. The trailing dot is what confines it — and this is the
+        // bug a free `list_prefix` invited.
+        let store = store();
+        store.put(&key!("window.position"), b"mine").unwrap();
+        store
+            .put(&key!("window_backup.position"), b"theirs")
+            .unwrap();
+
+        let listed = store.list_namespace("window").unwrap();
+
+        assert_eq!(listed.len(), 1, "{listed:?}");
+        assert_eq!(listed[0].0.as_str(), "window.position");
     }
 
     #[test]
     fn batch_is_applied_atomically() {
         let store = store();
-        store.put("keep", b"x").unwrap();
+        store.put(&key!("session.keep"), b"x").unwrap();
         store
             .batch(vec![
                 KvOp::Put {
-                    key: "a".to_string(),
+                    key: key!("session.a"),
                     value: b"1".to_vec(),
                 },
                 KvOp::Put {
-                    key: "b".to_string(),
+                    key: key!("session.b"),
                     value: b"2".to_vec(),
                 },
                 KvOp::Delete {
-                    key: "keep".to_string(),
+                    key: key!("session.keep"),
                 },
             ])
             .unwrap();
-        assert_eq!(store.get("a").unwrap().as_deref(), Some(&b"1"[..]));
-        assert_eq!(store.get("b").unwrap().as_deref(), Some(&b"2"[..]));
-        assert_eq!(store.get("keep").unwrap(), None);
+        assert_eq!(
+            store.get(&key!("session.a")).unwrap().as_deref(),
+            Some(&b"1"[..])
+        );
+        assert_eq!(
+            store.get(&key!("session.b")).unwrap().as_deref(),
+            Some(&b"2"[..])
+        );
+        assert_eq!(store.get(&key!("session.keep")).unwrap(), None);
     }
 
     #[test]
@@ -200,15 +238,18 @@ mod tests {
             ..Default::default()
         };
         let store = RedbKvStore::open_in_memory(&log).unwrap();
-        store.put("k", b"v").unwrap();
+        store.put(&key!("window.k"), b"v").unwrap();
         store
             .batch(vec![KvOp::Put {
-                key: "x".to_string(),
+                key: key!("window.x"),
                 value: b"y".to_vec(),
             }])
             .unwrap();
-        assert_eq!(store.get("k").unwrap().as_deref(), Some(&b"v"[..]));
-        assert_eq!(store.list_prefix("").unwrap().len(), 2);
+        assert_eq!(
+            store.get(&key!("window.k")).unwrap().as_deref(),
+            Some(&b"v"[..])
+        );
+        assert_eq!(store.list_namespace("window").unwrap().len(), 2);
     }
 
     #[test]
@@ -217,11 +258,11 @@ mod tests {
         let path = dir.path().join("state.redb");
         {
             let store = RedbKvStore::open(&path, &StoreLogConfig::default()).unwrap();
-            store.put("session.tabs", b"restored").unwrap();
+            store.put(&key!("session.tabs"), b"restored").unwrap();
         }
         let reopened = RedbKvStore::open(&path, &StoreLogConfig::default()).unwrap();
         assert_eq!(
-            reopened.get("session.tabs").unwrap().as_deref(),
+            reopened.get(&key!("session.tabs")).unwrap().as_deref(),
             Some(&b"restored"[..])
         );
     }

--- a/crates/nohrs-store/src/redb_kv.rs
+++ b/crates/nohrs-store/src/redb_kv.rs
@@ -117,7 +117,7 @@ impl KvStore for RedbKvStore {
                 Err(error) => {
                     tracing::warn!(
                         target: "nohrs_store::redb",
-                        "skipping unparseable key in namespace {namespace}: {error}"
+                        "skipping unparsable key in namespace {namespace}: {error}"
                     );
                     continue;
                 }

--- a/crates/nohrs-store/src/redb_kv.rs
+++ b/crates/nohrs-store/src/redb_kv.rs
@@ -142,29 +142,23 @@ impl KvStore for RedbKvStore {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+    use crate::kv_key;
 
     fn store() -> RedbKvStore {
         RedbKvStore::open_in_memory(&StoreLogConfig::default()).unwrap()
     }
 
-    /// Shorthand for a compile-time-checked key in these tests.
-    macro_rules! key {
-        ($key:literal) => {
-            KvKey::from_static($key)
-        };
-    }
-
     #[test]
     fn get_missing_key_before_any_write() {
         let store = store();
-        assert_eq!(store.get(&key!("window.absent")).unwrap(), None);
+        assert_eq!(store.get(&kv_key!("window.absent")).unwrap(), None);
         assert!(store.list_namespace("window").unwrap().is_empty());
     }
 
     #[test]
     fn put_get_delete_round_trip() {
         let store = store();
-        let key = key!("window.position");
+        let key = kv_key!("window.position");
         store.put(&key, b"1,2,3,4").unwrap();
         assert_eq!(store.get(&key).unwrap().as_deref(), Some(&b"1,2,3,4"[..]));
         store.delete(&key).unwrap();
@@ -174,9 +168,9 @@ mod tests {
     #[test]
     fn list_namespace_returns_only_that_namespace() {
         let store = store();
-        store.put(&key!("session.tabs"), b"a").unwrap();
-        store.put(&key!("session.active"), b"b").unwrap();
-        store.put(&key!("window.position"), b"c").unwrap();
+        store.put(&kv_key!("session.tabs"), b"a").unwrap();
+        store.put(&kv_key!("session.active"), b"b").unwrap();
+        store.put(&kv_key!("window.position"), b"c").unwrap();
         let mut session = store.list_namespace("session").unwrap();
         session.sort();
         assert_eq!(session.len(), 2);
@@ -190,9 +184,9 @@ mod tests {
         // after `window`. The trailing dot is what confines it — and this is the
         // bug a free `list_prefix` invited.
         let store = store();
-        store.put(&key!("window.position"), b"mine").unwrap();
+        store.put(&kv_key!("window.position"), b"mine").unwrap();
         store
-            .put(&key!("window_backup.position"), b"theirs")
+            .put(&kv_key!("window_backup.position"), b"theirs")
             .unwrap();
 
         let listed = store.list_namespace("window").unwrap();
@@ -204,31 +198,31 @@ mod tests {
     #[test]
     fn batch_is_applied_atomically() {
         let store = store();
-        store.put(&key!("session.keep"), b"x").unwrap();
+        store.put(&kv_key!("session.keep"), b"x").unwrap();
         store
             .batch(vec![
                 KvOp::Put {
-                    key: key!("session.a"),
+                    key: kv_key!("session.a"),
                     value: b"1".to_vec(),
                 },
                 KvOp::Put {
-                    key: key!("session.b"),
+                    key: kv_key!("session.b"),
                     value: b"2".to_vec(),
                 },
                 KvOp::Delete {
-                    key: key!("session.keep"),
+                    key: kv_key!("session.keep"),
                 },
             ])
             .unwrap();
         assert_eq!(
-            store.get(&key!("session.a")).unwrap().as_deref(),
+            store.get(&kv_key!("session.a")).unwrap().as_deref(),
             Some(&b"1"[..])
         );
         assert_eq!(
-            store.get(&key!("session.b")).unwrap().as_deref(),
+            store.get(&kv_key!("session.b")).unwrap().as_deref(),
             Some(&b"2"[..])
         );
-        assert_eq!(store.get(&key!("session.keep")).unwrap(), None);
+        assert_eq!(store.get(&kv_key!("session.keep")).unwrap(), None);
     }
 
     #[test]
@@ -238,15 +232,15 @@ mod tests {
             ..Default::default()
         };
         let store = RedbKvStore::open_in_memory(&log).unwrap();
-        store.put(&key!("window.k"), b"v").unwrap();
+        store.put(&kv_key!("window.k"), b"v").unwrap();
         store
             .batch(vec![KvOp::Put {
-                key: key!("window.x"),
+                key: kv_key!("window.x"),
                 value: b"y".to_vec(),
             }])
             .unwrap();
         assert_eq!(
-            store.get(&key!("window.k")).unwrap().as_deref(),
+            store.get(&kv_key!("window.k")).unwrap().as_deref(),
             Some(&b"v"[..])
         );
         assert_eq!(store.list_namespace("window").unwrap().len(), 2);
@@ -258,11 +252,11 @@ mod tests {
         let path = dir.path().join("state.redb");
         {
             let store = RedbKvStore::open(&path, &StoreLogConfig::default()).unwrap();
-            store.put(&key!("session.tabs"), b"restored").unwrap();
+            store.put(&kv_key!("session.tabs"), b"restored").unwrap();
         }
         let reopened = RedbKvStore::open(&path, &StoreLogConfig::default()).unwrap();
         assert_eq!(
-            reopened.get(&key!("session.tabs")).unwrap().as_deref(),
+            reopened.get(&kv_key!("session.tabs")).unwrap().as_deref(),
             Some(&b"restored"[..])
         );
     }

--- a/crates/nohrs-store/src/redb_kv.rs
+++ b/crates/nohrs-store/src/redb_kv.rs
@@ -86,6 +86,11 @@ impl KvStore for RedbKvStore {
 
     fn list_namespace(&self, namespace: &str) -> Result<Vec<(KvKey, Vec<u8>)>> {
         let started = Instant::now();
+        // The same rule `KvKey::new` applies. Without it `list_namespace` would
+        // accept `"window.main"`, scan `window.main.`, and return keys whose own
+        // `namespace()` is `"window"` — one argument meaning two things on
+        // either side of the API.
+        KvKey::check_namespace(namespace)?;
         // The trailing dot is what confines the scan to the namespace itself:
         // scanning from `window` alone would also walk into a `window_backup`
         // namespace, since `window_backup.x` sorts after `window`.
@@ -188,6 +193,24 @@ mod tests {
         assert_eq!(session.len(), 2);
         assert_eq!(session[0].0.as_str(), "session.active");
         assert_eq!(session[1].0.as_str(), "session.tabs");
+    }
+
+    #[test]
+    fn listing_and_construction_agree_on_what_a_namespace_is() {
+        // A namespace that `KvKey::new` refuses must not be listable either.
+        // `list_namespace("window.main")` used to scan `window.main.` and hand
+        // back keys whose own `namespace()` is `"window"` — the same argument
+        // meaning two different things on either side of the API.
+        let store = store();
+        store.put(&kv_key!("window.main.position"), b"x").unwrap();
+
+        assert!(KvKey::new("window.main", "position").is_err());
+        assert!(store.list_namespace("window.main").is_err());
+
+        // The key is still reachable under the namespace it actually has.
+        let listed = store.list_namespace("window").unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].0.as_str(), "window.main.position");
     }
 
     #[test]

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -235,6 +235,9 @@ fn cache_for(plugin_id: &str) -> TableDefinition<'static, &str, (i64, &[u8])>;
 ```rust
 // crates/nohrs-store/src/nohrs_store.rs
 
+// このスケッチ内だけの略記。実装では値はそのまま `Vec<u8>` です。
+type Bytes = Vec<u8>;
+
 pub trait MetadataQuery: Send + Sync {
     fn get_file(&self, path: &Path) -> Result<Option<FileRecord>>;
     fn list_children(&self, parent: &Path) -> Result<Vec<FileRecord>>;

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -206,6 +206,13 @@ macro_rules! kv_key {
 `list_prefix("sess")` が `session.*` にたまたま一致し、`list_prefix("window")` は
 `window_backup.*` まで拾います。末尾のドットを内部で足すことで、走査は名前空間の中で閉じます。
 
+**「名前空間」を受け取る引数は 1 セグメントです。** キー自体は 3 セグメント以上でも構いません
+(`kv_key!("window.main.position")` は有効) が、`namespace()` は**最初の**セグメントを返すので、
+このキーは `list_namespace("window")` に並びます。逆に `"window.main"` を名前空間として渡すのは
+`KvKey::new` でも `list_namespace` でもエラーです — 通してしまうと、呼び出し側が思っている
+名前空間とキーが実際に属する名前空間がずれます。両者は `KvKey::check_namespace` を共有していて、
+片方だけ緩むことがないようにしてあります。
+
 > **書き込み頻度に関する注意**: redb の commit はデフォルトで durable (fsync) なので、window ドラッグ等の高頻度更新を 1 操作ずつ `put` すると fsync が多発する。呼び出し側 (UI 層) で **debounce してから書く**、複数キーは `batch` でまとめる、を原則とする。
 
 ### プラグイン KV テーブル設計 (P4)

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -159,14 +159,35 @@ redb = "2"
 // crates/nohrs-store/src/nohrs_store.rs (擬似コード)
 use redb::TableDefinition;
 
-// 単一テーブル。key は "window.position" / "session.tabs" 等の名前空間付き文字列。
+// 単一テーブル。key は `KvKey` (= "window.position" / "session.tabs")。
 const HOST_KV: TableDefinition<'static, &str, &[u8]> = TableDefinition::new("kv");
 ```
 
 - `KvStore::get` / `put` / `delete` は `HOST_KV` への単純な点アクセス
-- `KvStore::list_prefix(prefix)` は `range(prefix..)` を走査し prefix 不一致で打ち切る
+- `KvStore::list_namespace(ns)` は `range("<ns>.".. )` を走査し prefix 不一致で打ち切る
 - `KvStore::batch(ops)` は 1 つの write transaction にまとめて atomic commit
 - value は JSON or MessagePack で serialize した blob (タブ群のスナップショット等)
+
+#### キーの名前空間は型で強制する
+
+key は `&str` ではなく **`KvKey`** です。`<namespace>.<name>` のドット区切りで、セグメントは
+1 つ以上・小文字 ASCII / 数字 / `_`。
+
+名前空間は「文字列の慣習」だった時期があり、それだと `put("tabs", …)` が普通にコンパイルされ、
+書けて読み戻せてしまいます。壊れるのは後から別の場所で、`list_*` が行を取りこぼす形です。
+そこで:
+
+| 作り方 | 検査 | 用途 |
+|--------|------|------|
+| `KvKey::from_static("session.explorer_tabs")` | **コンパイル時** (`const fn`) | サブシステムが持つ固定キー。ほぼ全部これ |
+| `KvKey::new(ns, name)` / `KvKey::parse(s)` | 実行時 (`Result`) | 実行時に組み立てるキー |
+
+`from_static` は `const fn` なので、`KvKey::from_static("tabs")` は実行時エラーではなく
+**ビルドエラー**になります。これが「規約」を規約以上のものにしている部分です。
+
+`list_namespace` が prefix ではなく名前空間を取るのも同じ理由です。自由な prefix だと
+`list_prefix("sess")` が `session.*` にたまたま一致し、`list_prefix("window")` は
+`window_backup.*` まで拾います。末尾のドットを内部で足すことで、走査は名前空間の中で閉じます。
 
 > **書き込み頻度に関する注意**: redb の commit はデフォルトで durable (fsync) なので、window ドラッグ等の高頻度更新を 1 操作ずつ `put` すると fsync が多発する。呼び出し側 (UI 層) で **debounce してから書く**、複数キーは `batch` でまとめる、を原則とする。
 
@@ -228,10 +249,10 @@ pub trait MetadataStore: MetadataQuery {
 }
 
 pub trait KvStore: Send + Sync {
-    fn get(&self, key: &str) -> Result<Option<Bytes>>;
-    fn put(&self, key: &str, value: &[u8]) -> Result<()>;
-    fn delete(&self, key: &str) -> Result<()>;
-    fn list_prefix(&self, prefix: &str) -> Result<Vec<(String, Bytes)>>;
+    fn get(&self, key: &KvKey) -> Result<Option<Bytes>>;
+    fn put(&self, key: &KvKey, value: &[u8]) -> Result<()>;
+    fn delete(&self, key: &KvKey) -> Result<()>;
+    fn list_namespace(&self, namespace: &str) -> Result<Vec<(KvKey, Bytes)>>;
     fn batch(&self, ops: Vec<KvOp>) -> Result<()>;
 }
 

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -170,8 +170,8 @@ const HOST_KV: TableDefinition<'static, &str, &[u8]> = TableDefinition::new("kv"
 
 #### キーの名前空間は型で強制する
 
-key は `&str` ではなく **`KvKey`** です。`<namespace>.<name>` のドット区切りで、セグメントは
-1 つ以上・小文字 ASCII / 数字 / `_`。
+key は `&str` ではなく **`KvKey`** です。`<namespace>.<name>` のドット区切りで、**セグメントは
+2 つ以上**（つまり必ず名前空間を持つ）。各セグメントは 1 文字以上の小文字 ASCII / 数字 / `_`。
 
 名前空間は「文字列の慣習」だった時期があり、それだと `put("tabs", …)` が普通にコンパイルされ、
 書けて読み戻せてしまいます。壊れるのは後から別の場所で、`list_*` が行を取りこぼす形です。

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -179,11 +179,28 @@ key は `&str` ではなく **`KvKey`** です。`<namespace>.<name>` のドッ�
 
 | 作り方 | 検査 | 用途 |
 |--------|------|------|
-| `KvKey::from_static("session.explorer_tabs")` | **コンパイル時** (`const fn`) | サブシステムが持つ固定キー。ほぼ全部これ |
+| `kv_key!("session.explorer_tabs")` | **コンパイル時** | サブシステムが持つ固定キー。ほぼ全部これ |
 | `KvKey::new(ns, name)` / `KvKey::parse(s)` | 実行時 (`Result`) | 実行時に組み立てるキー |
 
-`from_static` は `const fn` なので、`KvKey::from_static("tabs")` は実行時エラーではなく
-**ビルドエラー**になります。これが「規約」を規約以上のものにしている部分です。
+`kv_key!("tabs")` は実行時エラーではなく**ビルドエラー**です。これが「規約」を規約以上のものに
+している部分です。
+
+**効いているのはマクロの `const { … }` ブロックです。** 検証関数を `const fn` にしただけでは
+足りません — `const fn` は通常式から呼ばれたとき const 評価が*許される*だけで*強制されない*ので、
+素の呼び出しでは assert がそのまま実行時 panic になります。マクロは:
+
+```rust
+macro_rules! kv_key {
+    ($key:literal) => { const { $crate::KvKey::from_static_checked($key) } };
+}
+```
+
+- `const { … }` が全呼び出し箇所で const 評価を強制する
+- `$key:literal` が、実行時に選ばれた `&'static str` の混入を防ぐ
+
+素のコンストラクタ (`from_static_checked`) は `#[doc(hidden)]` です。マクロが他クレートで
+展開されるために public なだけで、直接呼ぶものではありません。この保証は 3 本の doctest
+（正しいリテラル / 名前空間なし `compile_fail` / 非リテラル `compile_fail`）で固定しています。
 
 `list_namespace` が prefix ではなく名前空間を取るのも同じ理由です。自由な prefix だと
 `list_prefix("sess")` が `session.*` にたまたま一致し、`list_prefix("window")` は


### PR DESCRIPTION
## Summary

`docs/persistence.md` §3 said host KV keys are `<namespace>.<name>`. Nothing checked it.

```rust
store.put("tabs", &bytes)?;   // compiled, wrote, and read back correctly
```

That is the worst shape a convention can have: **nothing goes wrong at the point the mistake is made.** It goes wrong later and somewhere else, as `list_prefix("session.")` quietly returning fewer rows than it should — a bug with no stack trace and no obvious author.

There is one production key today (`session.explorer_tabs`), so the cost of closing this is near zero now and grows with every key added — including the plugin keys P4 will build at runtime.

## Changes

- **`KvKey`**, with the check placed where keys are *written*:

  | Constructor | Checked | For |
  |---|---|---|
  | `kv_key!("session.explorer_tabs")` | **compile time** | the fixed keys a subsystem owns — nearly all of them |
  | `KvKey::new(ns, name)` / `KvKey::parse(s)` | runtime (`Result`) | keys built at runtime |

  `kv_key!` expands to `const { KvKey::from_static_checked($key) }`. The `const { … }` block is load-bearing: a `const fn` called from an ordinary expression is *permitted* to be const-evaluated but not required to, so a bare call leaves the assertion as a runtime panic. The block forces const evaluation at every call site, and `$key:literal` keeps a runtime-selected `&'static str` from reaching it at all.

  The validator is a hand-rolled byte loop rather than `split`/`all` because iterators are not available in a `const fn` — that is the whole reason it can reject a literal at build time.

- **`KvStore` and `KvOp` take `KvKey`**, so there is no route to the table that skips the check.

- **`list_prefix` → `list_namespace`**, which appends the separator itself. A free prefix was its own trap: `list_prefix("sess")` matched `session.*` by accident, and `list_prefix("window")` would return a `window_backup.*` namespace's rows too, because `window_backup.x` sorts after `window`. There is a regression test for exactly that.

- Docs (`persistence.md` §3, incl. the trait sketch) and CHANGELOG follow.

Segments are lowercase ASCII, digits and `_`, and there are always at least two — so every key names a namespace. `namespace()` returns the *first* segment, so `window.main.position` is found by `list_namespace("window")`.

## Testing

- `cargo test --workspace` — **201 tests**, +10 in this PR (key validation, namespace extraction, `new` joining both halves, the compile-time and runtime checks agreeing, the error message, namespace listing, the straddling regression, and three doctests).
- **The compile-time guarantee is tested, not asserted.** Three doctests: a valid literal that compiles and runs, an invalid literal that must *not* compile, and a non-literal that must *not* compile. `compile_fail` doctests need no new dependency and don't break when rustc rewrites an error message.
- The behavioural risk here is session restore, since `page.rs` is the one real caller. `explorer::tests::tabs_round_trip_through_the_store` covers it end to end against a real in-memory redb — saved, reopened, restored — and passes.

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`

Not a UI change — no rendering or layout differs, and the stored key string is byte-for-byte what it was, so existing `state.redb` files restore unchanged.

### Correction to an earlier claim in this PR

The first revision said `KvKey::from_static` made a bad literal a build error, full stop. That was wrong, and CodeRabbit caught it. It held only inside a `const` item; from an ordinary expression the assertion ran at runtime and panicked — confirmed before fixing:

```
thread 'runtime_call_of_from_static' panicked at nohrs_store.rs:249:
a kv key must be <namespace>.<name>, lowercase ASCII, digits and _
```

My verification had checked `const BAD: KvKey = …`, which is a const item and therefore the one case that could not fail. The tests' own `key!` helper expanded to a bare call, so they were running the check at runtime too. `kv_key!` and its `const { … }` block are the fix, and the `compile_fail` doctests are what now hold it in place.

Note for anyone running the suite on Linux: the GUI crates need `libxkbcommon-x11-0` installed and `RUSTFLAGS="-L $HOME/.local/devlibs"` (`script/ui-run.sh setup`). Without them `cargo test --workspace` fails at link time on an unrelated missing library.

## Release Notes

Release Notes:

- N/A

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGvq4wr6T12DEncToupAtb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changed**
  * Host key-value storage now uses validated keys following the `<namespace>.<name>` format.
  * Invalid keys are rejected with clear validation errors.
  * Namespace listings are limited to the requested namespace, preventing results from similarly named namespaces.
  * The storage listing API now returns typed keys instead of raw strings.
  * Listing is now namespace-based rather than prefix-based.

* **Documentation**
  * Updated persistence documentation and changelog to reflect the key format and namespace listing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->