### PR TITLE
nohrs-core: Name the rollover test's log file from the clock it tests against

### DIFF
--- a/crates/nohrs-core/src/telemetry/logging.rs
+++ b/crates/nohrs-core/src/telemetry/logging.rs
@@ -637,9 +637,13 @@ mod tests {
         // session has. Tightening only at startup would hold for the first day
         // of a long-running GUI and quietly stop holding after midnight.
         let directory = tempfile::tempdir().unwrap();
+        // `wrap` reads the real clock, so the file has to be named from the same
+        // one. A literal date here passes only on the day it is written: the
+        // wrapper tightens `<prefix>.<today>` and would find nothing to chmod.
+        let today = time::OffsetDateTime::now_utc().date();
         let rolled = directory
             .path()
-            .join(format!("{LOG_FILE_PREFIX}.2026-09-08"));
+            .join(log_file_name_for(today).expect("a name for today"));
         std::fs::write(&rolled, "{}\n").unwrap();
         std::fs::set_permissions(&rolled, std::fs::Permissions::from_mode(0o644)).unwrap();
 


### PR DESCRIPTION
## Summary

`develop` has been red since midnight UTC. `telemetry::logging::tests::a_file_created_by_a_rollover_is_tightened_too` fails with `left: 420, right: 384` — the file it created is still `0644` when it expected `0600`.

The test creates `nohrs.log.2026-09-08` and then asks `OwnerOnly::wrap` to tighten it. `wrap` reads the real clock, so the wrapper chmods `<prefix>.<today>`. On 2026-09-08 that was exactly the file the test had made; from 2026-09-09 it is a name that does not exist, so nothing is chmodded and the file stays at its umask mode.

**The tightening itself is fine.** The sibling tests drive the same code through `wrapped_appender`, whose injected clock agrees with the dates they write, and they still pass — including the midnight-straddling one. This was the only test that paired the real-clock constructor with a literal date. It now takes its name from the same clock the wrapper reads.

This is why CI passed on `fcae338` when #236 merged and fails now on the identical Rust tree: the code did not change, the date did.

## Testing

- `cargo test -p nohrs-core --lib` — 67 passed, 0 failed (was 66/1)
- Confirmed the failure is a date bomb, not my change: the test fails at `fcae338`, the commit *before* the web merge, and at `2d7fd1f`; substituting today's date makes it pass at both
- `cargo fmt --check -p nohrs-core` and `cargo clippy -p nohrs-core --lib --all-targets -- -D warnings` — clean

## Suggested .rules additions

A test that pairs a real-clock constructor with a literal date passes on the day it is written and fails from the next day on. When a test needs a date the code under test will also compute, take it from the same clock rather than writing it down — or inject a clock into both, as the sibling tests here do.

Release Notes:

- N/A

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQqvCRiiviXGb4gFCBTNsq

---
_Generated by [Claude Code](https://claude.ai/code/session_01VQqvCRiiviXGb4gFCBTNsq)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the rollover test's date bomb by naming its log file from the clock the code under test reads, so the test no longer fails once the hard-coded date (2026-09-08) passed.

- The test previously wrote `nohrs.log.2026-09-08` and expected `OwnerOnly::wrap` to tighten it, but `wrap` chmods `<prefix>.<today>` — after 2026-09-08 that name didn't exist, so nothing was chmodded and the file kept its umask mode.
- The test now derives the file name from `time::OffsetDateTime::now_utc()`, matching the clock `wrap` reads.

<sup>Written for commit cc2def1b623dece8dee667a39afbd0bb3786023c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/noh-rs/nohrs/pull/243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved rollover test reliability by deriving the expected log filename from the current date, allowing it to run consistently on different days.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->