### PR TITLE
explorer: Reserve paste destinations and keep failed cuts retryable

### DIFF
--- a/crates/nohrs-pages/src/explorer/file_ops.rs
+++ b/crates/nohrs-pages/src/explorer/file_ops.rs
@@ -36,9 +36,47 @@ pub(crate) enum ClipMode {
 #[derive(Clone, Default)]
 pub(crate) struct ExplorerClipboard {
     entry: Option<(ClipMode, Vec<PathBuf>)>,
+    // Bumped on every write. A paste records the generation it leaves behind so
+    // that, finishing later, it can tell its own clipboard state apart from one
+    // the user — or an overlapping paste — has claimed since. Comparing against
+    // "is the clipboard empty" cannot: two cut pastes in flight both leave it
+    // empty, and whichever finishes first would look like the owner of both.
+    generation: u64,
 }
 
 impl Global for ExplorerClipboard {}
+
+impl ExplorerClipboard {
+    // Replaces the clipboard contents, returning the generation stamped on this
+    // write.
+    fn write(entry: Option<(ClipMode, Vec<PathBuf>)>, cx: &mut App) -> u64 {
+        let generation = Self::generation(cx).wrapping_add(1);
+        cx.set_global(ExplorerClipboard { entry, generation });
+        generation
+    }
+
+    fn generation(cx: &App) -> u64 {
+        cx.try_global::<ExplorerClipboard>()
+            .map_or(0, |clip| clip.generation)
+    }
+}
+
+// Puts the sources a cut-paste could not move back on the clipboard, so the user
+// can retry them as a move. Without this the cleared clipboard falls through to
+// the system clipboard's path text, which carries no cut/copy distinction and so
+// retries a failed *move* as a *copy*.
+//
+// Only restores when the clipboard is still the one this paste left behind:
+// anything else means newer state the user can see, which is the live one.
+// Takes `&mut App` rather than the pane so a batch outliving the pane that
+// started it still restores — the clipboard is process-wide, and the retry
+// matters to whatever pane the user is looking at now.
+fn retain_failed_cut(failed: Vec<PathBuf>, generation: u64, cx: &mut App) {
+    if failed.is_empty() || ExplorerClipboard::generation(cx) != generation {
+        return;
+    }
+    ExplorerClipboard::write(Some((ClipMode::Cut, failed)), cx);
+}
 
 /// State of an in-progress inline rename of the listing row at `index` (an index
 /// into `filtered_entries`).
@@ -159,12 +197,14 @@ impl ExplorerPane {
     where
         F: FnOnce() -> Vec<String> + Send + 'static,
     {
-        self.run_fs_op_with(total, success_label, cx, move || (op(), ()), |_, (), _| {});
+        self.run_fs_op_with(total, success_label, cx, move || (op(), ()), |(), _| {});
     }
 
-    // [`run_fs_op`](Self::run_fs_op) for batches that need to report more than
-    // failure messages back to the UI thread: `op` also returns a value of its
-    // own, handed to `on_complete` once the listing has reloaded.
+    // [`run_fs_op`](Self::run_fs_op) for batches that carry an outcome of their
+    // own beyond the failure messages. `on_complete` takes `&mut App` rather
+    // than the pane, and runs whether or not the pane outlived the batch, so an
+    // outcome owning process-wide state is not dropped along with the pane that
+    // started the work.
     fn run_fs_op_with<T, F, G>(
         &mut self,
         total: usize,
@@ -175,16 +215,17 @@ impl ExplorerPane {
     ) where
         T: Send + 'static,
         F: FnOnce() -> (Vec<String>, T) + Send + 'static,
-        G: FnOnce(&mut Self, T, &mut Context<Self>) + 'static,
+        G: FnOnce(T, &mut App) + 'static,
     {
+        use nohrs_core::telemetry::LogErr as _;
         let task = cx.background_spawn(async move { op() });
         cx.spawn(move |this: WeakEntity<Self>, cx: &mut AsyncApp| {
             let mut cx = cx.clone();
             async move {
                 let (errors, outcome) = task.await;
+                cx.update(|cx| on_complete(outcome, cx)).log_err();
                 this.update(&mut cx, |pane, cx| {
                     pane.reload();
-                    on_complete(pane, outcome, cx);
                     if errors.is_empty() {
                         pane.set_status(StatusLevel::Info, success_label);
                     } else {
@@ -257,9 +298,7 @@ impl ExplorerPane {
             return;
         }
         let buffers = paths.iter().map(PathBuf::from).collect();
-        cx.set_global(ExplorerClipboard {
-            entry: Some((mode, buffers)),
-        });
+        ExplorerClipboard::write(Some((mode, buffers)), cx);
         cx.write_to_clipboard(ClipboardItem::new_string(paths.join("\n")));
         let verb = match mode {
             ClipMode::Copy => "copied",
@@ -420,10 +459,9 @@ impl ExplorerPane {
         // A cut consumes the clipboard: clear it now so a second paste, fired
         // while this one is still running, does not try to move the sources a
         // second time. Whatever fails to move is put back afterwards by
-        // `retain_failed_cut`.
-        if mode == ClipMode::Cut {
-            cx.set_global(ExplorerClipboard::default());
-        }
+        // `retain_failed_cut`, which uses this generation to recognize the
+        // clipboard state it left behind.
+        let cut_generation = (mode == ClipMode::Cut).then(|| ExplorerClipboard::write(None, cx));
         let label = format!(
             "{total} item(s) {}",
             if mode == ClipMode::Cut {
@@ -473,35 +511,12 @@ impl ExplorerPane {
                 }
                 (errors, failed)
             },
-            move |pane, failed, cx| {
-                if mode == ClipMode::Cut {
-                    pane.retain_failed_cut(failed, cx);
+            move |failed, cx| {
+                if let Some(generation) = cut_generation {
+                    retain_failed_cut(failed, generation, cx);
                 }
             },
         );
-    }
-
-    // Puts the sources a cut-paste could not move back on the clipboard, so the
-    // user can retry them as a move. Without this the cleared clipboard falls
-    // through to the system clipboard's path text, which carries no cut/copy
-    // distinction and so retries a failed *move* as a *copy*.
-    //
-    // Only restores when nothing has claimed the clipboard since the paste
-    // started: a copy or cut the user made while it ran is theirs, and silently
-    // replacing it would be worse than losing the retry.
-    fn retain_failed_cut(&mut self, failed: Vec<PathBuf>, cx: &mut Context<Self>) {
-        if failed.is_empty() {
-            return;
-        }
-        let claimed = cx
-            .try_global::<ExplorerClipboard>()
-            .is_some_and(|clip| clip.entry.is_some());
-        if claimed {
-            return;
-        }
-        cx.set_global(ExplorerClipboard {
-            entry: Some((ClipMode::Cut, failed)),
-        });
     }
 
     // ---- Rename + new folder (§1, §6) ----

--- a/crates/nohrs-pages/src/explorer/file_ops.rs
+++ b/crates/nohrs-pages/src/explorer/file_ops.rs
@@ -159,13 +159,32 @@ impl ExplorerPane {
     where
         F: FnOnce() -> Vec<String> + Send + 'static,
     {
+        self.run_fs_op_with(total, success_label, cx, move || (op(), ()), |_, (), _| {});
+    }
+
+    // [`run_fs_op`](Self::run_fs_op) for batches that need to report more than
+    // failure messages back to the UI thread: `op` also returns a value of its
+    // own, handed to `on_complete` once the listing has reloaded.
+    fn run_fs_op_with<T, F, G>(
+        &mut self,
+        total: usize,
+        success_label: String,
+        cx: &mut Context<Self>,
+        op: F,
+        on_complete: G,
+    ) where
+        T: Send + 'static,
+        F: FnOnce() -> (Vec<String>, T) + Send + 'static,
+        G: FnOnce(&mut Self, T, &mut Context<Self>) + 'static,
+    {
         let task = cx.background_spawn(async move { op() });
         cx.spawn(move |this: WeakEntity<Self>, cx: &mut AsyncApp| {
             let mut cx = cx.clone();
             async move {
-                let errors = task.await;
+                let (errors, outcome) = task.await;
                 this.update(&mut cx, |pane, cx| {
                     pane.reload();
+                    on_complete(pane, outcome, cx);
                     if errors.is_empty() {
                         pane.set_status(StatusLevel::Info, success_label);
                     } else {
@@ -298,7 +317,10 @@ impl ExplorerPane {
         let mut resolved = Vec::new();
         // Destination names already claimed by an earlier source in this same
         // batch, so two sources sharing a basename (possible via the system
-        // clipboard) don't silently overwrite each other.
+        // clipboard) don't silently overwrite each other. A name is claimed
+        // whether or not the destination is already occupied: a conflicting name
+        // resolved as Overwrite is still one destination, so a second source
+        // aiming at it has to be numbered too.
         let mut claimed = std::collections::HashSet::new();
         for src in sources {
             let Some(name) = src.file_name() else {
@@ -313,12 +335,13 @@ impl ExplorerPane {
                 }
                 continue;
             }
-            if ops::would_conflict(&dst) {
-                pending.push_back(src);
-            } else if !claimed.insert(dst) {
+            let occupied = ops::would_conflict(&dst);
+            if !claimed.insert(dst) {
                 // Another source already targets this name; number it instead of
                 // letting the later paste clobber the earlier one.
                 resolved.push((src, ConflictResolution::Rename));
+            } else if occupied {
+                pending.push_back(src);
             } else {
                 clear.push(src);
             }
@@ -394,8 +417,10 @@ impl ExplorerPane {
         if total == 0 {
             return;
         }
-        // A cut consumes the clipboard: clear it now so a second paste does not
-        // try to move the (already relocated) sources again.
+        // A cut consumes the clipboard: clear it now so a second paste, fired
+        // while this one is still running, does not try to move the sources a
+        // second time. Whatever fails to move is put back afterwards by
+        // `retain_failed_cut`.
         if mode == ClipMode::Cut {
             cx.set_global(ExplorerClipboard::default());
         }
@@ -407,36 +432,75 @@ impl ExplorerPane {
                 "pasted"
             }
         );
-        self.run_fs_op(total, label, cx, move || {
-            let mut errors = Vec::new();
-            for src in clear {
-                if let Some(name) = src.file_name() {
+        self.run_fs_op_with(
+            total,
+            label,
+            cx,
+            move || {
+                let mut errors = Vec::new();
+                let mut failed = Vec::new();
+                for src in clear {
+                    // Owned so the borrow of `src` ends before `src` is moved
+                    // into `failed`.
+                    let Some(name) = src.file_name().map(std::ffi::OsStr::to_os_string) else {
+                        continue;
+                    };
                     let dst = dest_dir.join(name);
                     if let Err(error) = apply_one(mode, &src, &dst) {
                         errors.push(format!("{}: {error}", src.display()));
+                        failed.push(src);
                     }
                 }
-            }
-            for (src, resolution) in resolved {
-                let Some(name) = file_name_of(&src) else {
-                    continue;
-                };
-                let result = match resolution {
-                    // Filtered out above; kept for exhaustiveness without panicking.
-                    ConflictResolution::Skip => continue,
-                    ConflictResolution::Rename => {
-                        let unique = ops::unique_name(&dest_dir, &name);
-                        apply_one(mode, &src, &dest_dir.join(unique))
+                for (src, resolution) in resolved {
+                    let Some(name) = file_name_of(&src) else {
+                        continue;
+                    };
+                    let result = match resolution {
+                        // Filtered out above; kept for exhaustiveness without panicking.
+                        ConflictResolution::Skip => continue,
+                        ConflictResolution::Rename => {
+                            let unique = ops::unique_name(&dest_dir, &name);
+                            apply_one(mode, &src, &dest_dir.join(unique))
+                        }
+                        ConflictResolution::Overwrite => {
+                            overwrite_apply(mode, &src, &dest_dir.join(&name))
+                        }
+                    };
+                    if let Err(error) = result {
+                        errors.push(format!("{}: {error}", src.display()));
+                        failed.push(src);
                     }
-                    ConflictResolution::Overwrite => {
-                        overwrite_apply(mode, &src, &dest_dir.join(&name))
-                    }
-                };
-                if let Err(error) = result {
-                    errors.push(format!("{}: {error}", src.display()));
                 }
-            }
-            errors
+                (errors, failed)
+            },
+            move |pane, failed, cx| {
+                if mode == ClipMode::Cut {
+                    pane.retain_failed_cut(failed, cx);
+                }
+            },
+        );
+    }
+
+    // Puts the sources a cut-paste could not move back on the clipboard, so the
+    // user can retry them as a move. Without this the cleared clipboard falls
+    // through to the system clipboard's path text, which carries no cut/copy
+    // distinction and so retries a failed *move* as a *copy*.
+    //
+    // Only restores when nothing has claimed the clipboard since the paste
+    // started: a copy or cut the user made while it ran is theirs, and silently
+    // replacing it would be worse than losing the retry.
+    fn retain_failed_cut(&mut self, failed: Vec<PathBuf>, cx: &mut Context<Self>) {
+        if failed.is_empty() {
+            return;
+        }
+        let claimed = cx
+            .try_global::<ExplorerClipboard>()
+            .is_some_and(|clip| clip.entry.is_some());
+        if claimed {
+            return;
+        }
+        cx.set_global(ExplorerClipboard {
+            entry: Some((ClipMode::Cut, failed)),
         });
     }
 

--- a/crates/nohrs-pages/src/explorer/tests.rs
+++ b/crates/nohrs-pages/src/explorer/tests.rs
@@ -1293,6 +1293,65 @@ async fn closing_the_conflict_dialog_leaves_the_plan_for_the_resolving_button(
 }
 
 #[gpui::test]
+async fn a_failed_cut_does_not_clobber_a_clipboard_claimed_while_it_ran(cx: &mut TestAppContext) {
+    // Restoring failed cut sources must not overwrite whatever the user (or an
+    // overlapping paste) put on the clipboard while the batch was in flight —
+    // that newer state is the one they can see.
+    let dir = tempfile::tempdir().unwrap();
+    let src = dir.path().join("src");
+    let dst = dir.path().join("dst");
+    std::fs::create_dir(&src).unwrap();
+    std::fs::create_dir(&dst).unwrap();
+    std::fs::write(src.join("x.txt"), "X").unwrap();
+    std::fs::write(src.join("y.txt"), "Y").unwrap();
+
+    let window = new_explorer(cx);
+    window
+        .update(cx, |pane, _window, cx| {
+            pane.cwd = src.to_string_lossy().to_string();
+            pane.reload();
+            pane.select_single(0); // x.txt
+            pane.cut_selection(cx);
+        })
+        .unwrap();
+
+    // Remove the source so the cut fails, then start the paste without parking.
+    std::fs::remove_file(src.join("x.txt")).unwrap();
+    window
+        .update(cx, |pane, window, cx| {
+            pane.cwd = dst.to_string_lossy().to_string();
+            pane.reload();
+            pane.paste_into_cwd(window, cx);
+            // Still in flight: the user copies something else.
+            pane.cwd = src.to_string_lossy().to_string();
+            pane.reload();
+            pane.select_all(); // only y.txt remains
+            pane.copy_selection(cx);
+        })
+        .unwrap();
+    cx.run_until_parked();
+
+    window
+        .update(cx, |pane, window, cx| {
+            pane.cwd = dst.to_string_lossy().to_string();
+            pane.reload();
+            pane.paste_into_cwd(window, cx);
+        })
+        .unwrap();
+    cx.run_until_parked();
+
+    assert_eq!(
+        std::fs::read_to_string(dst.join("y.txt")).unwrap(),
+        "Y",
+        "the copy the user made during the paste is what pastes"
+    );
+    assert!(
+        src.join("y.txt").exists(),
+        "and it stays a copy — the failed cut did not replace it"
+    );
+}
+
+#[gpui::test]
 async fn cut_paste_keeps_failed_sources_on_the_clipboard_as_a_cut(cx: &mut TestAppContext) {
     let dir = tempfile::tempdir().unwrap();
     let src = dir.path().join("src");

--- a/crates/nohrs-pages/src/explorer/tests.rs
+++ b/crates/nohrs-pages/src/explorer/tests.rs
@@ -1351,6 +1351,91 @@ async fn a_failed_cut_does_not_clobber_a_clipboard_claimed_while_it_ran(cx: &mut
     );
 }
 
+// Randomized scheduling: the two batches below complete in an order the
+// dispatcher picks, and the whole point of the generation stamp is that the
+// outcome no longer depends on it. Varying the seed exercises both orders.
+#[gpui::test(iterations = 25)]
+async fn overlapping_cut_pastes_restore_only_the_live_clipboard(cx: &mut TestAppContext) {
+    // Two failed cut pastes in flight at once. Both left the clipboard empty, so
+    // ownership cannot be read off "is the clipboard empty" — whichever finished
+    // first would claim the restore, and with A first that strands B's sources
+    // as non-retryable. Keyed on the generation each paste left behind, only B
+    // (whose clear is the clipboard's current state) restores, whichever order
+    // they finish in.
+    let dir = tempfile::tempdir().unwrap();
+    let src = dir.path().join("src");
+    let dst = dir.path().join("dst");
+    std::fs::create_dir(&src).unwrap();
+    std::fs::create_dir(&dst).unwrap();
+    std::fs::write(src.join("x.txt"), "X").unwrap();
+    std::fs::write(src.join("y.txt"), "Y").unwrap();
+
+    let window = new_explorer(cx);
+    // Batch A: cut x.txt, delete it so the move fails, start the paste.
+    window
+        .update(cx, |pane, _window, cx| {
+            pane.cwd = src.to_string_lossy().to_string();
+            pane.reload();
+            pane.select_single(0); // x.txt
+            pane.cut_selection(cx);
+        })
+        .unwrap();
+    std::fs::remove_file(src.join("x.txt")).unwrap();
+    window
+        .update(cx, |pane, window, cx| {
+            pane.cwd = dst.to_string_lossy().to_string();
+            pane.reload();
+            pane.paste_into_cwd(window, cx);
+        })
+        .unwrap();
+
+    // Batch B: same again for y.txt, without parking — so A is still in flight.
+    window
+        .update(cx, |pane, _window, cx| {
+            pane.cwd = src.to_string_lossy().to_string();
+            pane.reload();
+            pane.select_all(); // only y.txt remains
+            pane.cut_selection(cx);
+        })
+        .unwrap();
+    std::fs::remove_file(src.join("y.txt")).unwrap();
+    window
+        .update(cx, |pane, window, cx| {
+            pane.cwd = dst.to_string_lossy().to_string();
+            pane.reload();
+            pane.paste_into_cwd(window, cx);
+        })
+        .unwrap();
+    cx.run_until_parked();
+
+    // Restore both sources and retry whatever the clipboard kept.
+    std::fs::write(src.join("x.txt"), "X").unwrap();
+    std::fs::write(src.join("y.txt"), "Y").unwrap();
+    window
+        .update(cx, |pane, window, cx| {
+            pane.cwd = dst.to_string_lossy().to_string();
+            pane.reload();
+            pane.paste_into_cwd(window, cx);
+        })
+        .unwrap();
+    cx.run_until_parked();
+
+    assert_eq!(
+        std::fs::read_to_string(dst.join("y.txt")).unwrap(),
+        "Y",
+        "the later batch's failed source is the one retained"
+    );
+    assert!(
+        !src.join("y.txt").exists(),
+        "and it retries as a move, not a copy"
+    );
+    assert!(
+        !dst.join("x.txt").exists(),
+        "the earlier batch did not claim the restore"
+    );
+    assert!(src.join("x.txt").exists());
+}
+
 #[gpui::test]
 async fn cut_paste_keeps_failed_sources_on_the_clipboard_as_a_cut(cx: &mut TestAppContext) {
     let dir = tempfile::tempdir().unwrap();

--- a/crates/nohrs-pages/src/explorer/tests.rs
+++ b/crates/nohrs-pages/src/explorer/tests.rs
@@ -1183,6 +1183,169 @@ async fn cut_paste_without_conflict_moves_the_source(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn paste_numbers_a_second_source_sharing_an_existing_name(cx: &mut TestAppContext) {
+    // Two clipboard sources named `foo.txt`, and `foo.txt` already exists at the
+    // destination. Both collide with the same single destination, so resolving
+    // the collision as Overwrite must not point both at it — the second would
+    // silently replace the first.
+    let dir = tempfile::tempdir().unwrap();
+    let (first, second, dst) = (
+        dir.path().join("a"),
+        dir.path().join("b"),
+        dir.path().join("dst"),
+    );
+    for sub in [&first, &second, &dst] {
+        std::fs::create_dir(sub).unwrap();
+    }
+    std::fs::write(first.join("foo.txt"), "A").unwrap();
+    std::fs::write(second.join("foo.txt"), "B").unwrap();
+    std::fs::write(dst.join("foo.txt"), "D").unwrap();
+
+    let window = new_explorer(cx);
+    // Two files in different directories can't be selected in one listing, so
+    // seed them through the system-clipboard path text, which `read_clipboard`
+    // accepts as a copy.
+    cx.update(|cx| {
+        cx.write_to_clipboard(ClipboardItem::new_string(format!(
+            "{}\n{}",
+            first.join("foo.txt").display(),
+            second.join("foo.txt").display()
+        )));
+    });
+    window
+        .update(cx, |pane, _window, cx| {
+            pane.cwd = dst.to_string_lossy().to_string();
+            pane.reload();
+            assert!(pane.prepare_paste(cx), "the existing name collides");
+            pane.set_apply_to_all(true, cx);
+            pane.resolve_current_conflict(ConflictResolution::Overwrite, cx);
+            pane.execute_paste_plan(cx);
+        })
+        .unwrap();
+    cx.run_until_parked();
+
+    assert_eq!(
+        std::fs::read_to_string(dst.join("foo.txt")).unwrap(),
+        "A",
+        "the conflicting source overwrites the destination"
+    );
+    assert_eq!(
+        std::fs::read_to_string(dst.join("foo (2).txt")).unwrap(),
+        "B",
+        "the second source sharing that name is numbered, not dropped"
+    );
+}
+
+#[gpui::test]
+async fn closing_the_conflict_dialog_leaves_the_plan_for_the_resolving_button(
+    cx: &mut TestAppContext,
+) {
+    // Each conflict button resolves, then calls `window.close_dialog(cx)`, then
+    // `execute_paste_plan`. That order is only safe because gpui-component's
+    // `WindowExt::close_dialog` pops the dialog stack without running the
+    // dialog's own `on_close` — which cancels the paste, and would otherwise
+    // take the plan out from under the very paste the button just resolved.
+    // Pin it, so an upgrade that starts firing `on_close` from `close_dialog`
+    // fails here rather than silently pasting nothing.
+    use gpui_component::WindowExt as _;
+
+    let (_dir, src, dst) = paste_fixture();
+    let (window, pane) = new_explorer_in_root(cx);
+    // Opening the dialog updates the `Root` entity, so the window's own
+    // `update` (which already holds it) would panic on the second lease.
+    // `VisualTestContext` hands out the `Window` without taking that lease.
+    let mut cx = gpui::VisualTestContext::from_window(window.into(), cx);
+
+    pane.update_in(&mut cx, |pane, window, cx| {
+        pane.cwd = src.to_string_lossy().to_string();
+        pane.reload();
+        pane.select_all();
+        pane.copy_selection(cx);
+        pane.cwd = dst.to_string_lossy().to_string();
+        pane.reload();
+        pane.paste_into_cwd(window, cx);
+    });
+
+    let done = pane.update(&mut cx, |pane, cx| {
+        assert!(
+            pane.paste_plan.is_some(),
+            "the collision opens the dialog with a plan pending"
+        );
+        pane.resolve_current_conflict(ConflictResolution::Overwrite, cx)
+    });
+    assert!(done, "the only conflict is resolved");
+
+    cx.update(|window, cx| window.close_dialog(cx));
+    pane.update(&mut cx, |pane, cx| {
+        assert!(
+            pane.paste_plan.is_some(),
+            "close_dialog must not cancel the paste it is closing over"
+        );
+        pane.execute_paste_plan(cx);
+    });
+    cx.run_until_parked();
+
+    assert_eq!(
+        std::fs::read_to_string(dst.join("foo.txt")).unwrap(),
+        "SRC",
+        "the resolved overwrite actually ran"
+    );
+}
+
+#[gpui::test]
+async fn cut_paste_keeps_failed_sources_on_the_clipboard_as_a_cut(cx: &mut TestAppContext) {
+    let dir = tempfile::tempdir().unwrap();
+    let src = dir.path().join("src");
+    let dst = dir.path().join("dst");
+    std::fs::create_dir(&src).unwrap();
+    std::fs::create_dir(&dst).unwrap();
+    std::fs::write(src.join("x.txt"), "X").unwrap();
+
+    let window = new_explorer(cx);
+    window
+        .update(cx, |pane, _window, cx| {
+            pane.cwd = src.to_string_lossy().to_string();
+            pane.reload();
+            pane.select_all();
+            pane.cut_selection(cx);
+        })
+        .unwrap();
+
+    // Make the move fail by removing the source out from under the paste.
+    std::fs::remove_file(src.join("x.txt")).unwrap();
+    window
+        .update(cx, |pane, window, cx| {
+            pane.cwd = dst.to_string_lossy().to_string();
+            pane.reload();
+            pane.paste_into_cwd(window, cx);
+        })
+        .unwrap();
+    cx.run_until_parked();
+    window
+        .read_with(cx, |pane, _cx| {
+            let (_, is_error) = pane.status_for_footer().expect("the failure is reported");
+            assert!(is_error, "the move failed");
+        })
+        .unwrap();
+    assert!(!dst.join("x.txt").exists());
+
+    // Retrying must still be a *move*. Were the failed source dropped from the
+    // clipboard, this would fall back to the system clipboard's path text, which
+    // carries no cut/copy distinction and so would copy instead.
+    std::fs::write(src.join("x.txt"), "X").unwrap();
+    window
+        .update(cx, |pane, window, cx| pane.paste_into_cwd(window, cx))
+        .unwrap();
+    cx.run_until_parked();
+
+    assert_eq!(std::fs::read_to_string(dst.join("x.txt")).unwrap(), "X");
+    assert!(
+        !src.join("x.txt").exists(),
+        "the retry moves the source rather than copying it"
+    );
+}
+
+#[gpui::test]
 async fn rename_collision_falls_back_to_numbering(cx: &mut TestAppContext) {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path();


### PR DESCRIPTION
## Summary

Two data-integrity defects in the explorer paste path, both raised by review on #193. Stacked on `feature/explorer-core-file-ops`.

## Changes

**Reserve a destination for every paste source** (`file_ops.rs`)

`claimed` was only consulted on the collision-free branch, so a destination that already existed was never reserved:

```rust
if ops::would_conflict(&dst) {
    pending.push_back(src);        // dst never enters `claimed`
} else if !claimed.insert(dst) { ... }
```

Two clipboard sources named `foo.txt` pasted where `foo.txt` already exists therefore queued as two separate conflicts pointing at one target — resolving with Overwrite silently dropped the first. The name is now reserved whether or not the destination is occupied, and the reservation is checked before the collision, so a duplicate is numbered instead.

**Keep failed cuts retryable as cuts** (`file_ops.rs`)

A cut cleared the clipboard before `run_fs_op` ran. On a partial failure the failed sources became unreachable: the next paste fell through to the system clipboard's path text, which carries no cut/copy distinction, and retried a failed *move* as a *copy*. The clipboard is still cleared up front — a second paste fired mid-flight must not re-move the sources — and whatever failed to move is put back afterwards.

Ownership of that restore is keyed on a **clipboard generation** rather than on whether the clipboard is currently empty, because two cut pastes in flight both leave it empty and occupancy cannot tell them apart. Each paste records the generation it left behind and restores only over that; the outcome is therefore independent of which batch finishes first.

`run_fs_op` gains a `run_fs_op_with` variant whose completion hook takes `&mut App` rather than the pane, so recovery still runs if the pane is closed mid-batch — the clipboard is process-wide state, and the retry matters to whatever pane the user is looking at next.

**Pin the conflict dialog's close ordering** (`tests.rs`)

The resolution buttons resolve → `close_dialog` → `execute_paste_plan`. That is only safe because `gpui-component`'s `WindowExt::close_dialog` pops the dialog stack without running the dialog's `on_close` (which cancels the paste). A test drives the real dialog and asserts the plan survives the close, so an upgrade that changes this fails loudly instead of silently pasting nothing.

## Testing

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace` — 196 passing, 0 failing

Five tests added. Each was run against the code with its fix reverted, so it is a real guard rather than something that merely passes:

| Test | With its fix reverted |
| --- | --- |
| `paste_numbers_a_second_source_sharing_an_existing_name` | fails — `foo.txt` held the second source, `foo (2).txt` absent |
| `cut_paste_keeps_failed_sources_on_the_clipboard_as_a_cut` | fails — the retry copied instead of moving, source still present |
| `overlapping_cut_pastes_restore_only_the_live_clipboard` | fails on seed 0 — the earlier batch claimed the restore, so the retry moved the wrong file |
| `a_failed_cut_does_not_clobber_a_clipboard_claimed_while_it_ran` | fails with no ownership guard at all |
| `closing_the_conflict_dialog_leaves_the_plan_for_the_resolving_button` | passes — pins current library behavior; see below |

The overlap test runs under `#[gpui::test(iterations = 25)]`: the generation stamp makes the outcome order-independent, so varying the dispatcher seed exercises both completion orders rather than pinning one.

No UI verification: the diff is paste/clipboard logic and test code, with no rendered output.

## Review findings not addressed here

**`ACCENT_LIGHT` deprecated alias — declined.** `nohrs-ui` is a workspace-internal crate at `version = "0.0.1"`, unpublished, consumed only by sibling crates in this repo. Nothing references the constant, so there is no external compile to break. Noted on the thread that cubic reached the opposite conclusion earlier in #193 — the constant was removed *because* it was flagged unused.

**Conflict dialog `on_close` ordering — does not reproduce.** `WindowExt::close_dialog` (`gpui-component-0.5.1/src/root.rs:144`) pops `active_dialogs` and calls `cx.notify()`; it never invokes `on_close`. Every `on_close` call site is in `dialog.rs` itself (the X button, Escape, and the `on_ok`/`on_cancel` paths). The coverage gap the finding pointed at was real, so it is now closed by the test above.

**Background rename / `create_dir` — deferred, not silently dropped.** The scoped fix would not achieve its goal: `commit_rename` and `create_new_folder` both call `reload()`, which runs `list_dir_sync` — a full `readdir` plus stat of up to `DIR_LISTING_LIMIT` entries — on the UI thread in the same function. Moving the single `rename(2)` / `mkdir(2)` syscall off-thread while the far larger blocking call stays behind it is cosmetic. The cited guideline is also a paraphrase rather than repo text: `clippy.toml` bans direct `std::fs` calls and names *either* remedy — "route through `nohrs-services::fs` **or** move to a background task" — and this code takes the first. Making `reload()` async is the real change, touches every navigation path, and belongs in its own issue alongside #188.

**Two-overlapping-pastes coverage — initially missing, now added.** My first attempt at a regression test did not isolate the generation stamp: a failed cut followed by a copy leaves the clipboard occupied, so the old `entry.is_some()` check short-circuits identically. cubic caught this; `overlapping_cut_pastes_restore_only_the_live_clipboard` is the real case.

## Suggested .rules additions

Hit while writing the dialog test — non-obvious, and the failure mode is an opaque panic in `gpui`'s `entity_map.rs` rather than a useful message:

> In GPUI tests, do not call code that opens a dialog from inside `WindowHandle::update`. `WindowHandle<Root>::update` already leases the `Root` entity, and `WindowExt::open_dialog` leases it again — the second lease panics in `entity_map.rs`. Use `VisualTestContext::from_window(window.into(), cx)` and drive the view with `entity.update_in(&mut cx, ...)`, which hands out the `Window` without taking that lease.

Release Notes:

- Fixed a paste losing one of two clipboard items that share a name with an existing file, and a failed cut becoming un-retryable as a move

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013AQAWQhXsq8j2cPHgV3MRb