### PR TITLE
web: Stop an unconfigured comment section reporting a failure

### DIFF
--- a/docs/web.md
+++ b/docs/web.md
@@ -319,6 +319,8 @@ zed.dev の IA から商用要素 (Pricing / Business / Sign up / Jobs / Team / 
   - **エッジキャッシュ 60 秒**が事実上のレートリミッタ。人気記事でも GitHub への呼び出しは 1 分に 1 回
   - トークンは **Worker シークレット** (`GITHUB_TOKEN`)。ビルド時に HTML へ焼かれる `VITE_*` 系とは種類が違う。CI が `DISCUSSIONS_TOKEN` (repo 単位・read-only・Discussions のみの fine-grained PAT) を deploy 後に押し込む
   - 未設定なら 503。fork では giscus 時代と同じく**黙って GitHub へのリンクに落ちる**
+    - **503 と 502 の区別は UI まで運ぶ** (改訂 2026-09-11)。Worker 側で分けても、クライアントが `if (!response.ok) throw` で潰すと未設定が「読み込みに失敗しました」と出る。実際にそれを本番で出した。**未設定は障害ではない**ので、見出し・導入文・リンクだけを出して何も言わない
+    - **GitHub の environment secret は、deploy を 1 回走らせるまで Worker に届かない**。secret を足しただけでは何も変わらない (`wrangler secret put` は deploy ジョブの中にある)
 - **本文は GitHub が返す `bodyHTML` をそのまま入れる**。GitHub 側でサニタイズ済みで、giscus の iframe が出していたものと同一。ここで生 Markdown を描くと、パーサとサニタイザを自前で持つことになる
 - **リンクは全状態で描く**。prerender される静止状態 (`idle`) では読み込み中の文言を出さない — JavaScript が無い読者を、来ない fetch の前で待たせないため
 - 取得は `IntersectionObserver` で**セクションが近づいてから**。記事はコメントより手前で閉じられる方が多い

--- a/web/app/components/Comments.tsx
+++ b/web/app/components/Comments.tsx
@@ -27,7 +27,16 @@ const REACTION_EMOJI: Record<string, string> = {
   EYES: '👀',
 }
 
-type Status = 'idle' | 'loading' | 'ready' | 'error'
+/**
+ * `unconfigured` is not a failure. It is what a fork gets, and what this site
+ * gets until the Worker holds a Discussions token — nothing is broken, the
+ * comments are simply not wired up here, and saying "could not be loaded"
+ * would report a fault that does not exist.
+ */
+type Status = 'idle' | 'loading' | 'ready' | 'unconfigured' | 'error'
+
+/** The Worker's answer when it has no token to read the thread with. */
+const UNCONFIGURED = 503
 
 function Reactions({ items, label }: { items: Reaction[]; label?: string }) {
   if (items.length === 0) return null
@@ -139,10 +148,15 @@ export function Comments({ lang, term }: { lang: Lang; term: string }) {
     const aborter = new AbortController()
     fetch(`/api/discussion?term=${encodeURIComponent(term)}`, { signal: aborter.signal })
       .then(async (response) => {
+        if (response.status === UNCONFIGURED) return null
         if (!response.ok) throw new Error(String(response.status))
         return (await response.json()) as { thread: Thread | null }
       })
       .then((payload) => {
+        if (!payload) {
+          setStatus('unconfigured')
+          return
+        }
         setThread(payload.thread)
         setStatus('ready')
       })

--- a/web/app/components/Comments.tsx
+++ b/web/app/components/Comments.tsx
@@ -148,7 +148,14 @@ export function Comments({ lang, term }: { lang: Lang; term: string }) {
     const aborter = new AbortController()
     fetch(`/api/discussion?term=${encodeURIComponent(term)}`, { signal: aborter.signal })
       .then(async (response) => {
-        if (response.status === UNCONFIGURED) return null
+        if (response.status === UNCONFIGURED) {
+          // The status alone is not the answer. Our own handler says so in the
+          // body; a 503 from the edge — an overloaded Worker, a bad gateway —
+          // does not, and that is a fault worth reporting rather than a site
+          // without a token.
+          const body = (await response.json().catch(() => null)) as { error?: string } | null
+          if (body?.error === 'unconfigured') return null
+        }
         if (!response.ok) throw new Error(String(response.status))
         return (await response.json()) as { thread: Thread | null }
       })


### PR DESCRIPTION
Reported from production: the comment section reads

> スレッドを読み込めませんでした。GitHub では読めます。

which is the message for GitHub being unreachable. Nothing is unreachable. The Worker has no Discussions token yet, and that is not a fault.

## The defect

The Worker separates the two cases — `503 unconfigured`, `502 upstream` — and the client collapsed them on one line:

```ts
if (!response.ok) throw new Error(String(response.status))
```

So the distinction never reached anything a reader sees. `docs/web.md` has described the unconfigured state as "falls back to a link" since the first commit; that is simply not what shipped.

An unconfigured section now says nothing at all: the heading, the line about where replies go, and the link to the thread on GitHub. The failure message stays for actual failures. This is also exactly the state a fork gets.

## Also recorded in docs/web.md

**A GitHub environment secret does not reach the Worker until a deploy runs.** `wrangler secret put` lives in the deploy job, so adding `DISCUSSIONS_TOKEN` changes nothing on its own. I said the opposite when handing over #258 — this corrects it where the next person will look.

## Verification

`tsc --noEmit` clean; `node --test` 51/51; `vite build` + prerender of all 33 pages clean. The section read back in WebKit across its five states — a thread, a truncated thread, unconfigured, no thread yet, and GitHub unreachable — with the 503 case served through route interception.

Release Notes:

- Fixed the blog's comment section, which reported a loading failure when comments were simply not configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQqvCRiiviXGb4gFCBTNsq

---
_Generated by [Claude Code](https://claude.ai/code/session_01VQqvCRiiviXGb4gFCBTNsq)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops an unconfigured comment section from reporting a loading failure — a missing Discussions token used to collapse the Worker's 503 (unconfigured) and 502 (upstream failure) into one error, so it looked like a GitHub outage. An unconfigured section now renders only the heading, the replies line, and the GitHub link; real failures still show the error message.

- A 503 only counts as unconfigured when the response body says `unconfigured`; a 503 from the edge (overloaded Worker, bad gateway) is still a real failure and shows the error.
- `docs/web.md` now records that the 503/502 distinction reaches the UI and that a GitHub environment secret does not reach the Worker until a deploy runs.

<sup>Written for commit 28595a81ecc1e5ead0d34dd3ef8a1af082dc347a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/noh-rs/nohrs/pull/260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the blog comments experience when comments are not configured. The page now displays the heading, introduction, and GitHub Discussions link without showing an error message.
  - Preserved distinct handling for unavailable comments and service errors, ensuring genuine service failures continue to display appropriately.

- **Documentation**
  - Clarified the expected distinction between unavailable comments and service errors.
  - Documented that environment secret changes take effect after a deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->