### PR TITLE
Advance main to develop and stop the comment section reporting a failure

### DIFF
--- a/docs/web.md
+++ b/docs/web.md
@@ -319,6 +319,8 @@ zed.dev の IA から商用要素 (Pricing / Business / Sign up / Jobs / Team / 
   - **エッジキャッシュ 60 秒**が事実上のレートリミッタ。人気記事でも GitHub への呼び出しは 1 分に 1 回
   - トークンは **Worker シークレット** (`GITHUB_TOKEN`)。ビルド時に HTML へ焼かれる `VITE_*` 系とは種類が違う。CI が `DISCUSSIONS_TOKEN` (repo 単位・read-only・Discussions のみの fine-grained PAT) を deploy 後に押し込む
   - 未設定なら 503。fork では giscus 時代と同じく**黙って GitHub へのリンクに落ちる**
+    - **503 と 502 の区別は UI まで運ぶ** (改訂 2026-09-11)。Worker 側で分けても、クライアントが `if (!response.ok) throw` で潰すと未設定が「読み込みに失敗しました」と出る。実際にそれを本番で出した。**未設定は障害ではない**ので、見出し・導入文・リンクだけを出して何も言わない
+    - **GitHub の environment secret は、deploy を 1 回走らせるまで Worker に届かない**。secret を足しただけでは何も変わらない (`wrangler secret put` は deploy ジョブの中にある)
 - **本文は GitHub が返す `bodyHTML` をそのまま入れる**。GitHub 側でサニタイズ済みで、giscus の iframe が出していたものと同一。ここで生 Markdown を描くと、パーサとサニタイザを自前で持つことになる
 - **リンクは全状態で描く**。prerender される静止状態 (`idle`) では読み込み中の文言を出さない — JavaScript が無い読者を、来ない fetch の前で待たせないため
 - 取得は `IntersectionObserver` で**セクションが近づいてから**。記事はコメントより手前で閉じられる方が多い

--- a/web/app/components/Comments.tsx
+++ b/web/app/components/Comments.tsx
@@ -27,7 +27,16 @@ const REACTION_EMOJI: Record<string, string> = {
   EYES: '👀',
 }
 
-type Status = 'idle' | 'loading' | 'ready' | 'error'
+/**
+ * `unconfigured` is not a failure. It is what a fork gets, and what this site
+ * gets until the Worker holds a Discussions token — nothing is broken, the
+ * comments are simply not wired up here, and saying "could not be loaded"
+ * would report a fault that does not exist.
+ */
+type Status = 'idle' | 'loading' | 'ready' | 'unconfigured' | 'error'
+
+/** The Worker's answer when it has no token to read the thread with. */
+const UNCONFIGURED = 503
 
 function Reactions({ items, label }: { items: Reaction[]; label?: string }) {
   if (items.length === 0) return null
@@ -139,10 +148,22 @@ export function Comments({ lang, term }: { lang: Lang; term: string }) {
     const aborter = new AbortController()
     fetch(`/api/discussion?term=${encodeURIComponent(term)}`, { signal: aborter.signal })
       .then(async (response) => {
+        if (response.status === UNCONFIGURED) {
+          // The status alone is not the answer. Our own handler says so in the
+          // body; a 503 from the edge — an overloaded Worker, a bad gateway —
+          // does not, and that is a fault worth reporting rather than a site
+          // without a token.
+          const body = (await response.json().catch(() => null)) as { error?: string } | null
+          if (body?.error === 'unconfigured') return null
+        }
         if (!response.ok) throw new Error(String(response.status))
         return (await response.json()) as { thread: Thread | null }
       })
       .then((payload) => {
+        if (!payload) {
+          setStatus('unconfigured')
+          return
+        }
         setThread(payload.thread)
         setStatus('ready')
       })


### PR DESCRIPTION
Deploys #260. No new work; this moves `main` to `develop`.

Production currently shows 「スレッドを読み込めませんでした。GitHub では読めます。」 on every article — the message for GitHub being unreachable. Nothing is unreachable: the Worker has no Discussions token yet, and the client was collapsing that onto the failure path. After this, an unconfigured section says nothing at all — the heading, the line about where replies go, and the link to the thread on GitHub.

## This deploy is also what a token needs

`wrangler secret put` lives in the deploy job, so `DISCUSSIONS_TOKEN` in the `production` environment does nothing until a deploy runs. If the secret is in place before this merges, this same run wires the comments up; if it is added later, any deploy after that does it.

Release Notes:

- Fixed the blog's comment section, which reported a loading failure when comments were simply not configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQqvCRiiviXGb4gFCBTNsq

---
_Generated by [Claude Code](https://claude.ai/code/session_01VQqvCRiiviXGb4gFCBTNsq)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Advances `main` into `develop` and stops the blog comment section from reporting a load failure when comments are simply not configured.

- An unconfigured section now shows only the heading, the reply line, and the link to the GitHub thread; the "could not be loaded" message stays for real failures.
- The client now trusts the Worker's `unconfigured` body on a 503 instead of treating every non-OK response as an error.
- Docs now record that `DISCUSSIONS_TOKEN` only reaches the Worker after a deploy runs, since `wrangler secret put` is part of the deploy job.

<sup>Written for commit e5cce9e873beb0b74372ce7549e961503ff92a01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/noh-rs/nohrs/pull/261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

